### PR TITLE
Add caron-letters package

### DIFF
--- a/packages/caron-letters/0.1.0/README.md
+++ b/packages/caron-letters/0.1.0/README.md
@@ -1,0 +1,1 @@
+A package to insert caron letters.

--- a/packages/caron-letters/0.1.0/_manifest.yml
+++ b/packages/caron-letters/0.1.0/_manifest.yml
@@ -1,0 +1,6 @@
+name: "caron-letters"
+title: "Caron Letters"
+description: A package to insert caron letters
+version: 0.1.0
+author: Christian Kopač
+tags: ["caron","slovenian"]

--- a/packages/caron-letters/0.1.0/package.yml
+++ b/packages/caron-letters/0.1.0/package.yml
@@ -1,0 +1,13 @@
+matches:
+  - trigger: "c^"
+    replace: "č"
+  - trigger: "C^"
+    replace: "Č"
+  - trigger: "s^"
+    replace: "š"
+  - trigger: "S^"
+    replace: "Š"
+  - trigger: "z^"
+    replace: "ž"
+  - trigger: "Z^"
+    replace: "Ž"


### PR DESCRIPTION
The package could be expanded in the future by adding the rest of the caron letters available in other languages, as it currently supporting only the ones present in the Slovenian language.