### PR TITLE
Add English-French translation package

### DIFF
--- a/packages/translate-fr-en/0.1.0/LICENSE
+++ b/packages/translate-fr-en/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 José Ferreira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/translate-fr-en/0.1.0/README.md
+++ b/packages/translate-fr-en/0.1.0/README.md
@@ -2,6 +2,8 @@ This is a translation package.
 
 It is for bidirectional translation between **English** and **French**.
 
+Please note that it will use 10MB of disk storage, and 350MB of RAM when loaded into Espanso.
+
 # Example matches
 | Trigger    | Replace                |
 |------------|------------------------|

--- a/packages/translate-fr-en/0.1.0/README.md
+++ b/packages/translate-fr-en/0.1.0/README.md
@@ -1,0 +1,17 @@
+This is a translation package.
+
+It is for bidirectional translation between **English** and **French**.
+
+# Example matches
+| Trigger    | Replace                |
+|------------|------------------------|
+| apple:fr   | pomme                  |
+| hello:fr   | bonjour/salut (choice) |
+| soleil:en  | sun                    |
+| jour:en    | aperture/day (choice)  |
+
+# Source code for package.yml generation
+
+A simple Go script turns an MIT-licensed French-English dictionary into Espanso trigger/replacement pairs.
+
+The code is in the repository [espanso-translate-fr-en-generator](https://github.com/IdiosApps/espanso-translate-fr-en-generator)

--- a/packages/translate-fr-en/0.1.0/_manifest.yml
+++ b/packages/translate-fr-en/0.1.0/_manifest.yml
@@ -1,0 +1,6 @@
+name: "translate-fr-en"
+title: "Bidirectional French-English translation"
+description: A proof-of-concept package for bidirectional French-English translation
+version: 0.1.0
+author: James Clark
+tags: ["languages", "french", "english", "translation", "dictionary"]


### PR DESCRIPTION
This is a proof-of-concept translation package. I believe this is the first Espanso package to help with translation.

My goal is to improve people's fluency and language-learning ability when having text-based conversations. I found that text-expansion is a great tool that lets people find words they need, without getting distracted by a dictionary.

I generated the bidirectional translation trigger/replacement package.yml file at 
[espanso-translate-fr-en-generator](https://github.com/IdiosApps/espanso-translate-fr-en-generator).

The package is just under 10MB, and Espanso uses about 350MB of memory when it is loaded in. Whilst it is quite large, the package readme states this and so it's up to users if they want to try it. I didn't make any optimisations - it's just a POC at the moment.

I thought it'd be good to raise a PR to get it on the Hub in case people want to:
1. Try it, and see if they like it
2. Explore how to make Espanso translation packages more efficient
3. Explore creating more translation packages

If the disk/memory usage is too high, please let me know what limits you would find acceptable. 