### PR TITLE
style: match new version of espanso syntax for calc package

### DIFF
--- a/packages/calc/1.0.0/README.md
+++ b/packages/calc/1.0.0/README.md
@@ -1,0 +1,3 @@
+> This package only works on Windows and Espanso version 2.1.0-alpha
+
+Matches to do basic arithmetic using your shell.

--- a/packages/calc/1.0.0/_manifest.yml
+++ b/packages/calc/1.0.0/_manifest.yml
@@ -1,0 +1,7 @@
+author: UyCode
+description: Matches to do basic arithmetic using your shell with Espanso version 2.1.0-alpha
+homepage: https://github.com/UyCode/espanso-calc-new
+name: calc
+title: Calc
+version: 1.0.0
+tags: ["math", "utility", "calculator"]

--- a/packages/calc/1.0.0/package.yml
+++ b/packages/calc/1.0.0/package.yml
@@ -1,0 +1,31 @@
+# Calculator
+
+matches:
+  # Calculator
+  - trigger: ":calc"
+    replace: "{{solved}}"
+    vars:
+      - name: "input"
+        type: "form"
+        params: 
+          layout: |
+            [[val]]
+      - name: "solved"
+        type: "shell"
+        params: 
+          cmd: "set /a %ESPANSO_INPUT_VAL%"
+          shell: "cmd"
+  # Calculator w/ input
+  - trigger: ":ecalc"
+    replace: "{{input.val}} = {{solved}}"
+    vars:
+      - name: "input"
+        type: "form"
+        params: 
+          layout: |
+            [[val]]
+      - name: "solved"
+        type: "shell"
+        params: 
+          cmd: "set /a %ESPANSO_INPUT_VAL%"
+          shell: "cmd"


### PR DESCRIPTION
after I install the new version of Espanso, calc package version 0.1.0 have not run because of Espanso's new syntax role.
I changed the syntax {{val}} to [[val]]