### PR TITLE
New package: `basic-networking`

### DIFF
--- a/packages/basic-networking/0.1.0/README.md
+++ b/packages/basic-networking/0.1.0/README.md
@@ -1,0 +1,14 @@
+A package that provides basic info about your computer network.
+
+## Supported Operating Systems
+
+- Mac OS Ventura 13.2.1+
+
+## Usage
+
+Here is a list of the available commands:
+
+- `:pip` ﹕ Print the IP Address of the external (public facing) internet gateway. In other words, this is your network address on the world wide web!
+- `:lip` ﹕ This prints the IP address of your current client device (most likely your laptop) on the local network (LAN).
+- `:rip` ﹕ This prints the IP Address of your current  Access Point (most likely your router) for your current client device.
+- `:mac` ﹕ Get your current device's MAC Address. Normally, on a Mac OS machine, en0 is the Wi-Fi interface.

--- a/packages/basic-networking/0.1.0/_manifest.yml
+++ b/packages/basic-networking/0.1.0/_manifest.yml
@@ -1,0 +1,6 @@
+name: "basic-networking"
+title: "Basic Networking"
+description: A package that provides info about your computer network
+version: 0.1.0
+author: webdavis
+tags: ["networking", "computer", "macOS"]

--- a/packages/basic-networking/0.1.0/package.yml
+++ b/packages/basic-networking/0.1.0/package.yml
@@ -1,0 +1,44 @@
+matches:
+  - trigger: ":pip"
+    label: >
+      This prints the IP Address of the external (public facing) internet gateway.
+      In other words, this is your network address on the world wide web!
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: "curl https://ifconfig.me"
+
+  - trigger: ":lip"
+    label: >
+      This prints the IP address of your current client device (most likely your laptop)
+      on the local network (LAN).
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: "ipconfig getifaddr en0"
+
+  - trigger: ":rip"
+    label: >
+      This prints the IP Address of your current  Access Point (most likely your router)
+      for your current client device.
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: "netstat -rn | grep default -m 1 | awk '{print $2}'"
+
+  - trigger: ":mac"
+    label: >
+      This prints your current devices MAC Address.
+      Normally, on a Mac OS machine, en0 is the Wi-Fi interface.
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: "networksetup -getmacaddress en0 | awk '{print $3}'"


### PR DESCRIPTION
This adds the following matches:

- `:pip` ﹕ Print the IP Address of the external (public facing) internet gateway. In other words, this is your network address on the world wide web!
- `:lip` ﹕ This prints the IP address of your current client device (most likely your laptop) on the local network (LAN).
- `:rip` ﹕ This prints the IP Address of your current  Access Point (most likely your router) for your current client device.
- `:mac` ﹕ Get your current device's MAC Address. Normally, on a Mac OS machine, en0 is the Wi-Fi interface.