### PR TITLE
submitting packages: Form URL list & Surrounds

### DIFF
--- a/packages/Form-list/README.md
+++ b/packages/Form-list/README.md
@@ -1,0 +1,17 @@
+# Form list
+## A package for getting a list of expansions from one form.
+
+# Setup
+The package.yml does not need to be edited.
+
+You will need to customize the entries in the `form_urls.csv`. The sample lines are a good starting point. The basic syntax is:
+
+| Name/description (without quotes) | URL |
+| --- | --- |
+| gmail | https://gmail.com/ |
+
+**Separate the fields with a comma.** Remember to save the file.
+
+## reuse
+
+You can of course also copy the contents of this package and create multiple form lists with other text. 👍 If you do so, you will need to edit the global variable for the location of the csv file.

--- a/packages/Form-list/_manifest.yml
+++ b/packages/Form-list/_manifest.yml
@@ -1,0 +1,5 @@
+name: "form-url-list"
+title: "Form URLs List"
+description: Uses a CSV to present a list of links and then pastes the chosen URL. 
+version: 0.2.0
+author: Ben Alexander (mistahben)

--- a/packages/Form-list/form_urls.csv
+++ b/packages/Form-list/form_urls.csv
@@ -1,0 +1,2 @@
+﻿Espanso documentation, https://espanso.org/docs/
+DuckDuckGo,https://duckduckgo.com

--- a/packages/Form-list/package.yml
+++ b/packages/Form-list/package.yml
@@ -1,0 +1,32 @@
+# uses form_urls.csv to paste the link to the corresponding URL.
+
+global_vars:
+  - name: "urlcsv"
+    type: echo
+    params:
+      echo: |
+              "$CONFIG/match/packages/Form-list/form_urls.csv"
+matches:
+  - trigger: ":forms"
+    replace: "{{form_url}}"
+    vars:
+      - name: form_url
+        type: shell
+        params:
+          cmd: |
+                echo "$(awk -F"," -v u=$ESPANSO_FORM1_CHOICES '$1~/u/{print $2}' {{urlcsv}})"
+      - name: form_names
+        type: shell
+        params:
+          cmd: |
+                echo "$(awk -F"," '{print $1}' {{urlcsv}})"
+      - name: form1
+        type: form
+        params:
+          layout: |
+                    get link to D65 form:
+                    [[choices]]
+          fields:
+            choices:
+              type: list
+              values: "{{form_names}}"

--- a/packages/surrounds/README.md
+++ b/packages/surrounds/README.md
@@ -1,0 +1,22 @@
+# Surrounds for text strings
+
+# An Espanso file to quickly surround text in various punctuation.
+### Important note on trigger syntax:
+This package uses a leading semicolon `;` instead of Espanso's more standard `:`(colon). I find that this is slightly faster to type, but if you would like to change it, feel free to do so.
+
+## :Usage examples:
+
+Say you have a long string of text that you want to search in google using quotes.
+1. copy the text
+2. click on the google search bar so your cursor is blinking there. 
+3. use the trigger combination `;p"` and the text string will be placed with quotation marks around it.
+
+This can also be useful for surrounding text with matching brackets, braces, etc.
+
+For most surrounds, you simply choose the character you want to surround the text witth. 
+
+For characters with a different closing character (like `{}` or `[]`), only the open character will trigger the surround.
+
+> For example `;p(` will surround the text with opening and closing parentheses, but `;p)` will not.
+
+You may want to selectively disable this package depending on the apps you use and the contexts in which you type.

--- a/packages/surrounds/_manifest.yml
+++ b/packages/surrounds/_manifest.yml
@@ -1,0 +1,5 @@
+name: "surrounds"
+title: "Surrounds for text strings"
+description: Copy text and then use these expansions to surround the text with various punctuation.
+version: 0.2.0
+author: Ben Alexander (mistahben)

--- a/packages/surrounds/package.yml
+++ b/packages/surrounds/package.yml
@@ -1,0 +1,23 @@
+matches:
+  ## Surrounds
+  # surround word in double quotes
+  - triggers: [";pq", ';p"']
+    replace: '"{{paste_word}}"'
+
+  # surround in single quotes
+  - triggers: [";psq", ";sq", ";p'"]
+    replace: "'{{paste_word}}'"
+
+  - triggers: [";p`"] # handy for code markdown formatting
+    replace: "`{{paste_word}}`"
+  
+  # surround in parentheses, brackets, braces
+  - triggers: [";p("]
+    replace: "({{paste_word}})"
+
+  - triggers: [";p["]
+    replace: "[{{paste_word}}]"
+
+  - triggers: [';p{']
+    replace: |
+              {{{paste_word}}}


### PR DESCRIPTION
A package that users can create their own custom lists of URLS (or almost any text, really) and use one expansion to choose the link they want to expand.