### PR TITLE
New "air-codes" espanso package

### DIFF
--- a/packages/air-codes/0.1.0/LICENSE
+++ b/packages/air-codes/0.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Clément CHAÏB-GALLI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/air-codes/0.1.0/README.md
+++ b/packages/air-codes/0.1.0/README.md
@@ -11,7 +11,7 @@ The 'air-codes' package is a comprehensive resource for air transportation data,
 
 ### Airports Data
 
-Using the '::' trigger followed by an IATA 3-letter airport code and a question mark will reveal detailed information such as the full name, city, and IATA code of the airport. For instance, entering '::MXP?' will yield 'Malpensa International Airport, Milan, IT (MXP)', essentially answering the query "_*What are the details of the airport code MXP?*_".
+Using the '::' trigger followed by an IATA 3-letter airport code and a question mark will reveal detailed information such as the full name, city, and IATA code of the airport. For instance, entering '::MXP?' will provide 'Malpensa International Airport, Milan, IT (MXP)', essentially answering the query "_*What are the details of the airport code MXP?*_".
 
 ### Airlines Data
 

--- a/packages/air-codes/0.1.0/README.md
+++ b/packages/air-codes/0.1.0/README.md
@@ -54,3 +54,7 @@ You can contact me via:
 - [Twitter](https://twitter.com/cl3mcg)
 
 I'm open to discussions, collaborations, and suggestions related to air transportation, logistics, or any other relevant projects. Don't hesitate to connect or drop a message via these platforms.
+
+### Other Espanso packages for airport code abbreviations
+
+If you are interested in another Espanso package related to airport code abbreviations and their related cities, check the [`airport-codes` package](https://github.com/gflujan/espanso-airport-codes) from [Gabriel F. Lujan](https://github.com/gflujan).

--- a/packages/air-codes/0.1.0/README.md
+++ b/packages/air-codes/0.1.0/README.md
@@ -1,0 +1,56 @@
+# Airports & Airlines Data in Espanso
+
+## Description
+
+The 'air-codes' package is a comprehensive resource for air transportation data, offering convenient access to:
+
+- Properly formatted airport names and locations based on their IATA codes.
+- Accurate airline names associated with their respective IATA 2-letter airline identifiers.
+
+## Examples
+
+### Airports Data
+
+Using the '::' trigger followed by an IATA 3-letter airport code and a question mark will reveal detailed information such as the full name, city, and IATA code of the airport. For instance, entering '::MXP?' will yield 'Malpensa International Airport, Milan, IT (MXP)', essentially answering the query "_*What are the details of the airport code MXP?*_".
+
+### Airlines Data
+
+Similarly, using the '::' trigger followed by an IATA 2-letter identifier and a question mark will provide the full name of the airline. For example, entering '::AF?' will display 'Air France (AF), FR', answering the question "_*What are the details of the airline code AF?*_".
+
+## Data Sources
+
+### Airports Data
+
+The airport information is sourced from ourairports.com, both from their general website ([here](https://ourairports.com/airports.html)) and directly from their data section ([here](https://ourairports.com/data/)). The dataset has been cleaned, enhanced, and curated (to some extend) to focus on 'large_airport' types to ensure a concise package without compromising vital details.
+
+### Airlines Data
+
+The airline data is obtained from openflights.org ([here](https://openflights.org/data.php#airline)). The dataset has been refined to include only the airlines with IATA designator codes, while excluding outdated or irrelevant information, ensuring a relevant dataset.
+
+## Relevance
+
+### Why Use This Package?
+
+This package caters to individuals involved in airfreight or logistics, providing a quick and efficient way to access and decode potentially cryptic IATA codes. It serves as a valuable resource for anyone seeking detailed information on airlines and airports within the air transportation industry.
+
+## Disclaimer and Contributions
+
+### Data Accuracy Disclaimer
+
+Considering the volume of data, some information within this dataset was processed automatically. Thus, it's possible that there might be occasional inaccuracies or errors. Your understanding and contribution are appreciated in refining and enhancing this dataset for accuracy.
+
+### Contribution Encouragement
+
+Contributions to improve data accuracy are highly encouraged. If you notice any inaccuracies or errors, please do not hesitate to correct them. Your contributions will help maintain the quality and reliability of the dataset for all users.
+
+## Contact Information
+
+Feel free to reach out for further information or if you're interested in collaborating on projects related to freight or logistics.
+
+You can contact me via:
+
+- [LinkedIn](https://www.linkedin.com/in/cl3mcg/?locale=en_US)
+- [Mastodon](https://fosstodon.org/@cl3mcg)
+- [Twitter](https://twitter.com/cl3mcg)
+
+I'm open to discussions, collaborations, and suggestions related to air transportation, logistics, or any other relevant projects. Don't hesitate to connect or drop a message via these platforms.

--- a/packages/air-codes/0.1.0/README.md
+++ b/packages/air-codes/0.1.0/README.md
@@ -11,21 +11,21 @@ The 'air-codes' package is a comprehensive resource for air transportation data,
 
 ### Airports Data
 
-Using the '::' trigger followed by an IATA 3-letter airport code and a question mark will reveal detailed information such as the full name, city, and IATA code of the airport. For instance, entering '::MXP?' will provide 'Malpensa International Airport, Milan, IT (MXP)', essentially answering the query "_*What are the details of the airport code MXP?*_".
+Using the `::` trigger followed by an IATA 3-letter airport code and a question mark will reveal detailed information such as the full name, city, and IATA code of the airport. For instance, entering `::MXP?` will provide `Malpensa International Airport, Milan, IT (MXP)`, essentially answering the query "_*What are the details of the airport code MXP?*_".
 
 ### Airlines Data
 
-Similarly, using the '::' trigger followed by an IATA 2-letter identifier and a question mark will provide the full name of the airline. For example, entering '::AF?' will display 'Air France (AF), FR', answering the question "_*What are the details of the airline code AF?*_".
+Similarly, using the `::` trigger followed by an IATA 2-letter identifier and a question mark will provide the full name of the airline. For example, entering `::AF?` will display `Air France (AF), FR`, answering the question "_*What are the details of the airline code AF?*_".
 
 ## Data Sources
 
 ### Airports Data
 
-The airport information is sourced from ourairports.com, both from their general website ([here](https://ourairports.com/airports.html)) and directly from their data section ([here](https://ourairports.com/data/)). The dataset has been cleaned, enhanced, and curated (to some extend) to focus on 'large_airport' types to ensure a concise package without compromising vital details.
+The airport information is sourced from _*ourairports.com*_, both from their general website ([here](https://ourairports.com/airports.html)) and directly from their data section ([here](https://ourairports.com/data/)). The dataset has been cleaned, enhanced, and curated (to some extend) to focus on 'large_airport' types to ensure a concise package without compromising vital details.
 
 ### Airlines Data
 
-The airline data is obtained from openflights.org ([here](https://openflights.org/data.php#airline)). The dataset has been refined to include only the airlines with IATA designator codes, while excluding outdated or irrelevant information, ensuring a relevant dataset.
+The airline data is obtained from _*openflights.org*_ ([here](https://openflights.org/data.php#airline)). The dataset has been refined to include only the airlines with IATA designator codes, while excluding outdated or irrelevant information, ensuring a relevant dataset.
 
 ## Relevance
 

--- a/packages/air-codes/0.1.0/_manifest.yml
+++ b/packages/air-codes/0.1.0/_manifest.yml
@@ -1,0 +1,18 @@
+name: air-codes
+title: Airlines & Airports Names
+description: A comprehensive package offering a database of airlines and airports' names, based on their IATA designators and codes.
+version: 0.1.0
+author: Clément CHAÏB-GALLI
+homepage: https://github.com/cl3mcg/espanso-package-air-codes
+tags:
+  [
+    "airline",
+    "freight",
+    "IATA",
+    "logistics",
+    "airfreight",
+    "cargo",
+    "airport",
+    "aviation",
+    "transportation",
+  ]

--- a/packages/air-codes/0.1.0/package.yml
+++ b/packages/air-codes/0.1.0/package.yml
@@ -5473,7 +5473,7 @@ matches:
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Airline (H2), CL"
 
-    - trigger: "::OO?"
+  - trigger: "::OO?"
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "SkyWest (OO), US"
 
@@ -5737,7 +5737,7 @@ matches:
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "US Helicopter Corporation (UH), US"
 
-    - trigger: "::VA?"
+  - trigger: "::VA?"
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "V Australia Airlines (VA), AU"
 
@@ -6769,7 +6769,7 @@ matches:
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUR Avrupa Hava YollarÄ± (YI), TR"
 
-    - trigger: "::II?"
+  - trigger: "::II?"
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "LSM International (II), RU"
 
@@ -7025,7 +7025,7 @@ matches:
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indonesia Sky (I5), ID"
 
-    - trigger: "::9P?"
+  - trigger: "::9P?"
     label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pelangi (9P), MY"
 

--- a/packages/air-codes/0.1.0/package.yml
+++ b/packages/air-codes/0.1.0/package.yml
@@ -1,0 +1,7534 @@
+matches:
+  # Provide airport data based on IATA's three-letter airport codes
+  - trigger: "::LHR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "London Heathrow Airport, London, GB (LHR)"
+
+  - trigger: "::LAX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Los Angeles / Tom Bradley International Airport, Los Angeles, US (LAX)"
+
+  - trigger: "::ORD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chicago O'Hare International Airport, Chicago, US (ORD)"
+
+  - trigger: "::JFK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "John F Kennedy International Airport, New York, US (JFK)"
+
+  - trigger: "::ATL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hartsfield Jackson Atlanta International Airport, Atlanta, US (ATL)"
+
+  - trigger: "::CDG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Charles de Gaulle International Airport, Paris, FR (CDG)"
+
+  - trigger: "::SFO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "San Francisco International Airport, San Francisco, US (SFO)"
+
+  - trigger: "::AMS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Amsterdam Airport Schiphol, Amsterdam, NL (AMS)"
+
+  - trigger: "::FRA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Frankfurt Airport, Frankfurt am Main, DE (FRA)"
+
+  - trigger: "::EWR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Newark Liberty International Airport, Newark, US (EWR)"
+
+  - trigger: "::DFW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dallas Fort Worth International Airport, Dallas-Fort Worth, US (DFW)"
+
+  - trigger: "::LAS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Harry Reid International Airport, Las Vegas, US (LAS)"
+
+  - trigger: "::MCO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Orlando International Airport, Orlando, US (MCO)"
+
+  - trigger: "::DEN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Denver International Airport, Denver, US (DEN)"
+
+  - trigger: "::IAD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Washington Dulles International Airport, Dulles, US (IAD)"
+
+  - trigger: "::LGA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "La Guardia Airport, New York, US (LGA)"
+
+  - trigger: "::MIA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Miami International Airport, Miami, US (MIA)"
+
+  - trigger: "::SEA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Seattle–Tacoma International Airport, Seattle, US (SEA)"
+
+  - trigger: "::PHX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Phoenix Sky Harbor International Airport, Phoenix, US (PHX)"
+
+  - trigger: "::BOS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Logan International Airport, Boston, US (BOS)"
+
+  - trigger: "::PHL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Philadelphia International Airport, Philadelphia, US (PHL)"
+
+  - trigger: "::CLT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Charlotte Douglas International Airport, Charlotte, US (CLT)"
+
+  - trigger: "::LGW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "London Gatwick Airport, London, GB (LGW)"
+
+  - trigger: "::IAH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "George Bush Intercontinental Houston Airport, Houston, US (IAH)"
+
+  - trigger: "::DTW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Detroit Metropolitan Wayne County Airport, Detroit, US (DTW)"
+
+  - trigger: "::DCA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ronald Reagan Washington National Airport, Washington, US (DCA)"
+
+  - trigger: "::YYZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Toronto Lester B. Pearson International Airport, Toronto, CA (YYZ)"
+
+  - trigger: "::MSP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Minneapolis–Saint Paul International Airport / Wold–Chamberlain Field, Minneapolis, US (MSP)"
+
+  - trigger: "::MUC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Munich Airport, Munich, DE (MUC)"
+
+  - trigger: "::BCN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Josep Tarradellas Barcelona-El Prat Airport, Barcelona, ES (BCN)"
+
+  - trigger: "::FCO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Rome–Fiumicino Leonardo da Vinci International Airport, Rome, IT (FCO)"
+
+  - trigger: "::MAD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Adolfo Suárez Madrid–Barajas Airport, Madrid, ES (MAD)"
+
+  - trigger: "::SLC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Salt Lake City International Airport, Salt Lake City, US (SLC)"
+
+  - trigger: "::FLL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Fort Lauderdale Hollywood International Airport, Fort Lauderdale, US (FLL)"
+
+  - trigger: "::MDW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chicago Midway International Airport, Chicago, US (MDW)"
+
+  - trigger: "::ZRH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Zürich Airport, Zurich, CH (ZRH)"
+
+  - trigger: "::BWI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Baltimore/Washington International Thurgood Marshall Airport, Baltimore, US (BWI)"
+
+  - trigger: "::SAN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "San Diego International Airport, San Diego, US (SAN)"
+
+  - trigger: "::CPH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Copenhagen Kastrup Airport, Copenhagen, DK (CPH)"
+
+  - trigger: "::BRU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Brussels Airport, Zaventem, BE (BRU)"
+
+  - trigger: "::DUB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dublin Airport, Dublin, IE (DUB)"
+
+  - trigger: "::SIN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Singapore Changi Airport, Singapore, SG (SIN)"
+
+  - trigger: "::STL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "St Louis Lambert International Airport, St Louis, US (STL)"
+
+  - trigger: "::DXB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dubai International Airport, Dubai, AE (DXB)"
+
+  - trigger: "::VIE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Vienna International Airport, Vienna, AT (VIE)"
+
+  - trigger: "::YVR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Vancouver International Airport, Vancouver, CA (YVR)"
+
+  - trigger: "::NRT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Narita International Airport, Narita, JP (NRT)"
+
+  - trigger: "::HNL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Daniel K Inouye International Airport, Honolulu, US (HNL)"
+
+  - trigger: "::STN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "London Stansted Airport, London, GB (STN)"
+
+  - trigger: "::PDX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Portland International Airport, Portland, US (PDX)"
+
+  - trigger: "::YUL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Montreal / Pierre Elliott Trudeau International Airport, Montréal, CA (YUL)"
+
+  - trigger: "::MSY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Louis Armstrong New Orleans International Airport, New Orleans, US (MSY)"
+
+  - trigger: "::HKG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hong Kong International Airport, Islands, HK (HKG)"
+
+  - trigger: "::ARN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Stockholm-Arlanda Airport, Stockholm, SE (ARN)"
+
+  - trigger: "::TPA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tampa International Airport, Tampa, US (TPA)"
+
+  - trigger: "::LIS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Humberto Delgado Airport (Lisbon Portela Airport), Lisbon, PT (LIS)"
+
+  - trigger: "::BNA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nashville International Airport, Nashville, US (BNA)"
+
+  - trigger: "::PRG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Václav Havel Airport Prague, Prague, CZ (PRG)"
+
+  - trigger: "::CVG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cincinnati Northern Kentucky International Airport, Cincinnati / Covington, US (CVG)"
+
+  - trigger: "::SYD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sydney Kingsford Smith International Airport, Sydney, AU (SYD)"
+
+  - trigger: "::BKK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Suvarnabhumi Airport, Bangkok, TH (BKK)"
+
+  - trigger: "::AUS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Austin Bergstrom International Airport, Austin, US (AUS)"
+
+  - trigger: "::CUN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional de Cancún, Ciudad de Cancún, MX (CUN)"
+
+  - trigger: "::PIT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Pittsburgh International Airport, Pittsburgh, US (PIT)"
+
+  - trigger: "::MXP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Malpensa International Airport, Milan, IT (MXP)"
+
+  - trigger: "::RDU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Raleigh Durham International Airport, Raleigh/Durham, US (RDU)"
+
+  - trigger: "::ISL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "İstanbul Atatürk Airport, Bakırköy, Istanbul, TR (ISL)"
+
+  - trigger: "::ATH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Athens Eleftherios Venizelos International Airport, Athens, GR (ATH)"
+
+  - trigger: "::SJC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Norman Y. Mineta San Jose International Airport, San Jose, US (SJC)"
+
+  - trigger: "::BUD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Budapest Liszt Ferenc International Airport, Budapest, HU (BUD)"
+
+  - trigger: "::MCI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kansas City International Airport, Kansas City, US (MCI)"
+
+  - trigger: "::OSL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Oslo Airport, Gardermoen, Oslo, NO (OSL)"
+
+  - trigger: "::OAK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Metropolitan Oakland International Airport, Oakland, US (OAK)"
+
+  - trigger: "::SAT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "San Antonio International Airport, San Antonio, US (SAT)"
+
+  - trigger: "::MEM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Memphis International Airport, Memphis, US (MEM)"
+
+  - trigger: "::SNA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "John Wayne Orange County International Airport, Santa Ana, US (SNA)"
+
+  - trigger: "::PEK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Beijing Capital International Airport, Beijing, CN (PEK)"
+
+  - trigger: "::KEF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Keflavik International Airport, Reykjavík, IS (KEF)"
+
+  - trigger: "::MAN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Manchester Airport, Manchester, GB (MAN)"
+
+  - trigger: "::HEL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Helsinki Vantaa Airport, Helsinki, FI (HEL)"
+
+  - trigger: "::CLE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cleveland Hopkins International Airport, Cleveland, US (CLE)"
+
+  - trigger: "::GVA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Geneva Cointrin International Airport, Geneva, CH (GVA)"
+
+  - trigger: "::KUL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kuala Lumpur International Airport, Sepang, MY (KUL)"
+
+  - trigger: "::ORY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Paris-Orly Airport, Paris, FR (ORY)"
+
+  - trigger: "::IND?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Indianapolis International Airport, Indianapolis, US (IND)"
+
+  - trigger: "::EDI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Edinburgh Airport, Edinburgh, GB (EDI)"
+
+  - trigger: "::YYC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Calgary International Airport, Calgary, CA (YYC)"
+
+  - trigger: "::DUS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Düsseldorf Airport, Düsseldorf, DE (DUS)"
+
+  - trigger: "::MEX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Lic. Benito Juárez, Ciudad de México, MX (MEX)"
+
+  - trigger: "::PMI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Palma de Mallorca Airport, Palma de Mallorca, ES (PMI)"
+
+  - trigger: "::VCE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Venice Marco Polo Airport, Venice, IT (VCE)"
+
+  - trigger: "::CMH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "John Glenn Columbus International Airport, Columbus, US (CMH)"
+
+  - trigger: "::ICN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Incheon International Airport, Seoul, KR (ICN)"
+
+  - trigger: "::LTN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "London Luton Airport, London, GB (LTN)"
+
+  - trigger: "::WAW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Warsaw Chopin Airport, Warsaw, PL (WAW)"
+
+  - trigger: "::MEL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Melbourne International Airport, Melbourne, AU (MEL)"
+
+  - trigger: "::PVG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shanghai Pudong International Airport, Shanghai (Pudong), CN (PVG)"
+
+  - trigger: "::MKE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "General Mitchell International Airport, Milwaukee, US (MKE)"
+
+  - trigger: "::DEL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Indira Gandhi International Airport, New Delhi, IN (DEL)"
+
+  - trigger: "::AGP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Málaga-Costa del Sol Airport, Málaga, ES (AGP)"
+
+  - trigger: "::SJU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Luis Munoz Marin International Airport, San Juan, PR (SJU)"
+
+  - trigger: "::NCE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nice-Côte d'Azur Airport, Nice, FR (NCE)"
+
+  - trigger: "::JNB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "OR Tambo International Airport, Johannesburg, ZA (JNB)"
+
+  - trigger: "::JAX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jacksonville International Airport, Jacksonville, US (JAX)"
+
+  - trigger: "::HAM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hamburg Helmut Schmidt Airport, Hamburg, DE (HAM)"
+
+  - trigger: "::TLV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ben Gurion International Airport, Tel Aviv, IL (TLV)"
+
+  - trigger: "::AKL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Auckland International Airport, Auckland, NZ (AKL)"
+
+  - trigger: "::BUF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Buffalo Niagara International Airport, Buffalo, US (BUF)"
+
+  - trigger: "::ANC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ted Stevens Anchorage International Airport, Anchorage, US (ANC)"
+
+  - trigger: "::YOW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ottawa Macdonald-Cartier International Airport, Ottawa, CA (YOW)"
+
+  - trigger: "::GRU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Guarulhos - Governador André Franco Montoro International Airport, São Paulo, BR (GRU)"
+
+  - trigger: "::SVO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sheremetyevo International Airport, Moscow, RU (SVO)"
+
+  - trigger: "::GLA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Glasgow International Airport, Paisley, Renfrewshire, GB (GLA)"
+
+  - trigger: "::DMK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Don Mueang International Airport, Bangkok, TH (DMK)"
+
+  - trigger: "::HND?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tokyo Haneda International Airport, Tokyo, JP (HND)"
+
+  - trigger: "::CAI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cairo International Airport, Cairo, EG (CAI)"
+
+  - trigger: "::CGN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cologne Bonn Airport, Köln (Cologne), DE (CGN)"
+
+  - trigger: "::EZE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Minister Pistarini International Airport, Buenos Aires (Ezeiza), AR (EZE)"
+
+  - trigger: "::BNE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Brisbane International Airport, Brisbane, AU (BNE)"
+
+  - trigger: "::BOM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chhatrapati Shivaji International Airport, Mumbai, IN (BOM)"
+
+  - trigger: "::AUH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Abu Dhabi International Airport, Abu Dhabi, AE (AUH)"
+
+  - trigger: "::TPE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Taiwan Taoyuan International Airport, Taoyuan (Dayuan), TW (TPE)"
+
+  - trigger: "::LIM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jorge Chávez International Airport, Lima, PE (LIM)"
+
+  - trigger: "::SMF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sacramento International Airport, Sacramento, US (SMF)"
+
+  - trigger: "::DPS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ngurah Rai (Bali) International Airport, Denpasar, ID (DPS)"
+
+  - trigger: "::OMA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Eppley Airfield, Omaha, US (OMA)"
+
+  - trigger: "::MNL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ninoy Aquino International Airport, Manila, PH (MNL)"
+
+  - trigger: "::PBI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Palm Beach International Airport, West Palm Beach, US (PBI)"
+
+  - trigger: "::LPA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gran Canaria Airport, Gran Canaria Island, ES (LPA)"
+
+  - trigger: "::RNO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Reno Tahoe International Airport, Reno, US (RNO)"
+
+  - trigger: "::PVD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Theodore Francis Green State Airport, Warwick, US (PVD)"
+
+  - trigger: "::SDF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Louisville Muhammad Ali International Airport, Louisville, US (SDF)"
+
+  - trigger: "::CPT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cape Town International Airport, Cape Town, ZA (CPT)"
+
+  - trigger: "::MLA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Malta International Airport, Valletta, MT (MLA)"
+
+  - trigger: "::STR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Stuttgart Airport, Stuttgart, DE (STR)"
+
+  - trigger: "::DOH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hamad International Airport, Doha, QA (DOH)"
+
+  - trigger: "::GIG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Rio Galeão – Tom Jobim International Airport, Rio De Janeiro, BR (GIG)"
+
+  - trigger: "::SCL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Comodoro Arturo Merino Benítez International Airport, Santiago, CL (SCL)"
+
+  - trigger: "::BHX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Birmingham International Airport, Birmingham, GB (BHX)"
+
+  - trigger: "::YEG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Edmonton International Airport, Edmonton, CA (YEG)"
+
+  - trigger: "::YWG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Winnipeg / James Armstrong Richardson International Airport, Winnipeg, CA (YWG)"
+
+  - trigger: "::SAV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Savannah Hilton Head International Airport, Savannah, US (SAV)"
+
+  - trigger: "::RIC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Richmond International Airport, Richmond, US (RIC)"
+
+  - trigger: "::RIX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Riga International Airport, Riga, LV (RIX)"
+
+  - trigger: "::BGY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Milan Bergamo Airport, Milan, IT (BGY)"
+
+  - trigger: "::RSW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Southwest Florida International Airport, Fort Myers, US (RSW)"
+
+  - trigger: "::YHZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Halifax / Stanfield International Airport, Halifax, CA (YHZ)"
+
+  - trigger: "::PTY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tocumen International Airport, Tocumen, PA (PTY)"
+
+  - trigger: "::BGO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bergen Airport, Flesland, Bergen, NO (BGO)"
+
+  - trigger: "::OPO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Francisco de Sá Carneiro Airport, Porto, PT (OPO)"
+
+  - trigger: "::HKT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Phuket International Airport, Phuket, TH (HKT)"
+
+  - trigger: "::SGN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tan Son Nhat International Airport, Ho Chi Minh City, VN (SGN)"
+
+  - trigger: "::HER?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Heraklion International Nikos Kazantzakis Airport, Heraklion, GR (HER)"
+
+  - trigger: "::OTP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Henri Coandă International Airport, Bucharest, RO (OTP)"
+
+  - trigger: "::ONT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ontario International Airport, Ontario, US (ONT)"
+
+  - trigger: "::CGK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Soekarno-Hatta International Airport, Jakarta, ID (CGK)"
+
+  - trigger: "::AYT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Antalya International Airport, Antalya, TR (AYT)"
+
+  - trigger: "::NBO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jomo Kenyatta International Airport, Nairobi, KE (NBO)"
+
+  - trigger: "::SYR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Syracuse Hancock International Airport, Syracuse, US (SYR)"
+
+  - trigger: "::LCA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Larnaca International Airport, Larnaca, CY (LCA)"
+
+  - trigger: "::TFS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tenerife Sur Airport, Tenerife, ES (TFS)"
+
+  - trigger: "::KRK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kraków John Paul II International Airport, Kraków, PL (KRK)"
+
+  - trigger: "::KIX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kansai International Airport, Osaka, JP (KIX)"
+
+  - trigger: "::TUL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tulsa International Airport, Tulsa, US (TUL)"
+
+  - trigger: "::FAO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Faro Airport, Faro, PT (FAO)"
+
+  - trigger: "::PWM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Portland International Jetport, Portland, US (PWM)"
+
+  - trigger: "::ALC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Alicante-Elche Miguel Hernández Airport, Alicante, ES (ALC)"
+
+  - trigger: "::BEG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Belgrade Nikola Tesla Airport, Belgrade, RS (BEG)"
+
+  - trigger: "::MRS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Marseille Provence Airport, Marseille, FR (MRS)"
+
+  - trigger: "::BLQ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bologna Guglielmo Marconi Airport, Bologna, IT (BLQ)"
+
+  - trigger: "::CHC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Christchurch International Airport, Christchurch, NZ (CHC)"
+
+  - trigger: "::ZAG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Zagreb Airport, Zagreb, HR (ZAG)"
+
+  - trigger: "::YQB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Quebec Jean Lesage International Airport, Quebec, CA (YQB)"
+
+  - trigger: "::GOT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gothenburg-Landvetter Airport, Gothenburg, SE (GOT)"
+
+  - trigger: "::DME?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Domodedovo International Airport, Moscow, RU (DME)"
+
+  - trigger: "::NAS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lynden Pindling International Airport, Nassau, BS (NAS)"
+
+  - trigger: "::BOG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "El Dorado International Airport, Bogota, CO (BOG)"
+
+  - trigger: "::PUJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Punta Cana International Airport, Punta Cana, DO (PUJ)"
+
+  - trigger: "::NAP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Naples International Airport, Napoli, IT (NAP)"
+
+  - trigger: "::PER?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Perth International Airport, Perth, AU (PER)"
+
+  - trigger: "::HAN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Noi Bai International Airport, Hanoi (Soc Son), VN (HAN)"
+
+  - trigger: "::BSL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "EuroAirport Basel-Mulhouse-Freiburg, Saint-Louis, FR (BSL)"
+
+  - trigger: "::YYJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Victoria International Airport, Victoria, CA (YYJ)"
+
+  - trigger: "::TLS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Toulouse-Blagnac Airport, Toulouse/Blagnac, FR (TLS)"
+
+  - trigger: "::SAW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Istanbul Sabiha Gökçen International Airport, Pendik, Istanbul, TR (SAW)"
+
+  - trigger: "::LED?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Pulkovo Airport, St. Petersburg, RU (LED)"
+
+  - trigger: "::TLL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lennart Meri Tallinn Airport, Tallinn, EE (TLL)"
+
+  - trigger: "::SNN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shannon Airport, Shannon, IE (SNN)"
+
+  - trigger: "::HAV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "José Martí International Airport, Havana, CU (HAV)"
+
+  - trigger: "::PVR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Lic. Gustavo Díaz Ordaz, Ciudad de Puerto Vallarta, MX (PVR)"
+
+  - trigger: "::EIN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Eindhoven Airport, Eindhoven, NL (EIN)"
+
+  - trigger: "::CMN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mohammed V International Airport, Casablanca, MA (CMN)"
+
+  - trigger: "::PSA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Pisa International Airport, Pisa, IT (PSA)"
+
+  - trigger: "::LYS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lyon Saint-Exupéry Airport, Lyon, FR (LYS)"
+
+  - trigger: "::LUX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Luxembourg-Findel International Airport, Luxembourg, LU (LUX)"
+
+  - trigger: "::NUE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nuremberg Airport, Nuremberg, DE (NUE)"
+
+  - trigger: "::SOF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sofia Airport, Sofia, BG (SOF)"
+
+  - trigger: "::MCT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Muscat International Airport, Muscat, OM (MCT)"
+
+  - trigger: "::LJU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ljubljana Jože Pučnik Airport, Ljubljana, SI (LJU)"
+
+  - trigger: "::IST?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "İstanbul Airport, Arnavutköy, Istanbul, TR (IST)"
+
+  - trigger: "::CUZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Alejandro Velasco Astete International Airport, Cusco, PE (CUZ)"
+
+  - trigger: "::KBP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Boryspil International Airport, Boryspil, UA (KBP)"
+
+  - trigger: "::CMB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bandaranaike International Colombo Airport, Colombo, LK (CMB)"
+
+  - trigger: "::AMM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Queen Alia International Airport, Amman, JO (AMM)"
+
+  - trigger: "::SHA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shanghai Hongqiao International Airport, Shanghai (Minhang), CN (SHA)"
+
+  - trigger: "::SJD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional de Los Cabos, Ciudad de San José del Cabo, MX (SJD)"
+
+  - trigger: "::SFB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Orlando Sanford International Airport, Orlando, US (SFB)"
+
+  - trigger: "::CNX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chiang Mai International Airport, Chiang Mai, TH (CNX)"
+
+  - trigger: "::CAN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Guangzhou Baiyun International Airport, Guangzhou (Huadu), CN (CAN)"
+
+  - trigger: "::SVG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Stavanger Airport, Sola, Stavanger, NO (SVG)"
+
+  - trigger: "::CTA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Catania-Fontanarossa Airport, Catania, IT (CTA)"
+
+  - trigger: "::TUN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tunis Carthage International Airport, Tunis, TN (TUN)"
+
+  - trigger: "::VNO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Vilnius International Airport, Vilnius, LT (VNO)"
+
+  - trigger: "::MAA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chennai International Airport, Chennai, IN (MAA)"
+
+  - trigger: "::SKG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Thessaloniki Macedonia International Airport, Thessaloniki, GR (SKG)"
+
+  - trigger: "::IBZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ibiza Airport, Ibiza (Eivissa), ES (IBZ)"
+
+  - trigger: "::ADL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Adelaide International Airport, Adelaide, AU (ADL)"
+
+  - trigger: "::TRD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Trondheim Airport, Værnes, Trondheim, NO (TRD)"
+
+  - trigger: "::HAJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hannover Airport, Hannover, DE (HAJ)"
+
+  - trigger: "::SXM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Princess Juliana International Airport, Saint Martin, SX (SXM)"
+
+  - trigger: "::BFS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Belfast International Airport, Belfast, GB (BFS)"
+
+  - trigger: "::BAH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bahrain International Airport, Manama, BH (BAH)"
+
+  - trigger: "::AEP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jorge Newbery Airpark, Buenos Aires, AR (AEP)"
+
+  - trigger: "::BLR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kempegowda International Airport, Bangalore, IN (BLR)"
+
+  - trigger: "::BOD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bordeaux-Mérignac Airport, Bordeaux/Mérignac, FR (BOD)"
+
+  - trigger: "::BLL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Billund Airport, Billund, DK (BLL)"
+
+  - trigger: "::BTS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "M. R. Štefánik Airport, Bratislava, SK (BTS)"
+
+  - trigger: "::HRG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hurghada International Airport, Hurghada, EG (HRG)"
+
+  - trigger: "::ACE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "César Manrique-Lanzarote Airport, San Bartolomé, ES (ACE)"
+
+  - trigger: "::REP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Siem Reap International Airport, Siem Reap, KH (REP)"
+
+  - trigger: "::MLE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Malé International Airport, Malé, MV (MLE)"
+
+  - trigger: "::FAI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Fairbanks International Airport, Fairbanks, US (FAI)"
+
+  - trigger: "::KTM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tribhuvan International Airport, Kathmandu, NP (KTM)"
+
+  - trigger: "::SDQ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Las Américas International Airport, Santo Domingo, DO (SDQ)"
+
+  - trigger: "::CMA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Camarillo International Airport, Camarillo, US (CMA)"
+
+  - trigger: "::GMP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gimpo International Airport, Seoul, KR (GMP)"
+
+  - trigger: "::TRN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Turin Airport, Torino, IT (TRN)"
+
+  - trigger: "::GDN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gdańsk Lech Wałęsa Airport, Gdańsk, PL (GDN)"
+
+  - trigger: "::KWI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kuwait International Airport, Kuwait City, KW (KWI)"
+
+  - trigger: "::YYT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "St. John's International Airport, St. John's, CA (YYT)"
+
+  - trigger: "::GDL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Miguel Hidalgo, Ciudad de Tlajomulco de Zúñiga, MX (GDL)"
+
+  - trigger: "::AUA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Queen Beatrix International Airport, Oranjestad, AW (AUA)"
+
+  - trigger: "::ADB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Adnan Menderes International Airport, İzmir, TR (ADB)"
+
+  - trigger: "::ADD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Addis Ababa Bole International Airport, Addis Ababa, ET (ADD)"
+
+  - trigger: "::BER?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Berlin Brandenburg Airport, Berlin, DE (BER)"
+
+  - trigger: "::PMO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Falcone–Borsellino Airport, Palermo, IT (PMO)"
+
+  - trigger: "::DRW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Darwin International Airport / RAAF Darwin, Darwin, AU (DRW)"
+
+  - trigger: "::WLG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Wellington International Airport, Wellington, NZ (WLG)"
+
+  - trigger: "::FUE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Fuerteventura Airport, El Matorral, ES (FUE)"
+
+  - trigger: "::TOS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tromsø Airport, Langnes, Tromsø, NO (TOS)"
+
+  - trigger: "::JED?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Abdulaziz International Airport, Jeddah, SA (JED)"
+
+  - trigger: "::GUA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "La Aurora Airport, Guatemala City, GT (GUA)"
+
+  - trigger: "::BSB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Presidente Juscelino Kubitschek International Airport, Brasília, BR (BSB)"
+
+  - trigger: "::XIY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Xi'an Xianyang International Airport, Xianyang (Weicheng), CN (XIY)"
+
+  - trigger: "::SSH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sharm El Sheikh International Airport, Sharm El Sheikh, EG (SSH)"
+
+  - trigger: "::CCS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Simón Bolívar International Airport, Caracas, VE (CCS)"
+
+  - trigger: "::UIO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mariscal Sucre International Airport, Quito, EC (UIO)"
+
+  - trigger: "::VRN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Verona-Villafranca Valerio Catullo Airport, Villafranca di Verona, IT (VRN)"
+
+  - trigger: "::ITM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Osaka International Airport, Osaka, JP (ITM)"
+
+  - trigger: "::PNH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Phnom Penh International Airport, Phnom Penh (Pou Senchey), KH (PNH)"
+
+  - trigger: "::YXX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Abbotsford International Airport, Abbotsford, CA (YXX)"
+
+  - trigger: "::MVD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Carrasco General Cesáreo L. Berisso International Airport, Ciudad de la Costa, UY (MVD)"
+
+  - trigger: "::BEY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Beirut Rafic Hariri International Airport, Beirut, LB (BEY)"
+
+  - trigger: "::ESB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Esenboğa International Airport, Ankara, TR (ESB)"
+
+  - trigger: "::CTU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chengdu Shuangliu International Airport, Chengdu, CN (CTU)"
+
+  - trigger: "::CCU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Netaji Subhash Chandra Bose International Airport, Kolkata, IN (CCU)"
+
+  - trigger: "::CAG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cagliari Elmas Airport, Cagliari, IT (CAG)"
+
+  - trigger: "::FNC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Madeira International Airport Cristiano Ronaldo, Funchal, PT (FNC)"
+
+  - trigger: "::VKO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Vnukovo International Airport, Moscow, RU (VKO)"
+
+  - trigger: "::PLS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Providenciales International Airport, Providenciales, TC (PLS)"
+
+  - trigger: "::SZX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shenzhen Bao'an International Airport, Shenzhen (Bao'an), CN (SZX)"
+
+  - trigger: "::CEB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mactan Cebu International Airport, Lapu-Lapu City, PH (CEB)"
+
+  - trigger: "::ACC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kotoka International Airport, Accra, GH (ACC)"
+
+  - trigger: "::GOI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dabolim Airport, Vasco da Gama, IN (GOI)"
+
+  - trigger: "::MTY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Gral. Mariano Escobedo, Ciudad de Apodaca, MX (MTY)"
+
+  - trigger: "::GCM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Owen Roberts International Airport, George Town, KY (GCM)"
+
+  - trigger: "::KIN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Norman Manley International Airport, Kingston, JM (KIN)"
+
+  - trigger: "::SCQ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Santiago-Rosalía de Castro Airport, Santiago de Compostela, ES (SCQ)"
+
+  - trigger: "::LEJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Leipzig/Halle Airport, Schkeuditz, DE (LEJ)"
+
+  - trigger: "::GYE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "José Joaquín de Olmedo International Airport, Guayaquil, EC (GYE)"
+
+  - trigger: "::EBB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Entebbe International Airport, Kampala, UG (EBB)"
+
+  - trigger: "::TBS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tbilisi International Airport, Tbilisi, GE (TBS)"
+
+  - trigger: "::FUK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Fukuoka Airport, Fukuoka, JP (FUK)"
+
+  - trigger: "::LOS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Murtala Muhammed International Airport, Lagos, NG (LOS)"
+
+  - trigger: "::HYD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Rajiv Gandhi International Airport, Hyderabad, IN (HYD)"
+
+  - trigger: "::BRI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bari Karol Wojtyła Airport, Bari, IT (BRI)"
+
+  - trigger: "::DLM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dalaman International Airport, Dalaman, TR (DLM)"
+
+  - trigger: "::ZNZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Abeid Amani Karume International Airport, Zanzibar, TZ (ZNZ)"
+
+  - trigger: "::RUH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Khaled International Airport, Riyadh, SA (RUH)"
+
+  - trigger: "::GYD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Heydar Aliyev International Airport, Baku, AZ (GYD)"
+
+  - trigger: "::DAR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Julius Nyerere International Airport, Dar es Salaam, TZ (DAR)"
+
+  - trigger: "::DAC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hazrat Shahjalal International Airport, Dhaka, BD (DAC)"
+
+  - trigger: "::CTS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "New Chitose Airport, Sapporo, JP (CTS)"
+
+  - trigger: "::KMG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kunming Changshui International Airport, Kunming, CN (KMG)"
+
+  - trigger: "::CUR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hato International Airport, Willemstad, CW (CUR)"
+
+  - trigger: "::COK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cochin International Airport, Kochi, IN (COK)"
+
+  - trigger: "::MRU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sir Seewoosagur Ramgoolam International Airport, Plaine Magnien, MU (MRU)"
+
+  - trigger: "::VRA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Juan Gualberto Gomez International Airport, Matanzas, CU (VRA)"
+
+  - trigger: "::SSA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Deputado Luiz Eduardo Magalhães International Airport, Salvador, BR (SSA)"
+
+  - trigger: "::YXS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Prince George Airport, Prince George, CA (YXS)"
+
+  - trigger: "::BJV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Milas Bodrum International Airport, Bodrum, TR (BJV)"
+
+  - trigger: "::PPT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Faa'a International Airport, Papeete, PF (PPT)"
+
+  - trigger: "::MID?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Manuel Crescencio Rejón, Ciudad de Mérida, MX (MID)"
+
+  - trigger: "::LIR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Guanacaste Airport, Liberia, CR (LIR)"
+
+  - trigger: "::UVF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hewanorra International Airport, Vieux Fort, LC (UVF)"
+
+  - trigger: "::MBA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Moi International Airport, Mombasa, KE (MBA)"
+
+  - trigger: "::SAL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Monseñor Óscar Arnulfo Romero International Airport, San Salvador (San Luis Talpa), SV (SAL)"
+
+  - trigger: "::BZE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Philip S. W. Goldson International Airport, Belize City, BZ (BZE)"
+
+  - trigger: "::RGN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Yangon International Airport, Yangon, MM (RGN)"
+
+  - trigger: "::SUB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Juanda International Airport, Surabaya, ID (SUB)"
+
+  - trigger: "::ALA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Almaty International Airport, Almaty, KZ (ALA)"
+
+  - trigger: "::BOJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Burgas Airport, Burgas, BG (BOJ)"
+
+  - trigger: "::GUM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Antonio B. Won Pat International Airport, Hagåtña, GU (GUM)"
+
+  - trigger: "::KHI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jinnah International Airport, Karachi, PK (KHI)"
+
+  - trigger: "::IKA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Imam Khomeini International Airport, Tehran, IR (IKA)"
+
+  - trigger: "::SKP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Skopje International Airport, Ilinden, MK (SKP)"
+
+  - trigger: "::SEZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Seychelles International Airport, Mahe Island, SC (SEZ)"
+
+  - trigger: "::PDL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "João Paulo II Airport, Ponta Delgada, PT (PDL)"
+
+  - trigger: "::OKA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Naha Airport / JASDF Naha Air Base, Naha, JP (OKA)"
+
+  - trigger: "::BWN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Brunei International Airport, Bandar Seri Begawan, BN (BWN)"
+
+  - trigger: "::PUS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gimhae International Airport, Busan, KR (PUS)"
+
+  - trigger: "::MSQ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Minsk National Airport, Minsk, BY (MSQ)"
+
+  - trigger: "::MFM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Macau International Airport, Nossa Senhora do Carmo, MO (MFM)"
+
+  - trigger: "::FDF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Martinique Aimé Césaire International Airport, Fort-de-France, MQ (FDF)"
+
+  - trigger: "::ALG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Houari Boumediene Airport, Algiers, DZ (ALG)"
+
+  - trigger: "::ACA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Juan N. Álvarez, Ciudad de Acapulco, MX (ACA)"
+
+  - trigger: "::TIJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Gral. Abelardo Rodriguez, Ciudad de Tijuana, MX (TIJ)"
+
+  - trigger: "::KRT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Khartoum International Airport, Khartoum, SD (KRT)"
+
+  - trigger: "::TIA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tirana International Airport Mother Teresa, Tirana, AL (TIA)"
+
+  - trigger: "::CJU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jeju International Airport, Jeju City, KR (CJU)"
+
+  - trigger: "::MZT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Gral. Rafael Buelna, Ciudad de Mazatlàn, MX (MZT)"
+
+  - trigger: "::VVI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Viru Viru International Airport, Santa Cruz, BO (VVI)"
+
+  - trigger: "::TRV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Thiruvananthapuram International Airport, Thiruvananthapuram, IN (TRV)"
+
+  - trigger: "::WDH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hosea Kutako International Airport, Windhoek, NA (WDH)"
+
+  - trigger: "::CZM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional de Cozumel, Ciudad de Cozumel, MX (CZM)"
+
+  - trigger: "::PAP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Toussaint Louverture International Airport, Port-au-Prince, HT (PAP)"
+
+  - trigger: "::TAS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tashkent International Airport, Tashkent, UZ (TAS)"
+
+  - trigger: "::CNF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tancredo Neves International Airport, Belo Horizonte, BR (CNF)"
+
+  - trigger: "::LUN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kenneth Kaunda International Airport, Lusaka, ZM (LUN)"
+
+  - trigger: "::MAO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Eduardo Gomes International Airport, Manaus, BR (MAO)"
+
+  - trigger: "::PTP?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Pointe-à-Pitre Le Raizet International Airport, Pointe-à-Pitre, GP (PTP)"
+
+  - trigger: "::SHJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sharjah International Airport, Sharjah, AE (SHJ)"
+
+  - trigger: "::BJX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Del Bajío, Ciudad de Silao, MX (BJX)"
+
+  - trigger: "::XMN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Xiamen Gaoqi International Airport, Xiamen, CN (XMN)"
+
+  - trigger: "::NGO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chubu Centrair International Airport, Tokoname, JP (NGO)"
+
+  - trigger: "::NQZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nursultan Nazarbayev International Airport, Nur-Sultan, KZ (NQZ)"
+
+  - trigger: "::TGD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Podgorica Airport / Podgorica Golubovci Airbase, Podgorica, ME (TGD)"
+
+  - trigger: "::VAR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Varna Airport, Varna, BG (VAR)"
+
+  - trigger: "::HGH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hangzhou Xiaoshan International Airport, Hangzhou, CN (HGH)"
+
+  - trigger: "::CKG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chongqing Jiangbei International Airport, Chongqing, CN (CKG)"
+
+  - trigger: "::FRU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Manas International Airport, Bishkek, KG (FRU)"
+
+  - trigger: "::KWL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Guilin Liangjiang International Airport, Guilin (Lingui), CN (KWL)"
+
+  - trigger: "::WUH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Wuhan Tianhe International Airport, Wuhan (Huangpi), CN (WUH)"
+
+  - trigger: "::SID?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Amílcar Cabral International Airport, Espargos, CV (SID)"
+
+  - trigger: "::HMO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "General Ignacio P. Garcia International Airport, Hermosillo, MX (HMO)"
+
+  - trigger: "::KGL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kigali International Airport, Kigali, RW (KGL)"
+
+  - trigger: "::LAD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Quatro de Fevereiro International Airport, Luanda, AO (LAD)"
+
+  - trigger: "::KHH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kaohsiung International Airport, Kaohsiung (Xiaogang), TW (KHH)"
+
+  - trigger: "::EVN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Zvartnots International Airport, Yerevan, AM (EVN)"
+
+  - trigger: "::FLN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hercílio Luz International Airport, Florianópolis, BR (FLN)"
+
+  - trigger: "::JIB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Djibouti-Ambouli Airport, Djibouti City, DJ (JIB)"
+
+  - trigger: "::FIH?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ndjili International Airport, Kinshasa, CD (FIH)"
+
+  - trigger: "::BDS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Brindisi Airport, Brindisi, IT (BDS)"
+
+  - trigger: "::DUR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Shaka International Airport, Durban, ZA (DUR)"
+
+  - trigger: "::UPG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hasanuddin International Airport, Ujung Pandang, ID (UPG)"
+
+  - trigger: "::THR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mehrabad International Airport, Tehran, IR (THR)"
+
+  - trigger: "::HRE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Robert Gabriel Mugabe International Airport, Harare, ZW (HRE)"
+
+  - trigger: "::ADW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Joint Base Andrews, Camp Springs, US (ADW)"
+
+  - trigger: "::ABV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nnamdi Azikiwe International Airport, Abuja, NG (ABV)"
+
+  - trigger: "::MPM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Maputo Airport, Maputo, MZ (MPM)"
+
+  - trigger: "::ASU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Silvio Pettirossi, Asunción, PY (ASU)"
+
+  - trigger: "::DAM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Damascus International Airport, Damascus, SY (DAM)"
+
+  - trigger: "::LHE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Allama Iqbal International Airport, Lahore, PK (LHE)"
+
+  - trigger: "::RUN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Roland Garros Airport, Sainte-Marie, RE (RUN)"
+
+  - trigger: "::BJL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Banjul International Airport, Banjul, GM (BJL)"
+
+  - trigger: "::TLC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Adolfo López Mateos, Ciudad de Toluca, MX (TLC)"
+
+  - trigger: "::TNR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ivato Airport, Antananarivo, MG (TNR)"
+
+  - trigger: "::DLC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dalian Zhoushuizi International Airport, Ganjingzi, Dalian, CN (DLC)"
+
+  - trigger: "::HRB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Harbin Taiping International Airport, Harbin, CN (HRB)"
+
+  - trigger: "::DMM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Fahd International Airport, Ad Dammam, SA (DMM)"
+
+  - trigger: "::MED?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Prince Mohammad Bin Abdulaziz Airport, Medina, SA (MED)"
+
+  - trigger: "::POM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Port Moresby Jacksons International Airport, Port Moresby, PG (POM)"
+
+  - trigger: "::KOJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kagoshima Airport, Kagoshima, JP (KOJ)"
+
+  - trigger: "::BEL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Val de Cans/Júlio Cezar Ribeiro International Airport, Belém, BR (BEL)"
+
+  - trigger: "::NDJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "N'Djamena International Airport, N'Djamena, TD (NDJ)"
+
+  - trigger: "::DWC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Al Maktoum International Airport, Jebel Ali, AE (DWC)"
+
+  - trigger: "::ROB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Roberts International Airport, Monrovia, LR (ROB)"
+
+  - trigger: "::OVB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Novosibirsk Tolmachevo Airport, Novosibirsk, RU (OVB)"
+
+  - trigger: "::DNA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kadena Air Base, , JP (DNA)"
+
+  - trigger: "::SYZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shiraz Shahid Dastghaib International Airport, Shiraz, IR (SYZ)"
+
+  - trigger: "::AER?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sochi International Airport, Sochi, RU (AER)"
+
+  - trigger: "::TSN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Tianjin Binhai International Airport, Tianjin, CN (TSN)"
+
+  - trigger: "::GBE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sir Seretse Khama International Airport, Gaborone, BW (GBE)"
+
+  - trigger: "::VLI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Bauerfield International Airport, Port Vila, VU (VLI)"
+
+  - trigger: "::MDL?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mandalay International Airport, Mandalay, MM (MDL)"
+
+  - trigger: "::BON?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Flamingo International Airport, Kralendijk, Bonaire, BQ (BON)"
+
+  - trigger: "::KNO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kualanamu International Airport, Medan, ID (KNO)"
+
+  - trigger: "::NKG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nanjing Lukou International Airport, Nanjing, CN (NKG)"
+
+  - trigger: "::VIX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Eurico de Aguiar Salles Airport, Vitória, BR (VIX)"
+
+  - trigger: "::LWO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lviv International Airport, Lviv, UA (LWO)"
+
+  - trigger: "::SVX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Koltsovo Airport, Yekaterinburg, RU (SVX)"
+
+  - trigger: "::PBM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Johan Adolf Pengel International Airport, Zandery, SR (PBM)"
+
+  - trigger: "::NIM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Diori Hamani International Airport, Niamey, NE (NIM)"
+
+  - trigger: "::BGW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Baghdad International Airport / New Al Muthana Air Base, Baghdad, IQ (BGW)"
+
+  - trigger: "::BKO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Modibo Keita International Airport, Bamako, ML (BKO)"
+
+  - trigger: "::TNA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Jinan Yaoqiang International Airport, Jinan, CN (TNA)"
+
+  - trigger: "::PKX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Beijing Daxing International Airport, Beijing, CN (PKX)"
+
+  - trigger: "::BPS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Porto Seguro Airport, Porto Seguro, BR (BPS)"
+
+  - trigger: "::OKO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Yokota Air Base, Fussa, JP (OKO)"
+
+  - trigger: "::CGO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Zhengzhou Xinzheng International Airport, Zhengzhou, CN (CGO)"
+
+  - trigger: "::DJJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Dortheys Hiyo Eluay International Airport, Sentani, ID (DJJ)"
+
+  - trigger: "::VVO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Vladivostok International Airport, Artyom, RU (VVO)"
+
+  - trigger: "::URC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ürümqi Diwopu International Airport, Ürümqi, CN (URC)"
+
+  - trigger: "::ASB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ashgabat International Airport, Ashgabat, TM (ASB)"
+
+  - trigger: "::SHE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Shenyang Taoxian International Airport, Hunnan, Shenyang, CN (SHE)"
+
+  - trigger: "::FNA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lungi International Airport, Freetown (Lungi-Town), SL (FNA)"
+
+  - trigger: "::JUB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Juba International Airport, Juba, SS (JUB)"
+
+  - trigger: "::NGB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ningbo Lishe International Airport, Ningbo, CN (NGB)"
+
+  - trigger: "::SYX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sanya Phoenix International Airport, Sanya (Tianya), CN (SYX)"
+
+  - trigger: "::DVO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Francisco Bangoy International Airport, Davao, PH (DVO)"
+
+  - trigger: "::MHD?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mashhad International Airport, Mashhad, IR (MHD)"
+
+  - trigger: "::BPN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sultan Aji Muhammad Sulaiman Sepinggan International Airport, Balikpapan, ID (BPN)"
+
+  - trigger: "::CAY?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Cayenne – Félix Eboué Airport, Matoury, GF (CAY)"
+
+  - trigger: "::KUF?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kurumoch International Airport, Samara, RU (KUF)"
+
+  - trigger: "::KZN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Kazan International Airport, Kazan, RU (KZN)"
+
+  - trigger: "::LHW?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Lanzhou Zhongchuan International Airport, Lanzhou (Yongdeng), CN (LHW)"
+
+  - trigger: "::FOC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Fuzhou Changle International Airport, Fuzhou, CN (FOC)"
+
+  - trigger: "::SDJ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Sendai Airport, Natori, JP (SDJ)"
+
+  - trigger: "::BLA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "General José Antonio Anzoategui International Airport, Barcelona, VE (BLA)"
+
+  - trigger: "::TYN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Taiyuan Wusu Airport, Taiyuan, CN (TYN)"
+
+  - trigger: "::DSS?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Blaise Diagne International Airport, Dakar, SN (DSS)"
+
+  - trigger: "::HIR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Honiara International Airport, Honiara, SB (HIR)"
+
+  - trigger: "::KJA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Krasnoyarsk International Airport, Krasnoyarsk, RU (KJA)"
+
+  - trigger: "::ISB?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Islamabad International Airport, Attock, PK (ISB)"
+
+  - trigger: "::UFA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ufa International Airport, Ufa, RU (UFA)"
+
+  - trigger: "::HAK?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Haikou Meilan International Airport, Haikou (Meilan), CN (HAK)"
+
+  - trigger: "::CGQ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Changchun Longjia International Airport, Changchun, CN (CGQ)"
+
+  - trigger: "::NKC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nouakchott–Oumtounsy International Airport, Nouakchott, MR (NKC)"
+
+  - trigger: "::GEA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nouméa Magenta Airport, Nouméa, NC (GEA)"
+
+  - trigger: "::MJI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mitiga International Airport, Tripoli, LY (MJI)"
+
+  - trigger: "::DGO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Gral, Guadalupe Victoria, Ciudad de Durango, MX (DGO)"
+
+  - trigger: "::UBN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ulaanbaatar Chinggis Khaan International Airport, Ulaanbaatar (Sergelen), MN (UBN)"
+
+  - trigger: "::DHA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Abdulaziz Air Base, Dhahran, SA (DHA)"
+
+  - trigger: "::CSX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Changsha Huanghua International Airport, Changsha (Changsha), CN (CSX)"
+
+  - trigger: "::AGT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Guaraní, Ciudad del Este, PY (AGT)"
+
+  - trigger: "::ETM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ramon International Airport, Eilat, IL (ETM)"
+
+  - trigger: "::HET?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hohhot Baita International Airport, Hohhot, CN (HET)"
+
+  - trigger: "::WNZ?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Wenzhou Longwan International Airport, Wenzhou, CN (WNZ)"
+
+  - trigger: "::KWE?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Guiyang Longdongbao International Airport, Guiyang (Nanming), CN (KWE)"
+
+  - trigger: "::TAO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Qingdao Jiaodong International Airport, Jiaozhou, Qingdao, CN (TAO)"
+
+  - trigger: "::KHN?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nanchang Changbei International Airport, Nanchang, CN (KHN)"
+
+  - trigger: "::YNT?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Yantai Penglai International Airport, Yantai, CN (YNT)"
+
+  - trigger: "::NNG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Nanning Wuxu Airport, Nanning (Jiangnan), CN (NNG)"
+
+  - trigger: "::DQM?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Duqm International Airport, Duqm, OM (DQM)"
+
+  - trigger: "::NLU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional General Felipe Ángeles, Mexico City, MX (NLU)"
+
+  - trigger: "::SHO?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "King Mswati III International Airport, Mpaka, SZ (SHO)"
+
+  - trigger: "::ROV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Platov International Airport, Rostov-on-Don, RU (ROV)"
+
+  - trigger: "::HSA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Hazrat Sultan International Airport, , KZ (HSA)"
+
+  - trigger: "::HRI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Mattala Rajapaksa International Airport, , LK (HRI)"
+
+  - trigger: "::TFU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Chengdu Tianfu International Airport, Chengdu (Jianyang), CN (TFU)"
+
+  - trigger: "::ZIA?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Zhukovsky International Airport, Moscow, RU (ZIA)"
+
+  - trigger: "::MWX?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Muan International Airport, Piseo-ri (Muan), KR (MWX)"
+
+  - trigger: "::ESG?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Dr. Luis Maria Argaña, Mariscal Estigarribia, PY (ESG)"
+
+  - trigger: "::EHU?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Ezhou Huahu Airport, Ezhou, CN (EHU)"
+
+  - trigger: "::GSV?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Gagarin International Airport, Saratov, RU (GSV)"
+
+  - trigger: "::SAI?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Siem Reap-Angkor International Airport, Siem Reap, KH (SAI)"
+
+  - trigger: "::PJC?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Aeropuerto Internacional Dr. Augusto Roberto Fuster, Pedro Juan Caballero, PY (PJC)"
+
+  - trigger: "::HSR?"
+    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
+    replace: "Rajkot International Airport, Rajkot, IN (HSR)"
+
+  # Provide airline name based on IATA's two-character designators
+  - trigger: "::1T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "1Time Airline (1T), ZA"
+
+  - trigger: "::Q5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "40-Mile Air (Q5), US"
+
+  - trigger: "::AN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ansett Australia (AN), AU"
+
+  - trigger: "::1B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Abacus International (1B), SG"
+
+  - trigger: "::W9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Abelag Aviation (W9), BE"
+
+  - trigger: "::ZI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aigle Azur (ZI), FR"
+
+  - trigger: "::AQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aloha Airlines (AQ), US"
+
+  - trigger: "::AA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "American Airlines (AA), US"
+
+  - trigger: "::OZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Asiana Airlines (OZ), KR"
+
+  - trigger: "::4K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Askari Aviation (4K), PK"
+
+  - trigger: "::8U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Afriqiyah Airways (8U), LY"
+
+  - trigger: "::Q9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Afrinat International Airlines (Q9), GM"
+
+  - trigger: "::G4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Allegiant Air (G4), US"
+
+  - trigger: "::K5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aban Air (K5), IR"
+
+  - trigger: "::M3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ABSA - Aerolinhas Brasileiras (M3), BR"
+
+  - trigger: "::O4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Antrak Air (O4), GH"
+
+  - trigger: "::GB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airborne Express (GB), US"
+
+  - trigger: "::8V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Astral Aviation (8V), KE"
+
+  - trigger: "::E4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Asia International (E4), PK"
+
+  - trigger: "::YT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Togo (YT), TG"
+
+  - trigger: "::4G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Advance Leasing Company (4G), US"
+
+  - trigger: "::7A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aztec Worldwide Airlines (7A), US"
+
+  - trigger: "::8T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Tindi (8T), CA"
+
+  - trigger: "::ZY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ada Air (ZY), AL"
+
+  - trigger: "::Z7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ADC Airlines (Z7), NG"
+
+  - trigger: "::JP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Adria Airways (JP), SI"
+
+  - trigger: "::UX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Europa (UX), ES"
+
+  - trigger: "::EM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Benin (EM), BJ"
+
+  - trigger: "::A3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aegean Airlines (A3), GR"
+
+  - trigger: "::KI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Atlantique (KI), GB"
+
+  - trigger: "::PE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Europe (PE), IT"
+
+  - trigger: "::KO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alaska Central Express (KO), US"
+
+  - trigger: "::5W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Astraeus (5W), GB"
+
+  - trigger: "::VV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerosvit Airlines (VV), UA"
+
+  - trigger: "::I9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Italy (I9), IT"
+
+  - trigger: "::WK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "American Falcon (WK), AR"
+
+  - trigger: "::QQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alliance Airlines (QQ), AU"
+
+  - trigger: "::FG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ariana Afghan Airlines (FG), AF"
+
+  - trigger: "::SU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroflot Russian Airlines (SU), RU"
+
+  - trigger: "::JA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Bosna (JA), BA"
+
+  - trigger: "::AF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air France (AF), FR"
+
+  - trigger: "::SB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Caledonie International (SB), FR"
+
+  - trigger: "::GN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Gabon (GN), GA"
+
+  - trigger: "::2O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Salone (2O), SL"
+
+  - trigger: "::2Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Cargo Carriers (2Q), US"
+
+  - trigger: "::V7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Senegal International (V7), SN"
+
+  - trigger: "::SW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Namibia (SW), NA"
+
+  - trigger: "::5D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerolitoral (5D), MX"
+
+  - trigger: "::1A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Amadeus Global Travel Distribution (1A), ES"
+
+  - trigger: "::7T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Glaciers (7T), CH"
+
+  - trigger: "::PL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroper (PL), PE"
+
+  - trigger: "::8A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlas Blue (8A), MA"
+
+  - trigger: "::GD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Alpha Greenland (GD), DK"
+
+  - trigger: "::LD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Hong Kong (LD), HK"
+
+  - trigger: "::HT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeromist-Kharkiv (HT), UA"
+
+  - trigger: "::J2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Azerbaijan Airlines (J2), AZ"
+
+  - trigger: "::U3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avies (U3), EE"
+
+  - trigger: "::AP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airbus Industrie (AP), FR"
+
+  - trigger: "::5A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alpine Air Express (5A), US"
+
+  - trigger: "::ED?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airblue (ED), PK"
+
+  - trigger: "::AB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Berlin (AB), DE"
+
+  - trigger: "::AG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Contractors (AG), IE"
+
+  - trigger: "::AI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air India Limited (AI), IN"
+
+  - trigger: "::ZB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Bourbon (ZB), FR"
+
+  - trigger: "::CC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Atlanta Icelandic (CC), IS"
+
+  - trigger: "::RB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Srpska (RB), BA"
+
+  - trigger: "::TN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Tahiti Nui (TN), FR"
+
+  - trigger: "::W4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Services Executive (W4), FR"
+
+  - trigger: "::IZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arkia Israel Airlines (IZ), IL"
+
+  - trigger: "::JM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Jamaica (JM), JM"
+
+  - trigger: "::AP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air One (AP), IT"
+
+  - trigger: "::S2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Sahara (S2), IN"
+
+  - trigger: "::KM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Malta (KM), MT"
+
+  - trigger: "::M6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Amerijet International (M6), US"
+
+  - trigger: "::NQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Japan (NQ), JP"
+
+  - trigger: "::4A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Kiribati (4A), KI"
+
+  - trigger: "::EH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Nippon Network Co. Ltd. (EH), JP"
+
+  - trigger: "::HP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "America West Airlines (HP), US"
+
+  - trigger: "::ZW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Wisconsin (ZW), US"
+
+  - trigger: "::U9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tatarstan Airlines (U9), RU"
+
+  - trigger: "::VD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Libert (VD), FR"
+
+  - trigger: "::TT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Lithuania (TT), LT"
+
+  - trigger: "::QM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Malawi (QM), MW"
+
+  - trigger: "::BM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Sicilia (BM), IT"
+
+  - trigger: "::NX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Macau (NX), MO"
+
+  - trigger: "::ZV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Midwest (ZV), US"
+
+  - trigger: "::HM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Seychelles (HM), SC"
+
+  - trigger: "::AM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AeroMéxico (AM), MX"
+
+  - trigger: "::NH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Nippon Airways (NH), JP"
+
+  - trigger: "::YW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Nostrum (YW), ES"
+
+  - trigger: "::PX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Niugini (PX), PG"
+
+  - trigger: "::G9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Arabia (G9), AE"
+
+  - trigger: "::AC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Canada (AC), CA"
+
+  - trigger: "::BT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Baltic (BT), LV"
+
+  - trigger: "::EL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Nippon (EL), JP"
+
+  - trigger: "::TL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airnorth (TL), AU"
+
+  - trigger: "::4N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air North Charter - Canada (4N), CA"
+
+  - trigger: "::IW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AOM French Airlines (IW), FR"
+
+  - trigger: "::NZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air New Zealand (NZ), NZ"
+
+  - trigger: "::J6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AVCOM (J6), RU"
+
+  - trigger: "::2D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero VIP (2D), AR"
+
+  - trigger: "::6V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Vegas (6V), US"
+
+  - trigger: "::XM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alitalia Express (XM), IT"
+
+  - trigger: "::OE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly One Airlines S.R.L. (OE), RO"
+
+  - trigger: "::GV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Flight (GV), DE"
+
+  - trigger: "::JW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arrow Air (JW), US"
+
+  - trigger: "::W3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arik Air (W3), NG"
+
+  - trigger: "::2B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerocondor (2B), PT"
+
+  - trigger: "::4C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LATAM Airlines Colombia (4C), CO"
+
+  - trigger: "::AR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerolineas Argentinas (AR), AR"
+
+  - trigger: "::QN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Armenia (QN), AM"
+
+  - trigger: "::AS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alaska Airlines (AS), US"
+
+  - trigger: "::4D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Sinai (4D), EG"
+
+  - trigger: "::PL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airstars (PL), RU"
+
+  - trigger: "::EV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlantic Southeast Airlines (EV), US"
+
+  - trigger: "::OB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Astrakhan Airlines (OB), RU"
+
+  - trigger: "::TC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Tanzania (TC), TZ"
+
+  - trigger: "::2J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Burkina (2J), BF"
+
+  - trigger: "::HC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero-Tropics Air Services (HC), AU"
+
+  - trigger: "::FO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airlines Of Tasmania (FO), AU"
+
+  - trigger: "::PJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Saint Pierre (PJ), FR"
+
+  - trigger: "::8C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Transport International (8C), US"
+
+  - trigger: "::OS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Austrian Airlines (OS), AT"
+
+  - trigger: "::IQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Augsburg Airways (IQ), DE"
+
+  - trigger: "::RU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirBridge Cargo (RU), RU"
+
+  - trigger: "::MO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Abu Dhabi Amiri Flight (MO), AE"
+
+  - trigger: "::5N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroflot-Nord (5N), RU"
+
+  - trigger: "::GR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aurigny Air Services (GR), GB"
+
+  - trigger: "::NO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aus-Air (NO), AU"
+
+  - trigger: "::AU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Austral Lineas Aereas (AU), AR"
+
+  - trigger: "::AO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Australian Airlines (AO), AU"
+
+  - trigger: "::AV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avianca - Aerovias Nacionales de Colombia (AV), CO"
+
+  - trigger: "::NF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Vanuatu (NF), VU"
+
+  - trigger: "::K8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airlink Zambia (K8), ZM"
+
+  - trigger: "::B9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Bangladesh (B9), BD"
+
+  - trigger: "::DR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mediterranee (DR), FR"
+
+  - trigger: "::7E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroline GmbH (7E), DE"
+
+  - trigger: "::6G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Wales (6G), GB"
+
+  - trigger: "::TX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Caraïbes (TX), FR"
+
+  - trigger: "::IX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air India Express (IX), IN"
+
+  - trigger: "::HJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Asian Express Airlines (HJ), AU"
+
+  - trigger: "::XT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Exel (XT), NL"
+
+  - trigger: "::AK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirAsia (AK), MY"
+
+  - trigger: "::6V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Axis Airways (6V), FR"
+
+  - trigger: "::3G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlant-Soyuz Airlines (3G), RU"
+
+  - trigger: "::AZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alitalia (AZ), IT"
+
+  - trigger: "::ZE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arcus-Air Logistic (ZE), DE"
+
+  - trigger: "::Z8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Amaszonas (Z8), BO"
+
+  - trigger: "::UM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Zimbabwe (UM), ZW"
+
+  - trigger: "::R7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aserca Airlines (R7), VE"
+
+  - trigger: "::FV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rossiya-Russian Airlines (FV), RU"
+
+  - trigger: "::RX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aviaexpress (RX), HU"
+
+  - trigger: "::MQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "American Eagle Airlines (MQ), US"
+
+  - trigger: "::FF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airshop (FF), NL"
+
+  - trigger: "::ML?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "African Transport Trading and Investment Company (ML), SD"
+
+  - trigger: "::VU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Ivoire (VU), CI"
+
+  - trigger: "::BP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Botswana (BP), BW"
+
+  - trigger: "::GS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Foyle (GS), GB"
+
+  - trigger: "::VT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Tahiti (VT), FR"
+
+  - trigger: "::3N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Urga (3N), UA"
+
+  - trigger: "::VL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air VIA (VL), BG"
+
+  - trigger: "::FK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Africa West (FK), TG"
+
+  - trigger: "::G2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avirex (G2), GA"
+
+  - trigger: "::V8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ATRAN Cargo Airlines (V8), RU"
+
+  - trigger: "::VE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avensa (VE), VE"
+
+  - trigger: "::V5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avolar Aerolineas (V5), MX"
+
+  - trigger: "::CA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air China (CA), CN"
+
+  - trigger: "::Q6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Condor Peru (Q6), PE"
+
+  - trigger: "::5F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arctic Circle Air Service (5F), US"
+
+  - trigger: "::QC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Corridor (QC), MZ"
+
+  - trigger: "::NV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Central (NV), JP"
+
+  - trigger: "::CV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Chathams (CV), NZ"
+
+  - trigger: "::CW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Marshall Islands (CW), MH"
+
+  - trigger: "::ZA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Access Air (ZA), US"
+
+  - trigger: "::AH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Algerie (AH), DZ"
+
+  - trigger: "::KI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Adam Air (KI), ID"
+
+  - trigger: "::ER?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Astar Air Cargo (ER), US"
+
+  - trigger: "::HO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Antinea Airlines (HO), DZ"
+
+  - trigger: "::EN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Dolomiti (EN), IT"
+
+  - trigger: "::D9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroflot-Don (D9), RU"
+
+  - trigger: "::NM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Madrid (NM), ES"
+
+  - trigger: "::EE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Airlines (EE), EE"
+
+  - trigger: "::4F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air City (4F), DE"
+
+  - trigger: "::EI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aer Lingus (EI), IE"
+
+  - trigger: "::E8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alpi Eagles (E8), IT"
+
+  - trigger: "::KY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air S (KY), ST"
+
+  - trigger: "::PC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Fiji (PC), FJ"
+
+  - trigger: "::OF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Finland (OF), FI"
+
+  - trigger: "::FJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Pacific (FJ), FJ"
+
+  - trigger: "::RC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlantic Airways (RC), FO"
+
+  - trigger: "::QH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Florida (QH), US"
+
+  - trigger: "::NY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Iceland (NY), IS"
+
+  - trigger: "::2P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Philippines (2P), PH"
+
+  - trigger: "::ZX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Georgian (ZX), CA"
+
+  - trigger: "::2U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Guinee Express (2U), GN"
+
+  - trigger: "::0A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Amber Air (0A), LT"
+
+  - trigger: "::DA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Georgia (DA), GE"
+
+  - trigger: "::GL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Greenland (GL), DK"
+
+  - trigger: "::LL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Allegro (LL), MX"
+
+  - trigger: "::5Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlas Air (5Y), US"
+
+  - trigger: "::GG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Guyane (GG), FR"
+
+  - trigger: "::H9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air D'Ayiti (H9), HT"
+
+  - trigger: "::GG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Comores International (GG), KM"
+
+  - trigger: "::8C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Horizon (8C), TG"
+
+  - trigger: "::W9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Bagan (W9), MM"
+
+  - trigger: "::IP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atyrau Air Ways (IP), KZ"
+
+  - trigger: "::QK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Canada Jazz (QK), CA"
+
+  - trigger: "::KK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlasjet (KK), TR"
+
+  - trigger: "::JS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Koryo (JS), KP"
+
+  - trigger: "::KC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Astana (KC), KZ"
+
+  - trigger: "::LV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Albanian Airlines (LV), AL"
+
+  - trigger: "::D4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alidaunia (D4), IT"
+
+  - trigger: "::CD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alliance Air (CD), IN"
+
+  - trigger: "::XL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerolane (XL), EC"
+
+  - trigger: "::A6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Alps Aviation (A6), AT"
+
+  - trigger: "::TD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlantis European Airways (TD), AM"
+
+  - trigger: "::L8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Luxor GB (L8), GW"
+
+  - trigger: "::LK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Luxor (LK), PT"
+
+  - trigger: "::MK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mauritius (MK), MU"
+
+  - trigger: "::MD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Madagascar (MD), MG"
+
+  - trigger: "::9U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Moldova (9U), MD"
+
+  - trigger: "::M0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Mongolia (M0), MN"
+
+  - trigger: "::A7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Plus Comet (A7), ES"
+
+  - trigger: "::QO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeromexpress (QO), MX"
+
+  - trigger: "::MR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mauritanie (MR), MR"
+
+  - trigger: "::3S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeroland Airways (3S), GR"
+
+  - trigger: "::8D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Astair (8D), RU"
+
+  - trigger: "::F4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Albarka Air (F4), NG"
+
+  - trigger: "::AJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Contractors (AJ), NG"
+
+  - trigger: "::8Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Burundi (8Y), BI"
+
+  - trigger: "::OT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeropelican Air Services (OT), AU"
+
+  - trigger: "::AD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Paradise International (AD), ID"
+
+  - trigger: "::QD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Class Lineas Aereas (QD), UY"
+
+  - trigger: "::QS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "African Safari Airways (QS), KE"
+
+  - trigger: "::4Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airbus France (4Y), FR"
+
+  - trigger: "::MC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mobility Command (MC), US"
+
+  - trigger: "::RE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aer Arann (RE), IE"
+
+  - trigger: "::UU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Austral (UU), FR"
+
+  - trigger: "::6K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Asian Spirit (6K), PH"
+
+  - trigger: "::RK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Afrique (RK), CI"
+
+  - trigger: "::A5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airlinair (A5), FR"
+
+  - trigger: "::QL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Lanka (QL), LK"
+
+  - trigger: "::MV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Armenian International Airways (MV), AM"
+
+  - trigger: "::20?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Salone (20), SL"
+
+  - trigger: "::U8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Armavia (U8), AM"
+
+  - trigger: "::BQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeromar (BQ), DO"
+
+  - trigger: "::P5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AeroRep (P5), CO"
+
+  - trigger: "::BF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero-Service (BF), CG"
+
+  - trigger: "::5L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerosur (5L), BO"
+
+  - trigger: "::EX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Santo Domingo (EX), DO"
+
+  - trigger: "::JR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero California (JR), MX"
+
+  - trigger: "::Z3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avient Aviation (Z3), ZW"
+
+  - trigger: "::M3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Service (M3), MK"
+
+  - trigger: "::GM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Slovakia (GM), SK"
+
+  - trigger: "::R3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aircompany Yakutia (R3), RU"
+
+  - trigger: "::VW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aeromar (VW), MX"
+
+  - trigger: "::JY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Turks and Caicos (JY), TC"
+
+  - trigger: "::OR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arkefly (OR), NL"
+
+  - trigger: "::CG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airlines PNG (CG), PG"
+
+  - trigger: "::TY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Cal (TY), FR"
+
+  - trigger: "::FL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirTran Airways (FL), US"
+
+  - trigger: "::TS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Transat (TS), CA"
+
+  - trigger: "::EC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Avialeasing Aviation Company (EC), UZ"
+
+  - trigger: "::VO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tyrolean Airways (VO), AT"
+
+  - trigger: "::DW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero-Charter Ukraine (DW), UA"
+
+  - trigger: "::6U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Ukraine (6U), UA"
+
+  - trigger: "::2K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerolineas Galapagos (Aerogal) (2K), EC"
+
+  - trigger: "::6R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alrosa Mirny Air Enterprise (6R), RU"
+
+  - trigger: "::8Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Baker Aviation (8Q), US"
+
+  - trigger: "::BA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "British Airways (BA), GB"
+
+  - trigger: "::BG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Biman Bangladesh Airlines (BG), BD"
+
+  - trigger: "::BF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bluebird Cargo (BF), IS"
+
+  - trigger: "::B4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BACH Flugbetriebsges (B4), AT"
+
+  - trigger: "::BZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue Dart Aviation (BZ), IN"
+
+  - trigger: "::JA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "B&H Airlines (JA), BA"
+
+  - trigger: "::J4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Buffalo Airways (J4), CA"
+
+  - trigger: "::A8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Benin Golf Air (A8), BJ"
+
+  - trigger: "::4T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Belair Airlines (4T), CH"
+
+  - trigger: "::UP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bahamasair (UP), BS"
+
+  - trigger: "::E6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bringer Air Cargo Taxi Aereo (E6), BR"
+
+  - trigger: "::TH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BA Connect (TH), GB"
+
+  - trigger: "::BS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "British International Helicopters (BS), GB"
+
+  - trigger: "::B4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bankair (B4), US"
+
+  - trigger: "::PG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bangkok Airways (PG), TH"
+
+  - trigger: "::KF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue1 (KF), FI"
+
+  - trigger: "::JV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bearskin Lake Air Service (JV), CA"
+
+  - trigger: "::B3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bellview Airlines (B3), NG"
+
+  - trigger: "::BD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "bmi (BD), GB"
+
+  - trigger: "::WW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "bmibaby (WW), GB"
+
+  - trigger: "::CH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bemidji Airlines (CH), US"
+
+  - trigger: "::5Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bismillah Airlines (5Z), BD"
+
+  - trigger: "::BO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bouraq Indonesia Airlines (BO), ID"
+
+  - trigger: "::BV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue Panorama Airlines (BV), IT"
+
+  - trigger: "::7R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BRA-Transportes Aereos (7R), BR"
+
+  - trigger: "::8E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bering Air (8E), US"
+
+  - trigger: "::B2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Belavia Belarusian Airlines (B2), BY"
+
+  - trigger: "::K6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bravo Air Congo (K6), CD"
+
+  - trigger: "::BN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Braniff International Airways (BN), US"
+
+  - trigger: "::GQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Big Sky Airlines (GQ), US"
+
+  - trigger: "::V9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BAL Bashkirian Airlines (V9), RU"
+
+  - trigger: "::7P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Metro Batavia (7P), ID"
+
+  - trigger: "::J8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Berjaya Air (J8), MY"
+
+  - trigger: "::QW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue Wings (QW), DE"
+
+  - trigger: "::BM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bayu Indonesia Air (BM), ID"
+
+  - trigger: "::DB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Brit Air (DB), FR"
+
+  - trigger: "::E9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Boston-Maine Airways (E9), US"
+
+  - trigger: "::SN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Brussels Airlines (SN), BE"
+
+  - trigger: "::NT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Binter Canarias (NT), ES"
+
+  - trigger: "::0B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue Air (0B), RO"
+
+  - trigger: "::KJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "British Mediterranean Airways (KJ), GB"
+
+  - trigger: "::FB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bulgaria Air (FB), BG"
+
+  - trigger: "::8N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Barents AirLink (8N), SE"
+
+  - trigger: "::5C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CAL Cargo Air Lines (5C), IL"
+
+  - trigger: "::AW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CHC Airways (AW), NL"
+
+  - trigger: "::XG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Calima Aviacion (XG), ES"
+
+  - trigger: "::MO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Calm Air (MO), CA"
+
+  - trigger: "::R9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Camai Air (R9), US"
+
+  - trigger: "::UY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cameroon Airlines (UY), CM"
+
+  - trigger: "::C6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CanJet (C6), CA"
+
+  - trigger: "::CP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Canadian Airlines (CP), CA"
+
+  - trigger: "::5T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Canadian North (5T), CA"
+
+  - trigger: "::W2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Canadian Western Airlines (W2), CA"
+
+  - trigger: "::9K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cape Air (9K), US"
+
+  - trigger: "::PT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Capital Cargo International Airlines (PT), US"
+
+  - trigger: "::GG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cargo 360 (GG), US"
+
+  - trigger: "::2G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cargoitalia (2G), IT"
+
+  - trigger: "::W8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cargojet Airways (W8), CA"
+
+  - trigger: "::CV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cargolux (CV), LU"
+
+  - trigger: "::BW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Caribbean Airlines (BW), TT"
+
+  - trigger: "::8B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Caribbean Star Airlines (8B), AG"
+
+  - trigger: "::V3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Carpatair (V3), RO"
+
+  - trigger: "::RV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Caspian Airlines (RV), IR"
+
+  - trigger: "::CX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cathay Pacific (CX), HK"
+
+  - trigger: "::KX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cayman Airways (KX), KY"
+
+  - trigger: "::5J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cebu Pacific (5J), PH"
+
+  - trigger: "::7N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Centavia (7N), RS"
+
+  - trigger: "::C0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Centralwings (C0), PL"
+
+  - trigger: "::J7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Centre-Avia (J7), RU"
+
+  - trigger: "::WE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Centurion Air Cargo (WE), US"
+
+  - trigger: "::OP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chalk's Ocean Airways (OP), US"
+
+  - trigger: "::MG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Champion Air (MG), US"
+
+  - trigger: "::2Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Changan Airlines (2Z), CN"
+
+  - trigger: "::S8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chari Aviation Services (S8), TD"
+
+  - trigger: "::RP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chautauqua Airlines (RP), US"
+
+  - trigger: "::C8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chicago Express (C8), US"
+
+  - trigger: "::CI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Airlines (CI), TW"
+
+  - trigger: "::CK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Cargo Airlines (CK), CN"
+
+  - trigger: "::MU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Eastern Airlines (MU), CN"
+
+  - trigger: "::CJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Northern Airlines (CJ), CN"
+
+  - trigger: "::WH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Northwest Airlines (WH), CN"
+
+  - trigger: "::8Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Postal Airlines (8Y), CN"
+
+  - trigger: "::CZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Southern Airlines (CZ), CN"
+
+  - trigger: "::HR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China United Airlines (HR), CN"
+
+  - trigger: "::XO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Xinhua Airlines (XO), CN"
+
+  - trigger: "::3Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yunnan Airlines (3Q), CN"
+
+  - trigger: "::X7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chitaavia (X7), RU"
+
+  - trigger: "::A2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cielos Airlines (A2), PE"
+
+  - trigger: "::QI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cimber Air (QI), DK"
+
+  - trigger: "::C9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cirrus Airlines (C9), DE"
+
+  - trigger: "::CF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "City Airline (CF), SE"
+
+  - trigger: "::G3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "City Connexion Airlines (G3), BI"
+
+  - trigger: "::WX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CityJet (WX), IE"
+
+  - trigger: "::CJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BA CityFlyer (CJ), GB"
+
+  - trigger: "::CT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Civil Air Transport (CT), TW"
+
+  - trigger: "::6P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Club Air (6P), IT"
+
+  - trigger: "::BX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Coast Air (BX), NO"
+
+  - trigger: "::DQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Coastal Air (DQ), US"
+
+  - trigger: "::9L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Colgan Air (9L), US"
+
+  - trigger: "::OH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Comair (OH), US"
+
+  - trigger: "::MN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Comair (MN), ZA"
+
+  - trigger: "::C5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CommutAir (C5), US"
+
+  - trigger: "::KR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Comores Airlines (KR), KM"
+
+  - trigger: "::GJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Compania Mexicargo (GJ), MX"
+
+  - trigger: "::CP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Compass Airlines (CP), US"
+
+  - trigger: "::DE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Condor Flugdienst (DE), DE"
+
+  - trigger: "::6A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Consorcio Aviaxsa (6A), MX"
+
+  - trigger: "::C3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Contact Air (C3), DE"
+
+  - trigger: "::CO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Continental Airlines (CO), US"
+
+  - trigger: "::PC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Continental Airways (PC), RU"
+
+  - trigger: "::CO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Continental Express (CO), US"
+
+  - trigger: "::CS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Continental Micronesia (CS), US"
+
+  - trigger: "::V0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Conviasa (V0), VE"
+
+  - trigger: "::CM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Copa Airlines (CM), PA"
+
+  - trigger: "::SS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Corsairfly (SS), FR"
+
+  - trigger: "::XK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Corse-Mediterranee (XK), FR"
+
+  - trigger: "::OU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Croatia Airlines (OU), HR"
+
+  - trigger: "::QE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Crossair Europe (QE), CH"
+
+  - trigger: "::CU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cubana de Aviación (CU), CU"
+
+  - trigger: "::CY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cyprus Airways (CY), CY"
+
+  - trigger: "::YK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cyprus Turkish Airlines (YK), TR"
+
+  - trigger: "::OK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Czech Airlines (OK), CZ"
+
+  - trigger: "::WD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "DAS Air Cargo (WD), UG"
+
+  - trigger: "::DX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "DAT Danish Air Transport (DX), DK"
+
+  - trigger: "::ES?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "DHL International (ES), BH"
+
+  - trigger: "::L3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "DHL de Guatemala (L3), GT"
+
+  - trigger: "::D3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Daallo Airlines (D3), DJ"
+
+  - trigger: "::N2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dagestan Airlines (N2), RU"
+
+  - trigger: "::H8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dalavia (H8), RU"
+
+  - trigger: "::0D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Darwin Airline (0D), CH"
+
+  - trigger: "::D5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dauair (D5), DE"
+
+  - trigger: "::DL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Delta Air Lines (DL), US"
+
+  - trigger: "::2A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Deutsche Bahn (2A), DE"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Deutsche Rettungsflugwacht (1I), DE"
+
+  - trigger: "::D7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dinar (D7), AR"
+
+  - trigger: "::AW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dirgantara Air Service (AW), ID"
+
+  - trigger: "::DH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Discovery Airways (DH), US"
+
+  - trigger: "::D8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Djibouti Airlines (D8), DJ"
+
+  - trigger: "::DO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dominicana de Aviaci (DO), DO"
+
+  - trigger: "::E3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Domodedovo Airlines (E3), RU"
+
+  - trigger: "::KA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dragonair (KA), HK"
+
+  - trigger: "::KB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Druk Air (KB), BT"
+
+  - trigger: "::DI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "dba (DI), DE"
+
+  - trigger: "::1C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Electronic Data Systems (1C), CH"
+
+  - trigger: "::VE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "EUjet (VE), IE"
+
+  - trigger: "::BR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "EVA Air (BR), TW"
+
+  - trigger: "::H7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eagle Air (H7), UG"
+
+  - trigger: "::QU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "East African (QU), UG"
+
+  - trigger: "::S9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "East African Safari Air (S9), KE"
+
+  - trigger: "::T3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eastern Airways (T3), GB"
+
+  - trigger: "::DK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eastland Air (DK), AU"
+
+  - trigger: "::W9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eastwind Airlines (W9), US"
+
+  - trigger: "::WK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Edelweiss Air (WK), CH"
+
+  - trigger: "::MS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Egyptair (MS), EG"
+
+  - trigger: "::LY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "El Al Israel Airlines (LY), IL"
+
+  - trigger: "::UZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "El-Buraq Air Transport (UZ), LY"
+
+  - trigger: "::EK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Emirates (EK), AE"
+
+  - trigger: "::EM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Empire Airlines (EM), US"
+
+  - trigger: "::EU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Empresa Ecuatoriana De Aviacion (EU), EC"
+
+  - trigger: "::E0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eos Airlines (E0), US"
+
+  - trigger: "::B8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eritrean Airlines (B8), ER"
+
+  - trigger: "::E7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Estafeta Carga Aerea (E7), MX"
+
+  - trigger: "::OV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Estonian Air (OV), EE"
+
+  - trigger: "::ET?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ethiopian Airlines (ET), ET"
+
+  - trigger: "::EY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Etihad Airways (EY), AE"
+
+  - trigger: "::RZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Euro Exec Express (RZ), SE"
+
+  - trigger: "::UI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eurocypria Airlines (UI), CY"
+
+  - trigger: "::GJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eurofly Service (GJ), IT"
+
+  - trigger: "::K2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eurolot (K2), PL"
+
+  - trigger: "::3W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Euromanx Airways (3W), AT"
+
+  - trigger: "::EA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "European Air Express (EA), DE"
+
+  - trigger: "::QY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "European Air Transport (QY), BE"
+
+  - trigger: "::E7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "European Aviation Air Charter (E7), GB"
+
+  - trigger: "::EW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eurowings (EW), DE"
+
+  - trigger: "::EZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Evergreen International Airlines (EZ), US"
+
+  - trigger: "::JN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Excel Airways (JN), GB"
+
+  - trigger: "::MB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Execair Aviation (MB), CA"
+
+  - trigger: "::OW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Executive Airlines (OW), US"
+
+  - trigger: "::8D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Expo Aviation (8D), LK"
+
+  - trigger: "::EO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Express One International (EO), US"
+
+  - trigger: "::XE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ExpressJet (XE), US"
+
+  - trigger: "::U2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "easyJet (U2), GB"
+
+  - trigger: "::IH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Falcon Aviation (IH), SE"
+
+  - trigger: "::EF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Far Eastern Air Transport (EF), TW"
+
+  - trigger: "::F6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Faroejet (F6), FO"
+
+  - trigger: "::F3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Faso Airways (F3), BF"
+
+  - trigger: "::FX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Federal Express (FX), US"
+
+  - trigger: "::N8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fika Salaama Airlines (N8), UG"
+
+  - trigger: "::4S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Finalair Congo (4S), CG"
+
+  - trigger: "::AY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Finnair (AY), FI"
+
+  - trigger: "::FC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Finncomm Airlines (FC), FI"
+
+  - trigger: "::FY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Firefly (FY), MY"
+
+  - trigger: "::7F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "First Air (7F), CA"
+
+  - trigger: "::DP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "First Choice Airways (DP), GB"
+
+  - trigger: "::8F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fischer Air (8F), CZ"
+
+  - trigger: "::B5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flightline (B5), GB"
+
+  - trigger: "::PA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Florida Coastal Airlines (PA), US"
+
+  - trigger: "::RF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Florida West International Airways (RF), US"
+
+  - trigger: "::F2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Air (F2), TR"
+
+  - trigger: "::SH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Me Sweden (SH), SE"
+
+  - trigger: "::D7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirAsia X (D7), MY"
+
+  - trigger: "::TE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FlyLal (TE), LT"
+
+  - trigger: "::LF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FlyNordic (LF), SE"
+
+  - trigger: "::F7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flybaboo (F7), CH"
+
+  - trigger: "::BE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flybe (BE), GB"
+
+  - trigger: "::B4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flyglobespan (B4), GB"
+
+  - trigger: "::VY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Formosa Airlines (VY), TW"
+
+  - trigger: "::BN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Forward Air International Airlines (BN), US"
+
+  - trigger: "::HK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Four Star Aviation / Four Star Cargo (HK), US"
+
+  - trigger: "::FP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Freedom Air (FP), US"
+
+  - trigger: "::F9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Frontier Airlines (F9), US"
+
+  - trigger: "::2F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Frontier Flying Service (2F), US"
+
+  - trigger: "::FH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Futura International Airways (FH), ES"
+
+  - trigger: "::GT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "GB Airways (GT), GB"
+
+  - trigger: "::7O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Galaxy Air (7O), KG"
+
+  - trigger: "::1G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Galileo International (1G), US"
+
+  - trigger: "::GC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gambia International Airlines (GC), GM"
+
+  - trigger: "::G7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gandalf Airlines (G7), IT"
+
+  - trigger: "::GA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Garuda Indonesia (GA), ID"
+
+  - trigger: "::4G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gazpromavia (4G), RU"
+
+  - trigger: "::A9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Georgian Airways (A9), GE"
+
+  - trigger: "::QB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Georgian National Airlines (QB), GE"
+
+  - trigger: "::ST?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Germania (ST), DE"
+
+  - trigger: "::4U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Germanwings (4U), DE"
+
+  - trigger: "::GP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gestair (GP), ES"
+
+  - trigger: "::G0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ghana International Airlines (G0), GH"
+
+  - trigger: "::G8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Go Air (G8), IN"
+
+  - trigger: "::GK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Go One Airways (GK), GB"
+
+  - trigger: "::G7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "GoJet Airlines (G7), US"
+
+  - trigger: "::G3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gol Transportes Aéreos (G3), BR"
+
+  - trigger: "::DC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Golden Air (DC), SE"
+
+  - trigger: "::G1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gorkha Airlines (G1), NP"
+
+  - trigger: "::GS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Grant Aviation (GS), US"
+
+  - trigger: "::ZK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Great Lakes Airlines (ZK), US"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Great Wall Airlines (IJ), CN"
+
+  - trigger: "::TA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Grupo TACA (TA), CR"
+
+  - trigger: "::G6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Guine Bissaur Airlines (G6), GW"
+
+  - trigger: "::J9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Guinee Airlines (J9), GN"
+
+  - trigger: "::G8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gujarat Airways (G8), IN"
+
+  - trigger: "::GF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gulf Air Bahrain (GF), BH"
+
+  - trigger: "::H6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hageland Aviation Services (H6), US"
+
+  - trigger: "::HR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hahn Air (HR), DE"
+
+  - trigger: "::HU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hainan Airlines (HU), CN"
+
+  - trigger: "::1R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hainan Phoenix Information Systems (1R), CN"
+
+  - trigger: "::2T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Haiti Ambassador Airlines (2T), HT"
+
+  - trigger: "::4R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hamburg International (4R), DE"
+
+  - trigger: "::X3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TUIfly (X3), DE"
+
+  - trigger: "::HF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hapagfly (HF), DE"
+
+  - trigger: "::HB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Harbor Airlines (HB), US"
+
+  - trigger: "::HQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Harmony Airways (HQ), CA"
+
+  - trigger: "::HA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hawaiian Airlines (HA), US"
+
+  - trigger: "::HP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hawaiian Pacific Airlines (HP), US"
+
+  - trigger: "::BH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hawkair (BH), CA"
+
+  - trigger: "::HN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Heavylift Cargo Airlines (HN), AU"
+
+  - trigger: "::8H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Heli France (8H), FR"
+
+  - trigger: "::JB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Helijet (JB), CA"
+
+  - trigger: "::ZU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Helios Airways (ZU), CY"
+
+  - trigger: "::T4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hellas Jet (T4), GR"
+
+  - trigger: "::HW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hello (HW), CH"
+
+  - trigger: "::2L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Helvetic Airways (2L), CH"
+
+  - trigger: "::DU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hemus Air (DU), BG"
+
+  - trigger: "::EO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hewa Bora Airways (EO), CD"
+
+  - trigger: "::UD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hex'Air (UD), FR"
+
+  - trigger: "::5K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hi Fly (5K), PT"
+
+  - trigger: "::HD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hokkaido International Airlines (HD), JP"
+
+  - trigger: "::H5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hola Airlines (H5), ES"
+
+  - trigger: "::HX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hong Kong Airlines (HX), HK"
+
+  - trigger: "::UO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hong Kong Express Airways (UO), HK"
+
+  - trigger: "::HH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hope Air (HH), CA"
+
+  - trigger: "::QX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Horizon Air (QX), US"
+
+  - trigger: "::BN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Horizon Airlines (BN), AU"
+
+  - trigger: "::H4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Héli Sécurité Helicopter Airlines (H4), FR"
+
+  - trigger: "::II?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "IBC Airways (II), US"
+
+  - trigger: "::C3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ICAR Airlines (C3), UA"
+
+  - trigger: "::1F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "INFINI Travel Information (1F), JP"
+
+  - trigger: "::IB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iberia Airlines (IB), ES"
+
+  - trigger: "::TY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iberworld (TY), ES"
+
+  - trigger: "::FW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ibex Airlines (FW), JP"
+
+  - trigger: "::FI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Icelandair (FI), IS"
+
+  - trigger: "::IK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Imair Airlines (IK), AZ"
+
+  - trigger: "::DH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Independence Air (DH), US"
+
+  - trigger: "::6E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "IndiGo Airlines (6E), IN"
+
+  - trigger: "::IC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indian Airlines (IC), IN"
+
+  - trigger: "::I9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indigo (I9), US"
+
+  - trigger: "::QZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indonesia AirAsia (QZ), ID"
+
+  - trigger: "::IO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indonesian Airlines (IO), ID"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "InteliJet Airways (IJ), CO"
+
+  - trigger: "::H4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Inter Islands Airlines (H4), CV"
+
+  - trigger: "::D6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Interair South Africa (D6), ZA"
+
+  - trigger: "::ZA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Interavia Airlines (ZA), RU"
+
+  - trigger: "::RS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Intercontinental de Aviaci (RS), CO"
+
+  - trigger: "::ID?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Interlink Airlines (ID), ZA"
+
+  - trigger: "::6I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "International Business Air (6I), SE"
+
+  - trigger: "::3L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Intersky (3L), AT"
+
+  - trigger: "::I4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Interstate Airline (I4), NL"
+
+  - trigger: "::IR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iran Air (IR), IR"
+
+  - trigger: "::EP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iran Aseman Airlines (EP), IR"
+
+  - trigger: "::IA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iraqi Airways (IA), IQ"
+
+  - trigger: "::IS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Island Airlines (IS), US"
+
+  - trigger: "::2S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Island Express (2S), US"
+
+  - trigger: "::8L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cargo Plus Aviation (8L), AE"
+
+  - trigger: "::CN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Islands Nationair (CN), PG"
+
+  - trigger: "::IF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Islas Airways (IF), ES"
+
+  - trigger: "::WC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Islena De Inversiones (WC), HN"
+
+  - trigger: "::6H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Israir (6H), IL"
+
+  - trigger: "::9X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Itali Airlines (9X), IT"
+
+  - trigger: "::GI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Itek Air (GI), KG"
+
+  - trigger: "::H9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Izair (H9), TR"
+
+  - trigger: "::JC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JAL Express (JC), JP"
+
+  - trigger: "::JO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JALways (JO), JP"
+
+  - trigger: "::1M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JSC Transport Automated Information Systems (1M), RU"
+
+  - trigger: "::JL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Airlines (JL), JP"
+
+  - trigger: "::JL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Airlines Domestic (JL), JP"
+
+  - trigger: "::EG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Asia Airways (EG), JP"
+
+  - trigger: "::NU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Transocean Air (NU), JP"
+
+  - trigger: "::JU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jat Airways (JU), RS"
+
+  - trigger: "::VJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jatayu Airlines (VJ), ID"
+
+  - trigger: "::J9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jazeera Airways (J9), KW"
+
+  - trigger: "::7C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jeju Air (7C), KR"
+
+  - trigger: "::9W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jet Airways (9W), IN"
+
+  - trigger: "::QJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jet Airways (QJ), US"
+
+  - trigger: "::0J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetclub (0J), CH"
+
+  - trigger: "::3K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetstar Asia Airways (3K), SG"
+
+  - trigger: "::LS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jet2.com (LS), GB"
+
+  - trigger: "::8J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jet4You (8J), MA"
+
+  - trigger: "::B6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JetBlue Airways (B6), US"
+
+  - trigger: "::JF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetairfly (JF), BE"
+
+  - trigger: "::0J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetclub (0J), CH"
+
+  - trigger: "::SG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JetsGo (SG), CA"
+
+  - trigger: "::JQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetstar Airways (JQ), AU"
+
+  - trigger: "::JX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jett8 Airlines Cargo (JX), SG"
+
+  - trigger: "::GX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetx Airlines (GX), IS"
+
+  - trigger: "::R5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jordan Aviation (R5), JO"
+
+  - trigger: "::HO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Juneyao Airlines (HO), CN"
+
+  - trigger: "::KD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KD Avia (KD), RU"
+
+  - trigger: "::WA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KLM Cityhopper (WA), NL"
+
+  - trigger: "::KL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KLM Royal Dutch Airlines (KL), NL"
+
+  - trigger: "::N2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kabo Air (N2), NG"
+
+  - trigger: "::K4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kalitta Air (K4), US"
+
+  - trigger: "::RQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kam Air (RQ), AF"
+
+  - trigger: "::E2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kampuchea Airlines (E2), KH"
+
+  - trigger: "::V2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Karat (V2), RU"
+
+  - trigger: "::KV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kavminvodyavia (KV), RU"
+
+  - trigger: "::M5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kenmore Air (M5), US"
+
+  - trigger: "::KQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kenya Airways (KQ), KE"
+
+  - trigger: "::BZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Keystone Air Services (BZ), CA"
+
+  - trigger: "::IT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kingfisher Airlines (IT), IN"
+
+  - trigger: "::Y9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kish Air (Y9), IR"
+
+  - trigger: "::KP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kiwi International Air Lines (KP), US"
+
+  - trigger: "::7K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kogalymavia Air Company (7K), RU"
+
+  - trigger: "::8J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Komiinteravia (8J), RU"
+
+  - trigger: "::KE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Korean Air (KE), KR"
+
+  - trigger: "::7B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Krasnojarsky Airlines (7B), RU"
+
+  - trigger: "::K9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Krylo Airlines (K9), RU"
+
+  - trigger: "::GW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kuban Airlines (GW), RU"
+
+  - trigger: "::VD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kunpeng Airlines (VD), CN"
+
+  - trigger: "::KU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kuwait Airways (KU), KW"
+
+  - trigger: "::GO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kuzu Airlines Cargo (GO), TR"
+
+  - trigger: "::N5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kyrgyz Airlines (N5), KG"
+
+  - trigger: "::QH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kyrgyzstan (QH), KG"
+
+  - trigger: "::R8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kyrgyzstan Airlines (R8), KG"
+
+  - trigger: "::KY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kibris T (KY), TR"
+
+  - trigger: "::JF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "L.A.B. Flying Service (JF), US"
+
+  - trigger: "::LR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LACSA (LR), CR"
+
+  - trigger: "::KG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAI - Linea Aerea IAACA (KG), VE"
+
+  - trigger: "::LA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAN Airlines (LA), CL"
+
+  - trigger: "::4M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAN Argentina (4M), AR"
+
+  - trigger: "::LU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAN Express (LU), CL"
+
+  - trigger: "::LP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAN Peru (LP), PE"
+
+  - trigger: "::LO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LOT Polish Airlines (LO), PL"
+
+  - trigger: "::XO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LTE International Airways (XO), ES"
+
+  - trigger: "::L3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LTU Austria (L3), AT"
+
+  - trigger: "::LT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LTU International (LT), DE"
+
+  - trigger: "::N6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lagun Air (N6), ES"
+
+  - trigger: "::IK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lankair (IK), LK"
+
+  - trigger: "::QV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lao Airlines (QV), LA"
+
+  - trigger: "::L7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Laoag International Airlines (L7), PH"
+
+  - trigger: "::NG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lauda Air (NG), AT"
+
+  - trigger: "::LQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lebanese Air Transport (LQ), LB"
+
+  - trigger: "::LI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Leeward Islands Air Transport (LI), AG"
+
+  - trigger: "::LN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Libyan Arab Airlines (LN), LY"
+
+  - trigger: "::L7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Linea Aerea SAPSA (L7), CL"
+
+  - trigger: "::8z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Linea Aerea de Servicio Ejecutivo Regional (8z), VE"
+
+  - trigger: "::LD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Linea Turistica Aerotuy (LD), VE"
+
+  - trigger: "::ZE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lineas Aereas Azteca (ZE), MX"
+
+  - trigger: "::LM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Linhas A (LM), MZ"
+
+  - trigger: "::JT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lion Mentari Airlines (JT), ID"
+
+  - trigger: "::LM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Livingston (LM), IT"
+
+  - trigger: "::LB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lloyd Aereo Boliviano (LB), BO"
+
+  - trigger: "::HE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Luftfahrtgesellschaft Walter (HE), DE"
+
+  - trigger: "::LH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufthansa (LH), DE"
+
+  - trigger: "::LH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufthansa Cargo (LH), DE"
+
+  - trigger: "::CL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufthansa CityLine (CL), DE"
+
+  - trigger: "::L1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufthansa Systems (L1), DE"
+
+  - trigger: "::DV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufttaxi Fluggesellschaft (DV), DE"
+
+  - trigger: "::L5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lufttransport (L5), NO"
+
+  - trigger: "::LG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Luxair (LG), LU"
+
+  - trigger: "::5V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lviv Airlines (5V), UA"
+
+  - trigger: "::L2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lynden Air Cargo (L2), US"
+
+  - trigger: "::MJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LAPA – Líneas Aéreas Privadas Argentinas (MJ), AR"
+
+  - trigger: "::M7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MasAir (M7), MX"
+
+  - trigger: "::IN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MAT Macedonian Airlines (IN), MK"
+
+  - trigger: "::OM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MIAT Mongolian Airlines (OM), MN"
+
+  - trigger: "::MB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MNG Airlines (MB), TR"
+
+  - trigger: "::CC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Macair Airlines (CC), AU"
+
+  - trigger: "::DM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maersk (DM), DK"
+
+  - trigger: "::W5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mahan Air (W5), IR"
+
+  - trigger: "::M2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mahfooz Aviation (M2), GM"
+
+  - trigger: "::MH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malaysia Airlines (MH), MY"
+
+  - trigger: "::TF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malmö Aviation (TF), SE"
+
+  - trigger: "::R5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malta Air Charter (R5), MT"
+
+  - trigger: "::MA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malév (MA), HU"
+
+  - trigger: "::RI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mandala Airlines (RI), ID"
+
+  - trigger: "::AE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mandarin Airlines (AE), TW"
+
+  - trigger: "::JE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mango (JE), ZA"
+
+  - trigger: "::6V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mars RK (6V), UA"
+
+  - trigger: "::M7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Marsland Aviation (M7), SD"
+
+  - trigger: "::MP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Martinair (MP), NL"
+
+  - trigger: "::Q4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mastertop Linhas Aereas (Q4), BR"
+
+  - trigger: "::H5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mavial Magadan Airlines (H5), RU"
+
+  - trigger: "::8M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maxair (8M), SE"
+
+  - trigger: "::MY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maxjet Airways (MY), US"
+
+  - trigger: "::MW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maya Island Air (MW), BZ"
+
+  - trigger: "::IM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Menajet (IM), LB"
+
+  - trigger: "::IG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Meridiana (IG), IT"
+
+  - trigger: "::MZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Merpati Nusantara Airlines (MZ), ID"
+
+  - trigger: "::YV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mesa Airlines (YV), US"
+
+  - trigger: "::XJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mesaba Airlines (XJ), US"
+
+  - trigger: "::MX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mexicana de Aviaci (MX), MX"
+
+  - trigger: "::GL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Miami Air International (GL), US"
+
+  - trigger: "::ME?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Middle East Airlines (ME), LB"
+
+  - trigger: "::JI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Midway Airlines (JI), US"
+
+  - trigger: "::YX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Midwest Airlines (YX), US"
+
+  - trigger: "::MY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Midwest Airlines (Egypt) (MY), EG"
+
+  - trigger: "::2M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Moldavian Airlines (2M), MD"
+
+  - trigger: "::ZB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Monarch Airlines (ZB), GB"
+
+  - trigger: "::8I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Myway Airlines (8I), IT"
+
+  - trigger: "::YM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Montenegro Airlines (YM), ME"
+
+  - trigger: "::3R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Moskovia Airlines (3R), RU"
+
+  - trigger: "::M9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Motor Sich (M9), UA"
+
+  - trigger: "::NM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mount Cook Airlines (NM), NZ"
+
+  - trigger: "::N4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mountain Air Company (N4), SL"
+
+  - trigger: "::VZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MyTravel Airways (VZ), GB"
+
+  - trigger: "::UB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Myanma Airways (UB), MM"
+
+  - trigger: "::8M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Myanmar Airways International (8M), MM"
+
+  - trigger: "::DV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nantucket Airlines (DV), US"
+
+  - trigger: "::P9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nas Air (P9), ML"
+
+  - trigger: "::UE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nasair (UE), ER"
+
+  - trigger: "::N4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Airlines (N4), CL"
+
+  - trigger: "::N7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Airlines (N7), US"
+
+  - trigger: "::NA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Airlines (NA), US"
+
+  - trigger: "::9O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Airways Cameroon (9O), CM"
+
+  - trigger: "::NC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Jet Systems (NC), AU"
+
+  - trigger: "::CE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nationwide Airlines (CE), ZA"
+
+  - trigger: "::ON?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nauru Air Corporation (ON), NR"
+
+  - trigger: "::1N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Navitaire (1N), US"
+
+  - trigger: "::RA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nepal Airlines (RA), NP"
+
+  - trigger: "::NO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Neos (NO), IT"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "NetJets (1I), US"
+
+  - trigger: "::EJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "New England Airlines (EJ), US"
+
+  - trigger: "::2N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "NextJet (2N), SE"
+
+  - trigger: "::HG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Niki (HG), AT"
+
+  - trigger: "::KZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nippon Cargo Airlines (KZ), JP"
+
+  - trigger: "::DD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nok Air (DD), TH"
+
+  - trigger: "::JH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nordeste Linhas Aereas Regionais (JH), BR"
+
+  - trigger: "::6N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nordic Regional (6N), SE"
+
+  - trigger: "::N9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "North Coast Aviation (N9), PG"
+
+  - trigger: "::M3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "North Flying (M3), DK"
+
+  - trigger: "::HW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "North-Wright Airways (HW), CA"
+
+  - trigger: "::NC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Northern Air Cargo (NC), US"
+
+  - trigger: "::U7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Northern Dene Airways (U7), CA"
+
+  - trigger: "::NW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Northwest Airlines (NW), US"
+
+  - trigger: "::FY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Northwest Regional Airlines (FY), AU"
+
+  - trigger: "::J3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Northwestern Air (J3), CA"
+
+  - trigger: "::DY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Norwegian Air Shuttle (DY), NO"
+
+  - trigger: "::BJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nouvel Air Tunisie (BJ), TN"
+
+  - trigger: "::M4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nova Airline (M4), SD"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Novair (1I), SE"
+
+  - trigger: "::N6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nuevo Continente (N6), PE"
+
+  - trigger: "::XY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nas Air (XY), SA"
+
+  - trigger: "::UQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "O'Connor Airlines (UQ), AU"
+
+  - trigger: "::CR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "OAG (CR), GB"
+
+  - trigger: "::O8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Oasis Hong Kong Airlines (O8), HK"
+
+  - trigger: "::VC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ocean Airlines (VC), IT"
+
+  - trigger: "::O6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Oceanair (O6), BR"
+
+  - trigger: "::O2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Oceanic Airlines (O2), GN"
+
+  - trigger: "::OA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Olympic Airlines (OA), GR"
+
+  - trigger: "::WY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Oman Air (WY), OM"
+
+  - trigger: "::OY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Omni Air International (OY), US"
+
+  - trigger: "::N3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Omskavia Airline (N3), RU"
+
+  - trigger: "::8Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Onur Air (8Q), TR"
+
+  - trigger: "::R2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Orenburg Airlines (R2), RU"
+
+  - trigger: "::OX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Orient Thai Airlines (OX), TH"
+
+  - trigger: "::QO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Origin Pacific Airways (QO), NZ"
+
+  - trigger: "::OL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ostfriesische Lufttransport (OL), DE"
+
+  - trigger: "::ON?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Our Airline (ON), NR"
+
+  - trigger: "::OJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Overland Airways (OJ), NG"
+
+  - trigger: "::OZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ozark Air Lines (OZ), US"
+
+  - trigger: "::O7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ozjet Airlines (O7), AU"
+
+  - trigger: "::PV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PAN Air (PV), ES"
+
+  - trigger: "::9Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PB Air (9Q), TH"
+
+  - trigger: "::PU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PLUNA (PU), UY"
+
+  - trigger: "::U4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PMTair (U4), KH"
+
+  - trigger: "::Y5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pace Airlines (Y5), US"
+
+  - trigger: "::BL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetstar Pacific (BL), VN"
+
+  - trigger: "::DJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific Blue (DJ), NZ"
+
+  - trigger: "::8P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific Coastal Airline (8P), CA"
+
+  - trigger: "::Q8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific East Asia Cargo Airlines (Q8), PH"
+
+  - trigger: "::PS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific Southwest Airlines (PS), US"
+
+  - trigger: "::LW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific Wings (LW), US"
+
+  - trigger: "::GX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacificair (GX), PH"
+
+  - trigger: "::PK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pakistan International Airlines (PK), PK"
+
+  - trigger: "::GP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Palau Trans Pacific Airline (GP), PW"
+
+  - trigger: "::PF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Palestinian Airlines (PF), EG"
+
+  - trigger: "::NR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pamir Airways (NR), AF"
+
+  - trigger: "::PA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pan American Airways (PA), US"
+
+  - trigger: "::PA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pan American World Airways (PA), US"
+
+  - trigger: "::PQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Panafrican Airways (PQ), CI"
+
+  - trigger: "::P8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pantanal Linhas Aéreas (P8), BR"
+
+  - trigger: "::I7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Paramount Airways (I7), IN"
+
+  - trigger: "::HP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pearl Airways (HP), HT"
+
+  - trigger: "::PC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pegasus Airlines (PC), TR"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pegasus Hava Tasimaciligi (1I), TR"
+
+  - trigger: "::KS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Peninsula Airways (KS), US"
+
+  - trigger: "::P9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Perm Airlines (P9), RU"
+
+  - trigger: "::PR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Philippine Airlines (PR), PH"
+
+  - trigger: "::HP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Phoenix Airways (HP), CH"
+
+  - trigger: "::9R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Phuket Air (9R), TH"
+
+  - trigger: "::PI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Piedmont Airlines (1948-1989) (PI), US"
+
+  - trigger: "::9E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pinnacle Airlines (9E), US"
+
+  - trigger: "::PO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polar Air Cargo (PO), US"
+
+  - trigger: "::PH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polynesian Airlines (PH), WS"
+
+  - trigger: "::DJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polynesian Blue (DJ), NZ"
+
+  - trigger: "::1U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polyot Sirena (1U), RU"
+
+  - trigger: "::PD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Porter Airlines (PD), CA"
+
+  - trigger: "::NI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Portugalia (NI), PT"
+
+  - trigger: "::BK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Potomac Air (BK), US"
+
+  - trigger: "::PW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Precision Air (PW), TZ"
+
+  - trigger: "::TO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "President Airlines (TO), KH"
+
+  - trigger: "::FE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Primaris Airlines (FE), US"
+
+  - trigger: "::8W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Private Wings Flugcharter (8W), DE"
+
+  - trigger: "::P0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Proflight Commuter Services (P0), ZM"
+
+  - trigger: "::QF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Qantas (QF), AU"
+
+  - trigger: "::QR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Qatar Airways (QR), QA"
+
+  - trigger: "::R6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "RACSA (R6), GT"
+
+  - trigger: "::1D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Radixx Solutions International (1D), US"
+
+  - trigger: "::8L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Redhill Aviation (8L), GB"
+
+  - trigger: "::V4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Reem Air (V4), KG"
+
+  - trigger: "::FN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regional Airlines (FN), MA"
+
+  - trigger: "::ZL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regional Express (ZL), AU"
+
+  - trigger: "::3C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "RegionsAir (3C), US"
+
+  - trigger: "::QQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Reno Air (QQ), US"
+
+  - trigger: "::RW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rwandair Express (WB), RW"
+
+  - trigger: "::RD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ryan International Airlines (RD), US"
+
+  - trigger: "::FR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ryanair (FR), IE"
+
+  - trigger: "::YS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Régional (YS), FR"
+
+  - trigger: "::S4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SATA International (S4), PT"
+
+  - trigger: "::SA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "South African Airways (SA), ZA"
+
+  - trigger: "::NL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shaheen Air International (NL), PK"
+
+  - trigger: "::SK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Scandinavian Airlines System (SK), SE"
+
+  - trigger: "::S7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "S7 Airlines (S7), RU"
+
+  - trigger: "::BB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Seaborne Airlines (BB), US"
+
+  - trigger: "::UL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SriLankan Airlines (UL), LK"
+
+  - trigger: "::SY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sun Country Airlines (SY), US"
+
+  - trigger: "::G3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Express (G3), GR"
+
+  - trigger: "::SG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spicejet (SG), IN"
+
+  - trigger: "::I6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Eyes (I6), TH"
+
+  - trigger: "::EH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SAETA (EH), EC"
+
+  - trigger: "::7G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Star Flyer (7G), JP"
+
+  - trigger: "::FA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Safair (FA), ZA"
+
+  - trigger: "::N5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skagway Air Service (N5), US"
+
+  - trigger: "::SP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SATA Air Acores (SP), PT"
+
+  - trigger: "::SQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Singapore Airlines (SQ), SG"
+
+  - trigger: "::5M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sibaviatrans (5M), RU"
+
+  - trigger: "::SI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skynet Airlines (SI), IE"
+
+  - trigger: "::XS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SITA (XS), BE"
+
+  - trigger: "::SJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sriwijaya Air (SJ), ID"
+
+  - trigger: "::ZS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sama Airlines (ZS), SA"
+
+  - trigger: "::FT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Siem Reap Airways (FT), KH"
+
+  - trigger: "::SX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Work Airlines (SX), CH"
+
+  - trigger: "::SM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Swedline Express (SM), SE"
+
+  - trigger: "::DG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "South East Asian Airlines (DG), PH"
+
+  - trigger: "::VD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SwedJet Airways (VD), SE"
+
+  - trigger: "::5G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skyservice Airlines (5G), CA"
+
+  - trigger: "::FS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Servicios de Transportes A (FS), AR"
+
+  - trigger: "::SD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sudan Airways (SD), SD"
+
+  - trigger: "::PI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sun Air (Fiji) (PI), FJ"
+
+  - trigger: "::EZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sun Air of Scandinavia (EZ), DK"
+
+  - trigger: "::SV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Saudi Arabian Airlines (SV), SA"
+
+  - trigger: "::WN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southwest Airlines (WN), US"
+
+  - trigger: "::A4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southern Winds Airlines (A4), AR"
+
+  - trigger: "::WG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sunwing Airlines (WG), CA"
+
+  - trigger: "::LX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Swiss International Air Lines (LX), CH"
+
+  - trigger: "::SR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Swissair (SR), CH"
+
+  - trigger: "::WV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Swe Fly (WV), SE"
+
+  - trigger: "::S8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shovkoviy Shlyah (S8), UA"
+
+  - trigger: "::XQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SunExpress (XQ), TR"
+
+  - trigger: "::RB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Syrian Arab Airlines (RB), SY"
+
+  - trigger: "::AL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skywalk Airlines (AL), US"
+
+  - trigger: "::ZP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Silk Way Airlines (ZP), AZ"
+
+  - trigger: "::E5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Samara Airlines (E5), RU"
+
+  - trigger: "::SC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shandong Airlines (SC), CN"
+
+  - trigger: "::9S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spring Airlines (9S), CN"
+
+  - trigger: "::3U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sichuan Airlines (3U), CN"
+
+  - trigger: "::FM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shanghai Airlines (FM), CN"
+
+  - trigger: "::ZH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shenzhen Airlines (ZH), CN"
+
+  - trigger: "::8C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shanxi Airlines (8C), CN"
+
+  - trigger: "::7L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sun D'Or (7L), IL"
+
+  - trigger: "::NE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SkyEurope (NE), SK"
+
+  - trigger: "::CQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sunshine Express Airlines (CQ), AU"
+
+  - trigger: "::SO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Superior Aviation (SO), US"
+
+  - trigger: "::JK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spanair (JK), ES"
+
+  - trigger: "::2G?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "San Juan Airlines (2G), US"
+
+  - trigger: "::1Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sabre Pacific (1Z), AU"
+
+  - trigger: "::1S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sabre (1S), US"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sierra Nevada Airlines (1I), US"
+
+  - trigger: "::1H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Siren-Travel (1H), RU"
+
+  - trigger: "::1Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sirena (1Q), RU"
+
+  - trigger: "::1K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southern Cross Distribution (1K), AU"
+
+  - trigger: "::1K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sutra (1K), US"
+
+  - trigger: "::2C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SNCF (2C), FR"
+
+  - trigger: "::2S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Star Equatorial Airlines (2S), GN"
+
+  - trigger: "::NK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spirit Airlines (NK), US"
+
+  - trigger: "::9R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SATENA (9R), CO"
+
+  - trigger: "::S0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Slok Air Gambia (S0), GM"
+
+  - trigger: "::SO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sosoliso Airlines (SO), NG"
+
+  - trigger: "::1I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Trek International Airlines (1I), US"
+
+  - trigger: "::SX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skybus Airlines (SX), US"
+
+  - trigger: "::RU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SkyKing Turks and Caicos Airways (RU), TC"
+
+  - trigger: "::S3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Santa Barbara Airlines (S3), VE"
+
+  - trigger: "::H2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Airline (H2), CL"
+
+    - trigger: "::OO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SkyWest (OO), US"
+
+  - trigger: "::JZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skyways Express (JZ), SE"
+
+  - trigger: "::BC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skymark Airlines (BC), JP"
+
+  - trigger: "::LJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sierra National Airlines (LJ), SL"
+
+  - trigger: "::MI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SilkAir (MI), SG"
+
+  - trigger: "::6Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Slovak Airlines (6Q), SK"
+
+  - trigger: "::PY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Surinam Airways (PY), SR"
+
+  - trigger: "::8D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Servant Air (8D), US"
+
+  - trigger: "::NB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sterling Airlines (NB), DK"
+
+  - trigger: "::6J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skynet Asia Airways (6J), JP"
+
+  - trigger: "::IE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Solomon Airlines (IE), SB"
+
+  - trigger: "::6W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Saratov Aviation Division (6W), RU"
+
+  - trigger: "::HZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sat Airlines (HZ), KZ"
+
+  - trigger: "::S5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Shuttle America (S5), US"
+
+  - trigger: "::DV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Scat Air (DV), KZ"
+
+  - trigger: "::S6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Star Air (S6), DK"
+
+  - trigger: "::EQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAME (EQ), EC"
+
+  - trigger: "::JJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAM Brazilian Airlines (JJ), BR"
+
+  - trigger: "::TP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAP Portugal (TP), PT"
+
+  - trigger: "::TU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tunisair (TU), TN"
+
+  - trigger: "::3V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TNT Airways (3V), BE"
+
+  - trigger: "::M7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tropical Airways (M7), HT"
+
+  - trigger: "::T2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai Air Cargo (T2), TH"
+
+  - trigger: "::FQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thomas Cook Airlines (FQ), BE"
+
+  - trigger: "::MT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thomas Cook Airlines (MT), GB"
+
+  - trigger: "::TQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tandem Aero (TQ), MD"
+
+  - trigger: "::L9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Teamline Air (L9), AT"
+
+  - trigger: "::UE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Transeuropean Airlines (UE), RU"
+
+  - trigger: "::ZT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Titan Airways (ZT), GB"
+
+  - trigger: "::TR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tiger Airways (TR), SG"
+
+  - trigger: "::TT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tiger Airways Australia (TT), AU"
+
+  - trigger: "::TG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai Airways International (TG), TH"
+
+  - trigger: "::FD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai AirAsia (FD), TH"
+
+  - trigger: "::TK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Turkish Airlines (TK), TR"
+
+  - trigger: "::T7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Twin Jet (T7), FR"
+
+  - trigger: "::9I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai Sky Airlines (9I), TH"
+
+  - trigger: "::TD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tulip Air (TD), NL"
+
+  - trigger: "::TL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Trans Mediterranean Airlines (TL), LB"
+
+  - trigger: "::GY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tri-MG Intra Asia Airlines (GY), ID"
+
+  - trigger: "::3P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tiara Air (3P), AW"
+
+  - trigger: "::7T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tobruk Air (7T), LY"
+
+  - trigger: "::TI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tol-Air Services (TI), US"
+
+  - trigger: "::BY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Transaviaexport (BY), BY"
+
+  - trigger: "::6B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TUIfly Nordic (6B), SE"
+
+  - trigger: "::DT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAAG Angola Airlines (DT), AO"
+
+  - trigger: "::SF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tassili Airlines (SF), DZ"
+
+  - trigger: "::PZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAM Mercosur (PZ), PY"
+
+  - trigger: "::AX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Trans States Airlines (AX), US"
+
+  - trigger: "::1E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Travelsky Technology (1E), CN"
+
+  - trigger: "::2H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thalys (2H), BE"
+
+  - trigger: "::RO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tarom (RO), RO"
+
+  - trigger: "::3T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Turan Air (3T), AZ"
+
+  - trigger: "::8R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TRIP Linhas A (8R), BR"
+
+  - trigger: "::U5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "USA3000 Airlines (U5), US"
+
+  - trigger: "::UA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "United Airlines (UA), US"
+
+  - trigger: "::U2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "United Feeder Service (U2), US"
+
+  - trigger: "::U7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "USA Jet Airlines (U7), US"
+
+  - trigger: "::U6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ural Airlines (U6), RU"
+
+  - trigger: "::UF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "UM Airlines (UF), UA"
+
+  - trigger: "::6Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ukrainian Cargo Airways (6Z), UA"
+
+  - trigger: "::5X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "United Parcel Service (5X), US"
+
+  - trigger: "::US?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "US Airways (US), US"
+
+  - trigger: "::UT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "UTair Aviation (UT), RU"
+
+  - trigger: "::HY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Uzbekistan Airways (HY), UZ"
+
+  - trigger: "::PS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ukraine International Airlines (PS), UA"
+
+  - trigger: "::UH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "US Helicopter Corporation (UH), US"
+
+    - trigger: "::VA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "V Australia Airlines (VA), AU"
+
+  - trigger: "::VF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Valuair (VF), SG"
+
+  - trigger: "::VC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Voyageur Airways (VC), CA"
+
+  - trigger: "::VN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vietnam Airlines (VN), VN"
+
+  - trigger: "::NN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VIM Airlines (NN), RU"
+
+  - trigger: "::2R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VIA Rail Canada (2R), CA"
+
+  - trigger: "::VA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Viasa (VA), VE"
+
+  - trigger: "::Y4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Volaris (Y4), MX"
+
+  - trigger: "::VI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Volga-Dnepr Airlines (VI), RU"
+
+  - trigger: "::VX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin America (VX), US"
+
+  - trigger: "::TV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Express (TV), BE"
+
+  - trigger: "::VK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Nigeria Airways (VK), NG"
+
+  - trigger: "::VS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Atlantic Airways (VS), GB"
+
+  - trigger: "::ZG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Viva Macau (ZG), MO"
+
+  - trigger: "::VE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Volare Airlines (VE), IT"
+
+  - trigger: "::VY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vueling Airlines (VY), ES"
+
+  - trigger: "::XF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vladivostok Air (XF), RU"
+
+  - trigger: "::LC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Varig Log (LC), BR"
+
+  - trigger: "::VM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Viaggio Air (VM), BG"
+
+  - trigger: "::VA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Australia (VA), AU"
+
+  - trigger: "::DJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Blue (DJ), AU"
+
+  - trigger: "::RG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VRG Linhas Aereas (RG), BR"
+
+  - trigger: "::VP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VASP (VP), BR"
+
+  - trigger: "::VG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VLM Airlines (VG), BE"
+
+  - trigger: "::7W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wayraper (7W), PE"
+
+  - trigger: "::WJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "WebJet Linhas A (WJ), BR"
+
+  - trigger: "::2W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Welcome Air (2W), AT"
+
+  - trigger: "::PT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "West Air Sweden (PT), SE"
+
+  - trigger: "::8O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "West Coast Air (8O), CA"
+
+  - trigger: "::WS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "WestJet (WS), CA"
+
+  - trigger: "::WA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Western Airlines (WA), US"
+
+  - trigger: "::CN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Westward Airways (CN), US"
+
+  - trigger: "::WF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Widerøe (WF), NO"
+
+  - trigger: "::IV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wind Jet (IV), IT"
+
+  - trigger: "::IW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wings Air (IW), ID"
+
+  - trigger: "::K5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wings of Alaska (K5), US"
+
+  - trigger: "::W6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wizz Air (W6), HU"
+
+  - trigger: "::8Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wizz Air Hungary (8Z), BG"
+
+  - trigger: "::WO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "World Airways (WO), US"
+
+  - trigger: "::1P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Worldspan (1P), US"
+
+  - trigger: "::8V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wright Air Service (8V), US"
+
+  - trigger: "::SE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "XL Airways France (SE), FR"
+
+  - trigger: "::MF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Xiamen Airlines (MF), CN"
+
+  - trigger: "::XP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Xtra Airways (XP), US"
+
+  - trigger: "::YL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yamal Airlines (YL), RU"
+
+  - trigger: "::Y8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yangtze River Express (Y8), CN"
+
+  - trigger: "::IY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yemenia (IY), YE"
+
+  - trigger: "::Q3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zambian Airways (Q3), ZM"
+
+  - trigger: "::3J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zip (3J), CA"
+
+  - trigger: "::C4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zimex Aviation (C4), CH"
+
+  - trigger: "::Z4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zoom Airlines (Z4), CA"
+
+  - trigger: "::UK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vistara (UK), IN"
+
+  - trigger: "::8Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maldivian Air Taxi (8Q), MV"
+
+  - trigger: "::XW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Express (XW), RU"
+
+  - trigger: "::Y0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yellow Air Taxi (Y0), US"
+
+  - trigger: "::VJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal Air Cambodge (VJ), KH"
+
+  - trigger: "::6T?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mandalay (6T), MM"
+
+  - trigger: "::SH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAN-SAHSA (SH), HN"
+
+  - trigger: "::BX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Busan (BX), KR"
+
+  - trigger: "::TB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TUI Airlines Belgium (TB), BE"
+
+  - trigger: "::GH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Globus (GH), RU"
+
+  - trigger: "::9Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Kazakhstan (9Y), KZ"
+
+  - trigger: "::JD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Air System (JD), JP"
+
+  - trigger: "::ZQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Annsett New Zealand (ZQ), NZ"
+
+  - trigger: "::DS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "EasyJet (DS), CH"
+
+  - trigger: "::2I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Star Peru (2I), PE"
+
+  - trigger: "::KW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Carnival Air Lines (KW), US"
+
+  - trigger: "::4H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "United Airways (4H), BD"
+
+  - trigger: "::M8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Trans Maldivian Airways (M8), MV"
+
+  - trigger: "::5H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly540 (5H), KE"
+
+  - trigger: "::TO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Transavia France (TO), FR"
+
+  - trigger: "::WP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Island Air (WP), US"
+
+  - trigger: "::OG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "1-2-go (OG), TH"
+
+  - trigger: "::B7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Uni Air (B7), TW"
+
+  - trigger: "::YD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gomelavia (YD), BY"
+
+  - trigger: "::WZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Red Wings (WZ), RU"
+
+  - trigger: "::11?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TUIfly (X3) (11), DE"
+
+  - trigger: "::FU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Felix Airways (FU), YE"
+
+  - trigger: "::K1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kostromskie avialinii (K1), RU"
+
+  - trigger: "::XX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Greenfly (XX), ES"
+
+  - trigger: "::7J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tajik Air (7J), TJ"
+
+  - trigger: "::TM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mozambique (TM), MZ"
+
+  - trigger: "::GY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gabon Airlines (GY), GA"
+
+  - trigger: "::ML?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maldivo Airlines (ML), MV"
+
+  - trigger: "::VH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virgin Pacific (VH), FJ"
+
+  - trigger: "::Z2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zest Air (Z2), PH"
+
+  - trigger: "::HK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yangon Airways (HK), MM"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Transport Aérien Transrégional (IJ), FR"
+
+  - trigger: "::N4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Minerva Airlines (N4), IT"
+
+  - trigger: "::ZE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eastar Jet (ZE), KR"
+
+  - trigger: "::LJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jin Air (LJ), KR"
+
+  - trigger: "::SH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aéris (Priv) (SH), FR"
+
+  - trigger: "::3O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Arabia Maroc (3O), MA"
+
+  - trigger: "::B1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Baltic Air lines (B1), LV"
+
+  - trigger: "::YC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ciel Canadien (YC), CA"
+
+  - trigger: "::CN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Canadian National Airways (CN), CA"
+
+  - trigger: "::FA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Epic Holiday (FA), US"
+
+  - trigger: "::3I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Comet Chile (3I), CL"
+
+  - trigger: "::DN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Voronezhskie Airlanes (DN), RU"
+
+  - trigger: "::L8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Line Blue (L8), DE"
+
+  - trigger: "::BU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Blue Sky America (BU), US"
+
+  - trigger: "::XS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Texas Spirit (XS), US"
+
+  - trigger: "::IL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Illinois Airways (IL), US"
+
+  - trigger: "::SZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Salzburg arrows (SZ), AT"
+
+  - trigger: "::TQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Texas Wings (TQ), US"
+
+  - trigger: "::KT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "California Western (KT), US"
+
+  - trigger: "::DH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dennis Sky (DH), IL"
+
+  - trigger: "::ZZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zz (ZZ), BE"
+
+  - trigger: "::A1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atifly (A1), US"
+
+  - trigger: "::UK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air UK (UK), GB"
+
+  - trigger: "::CB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Suckling Airways (CB), GB"
+
+  - trigger: "::RY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Reno Sky (RY), US"
+
+  - trigger: "::99?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Ciao Air (99), IT"
+
+  - trigger: "::VB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Birmingham European (VB), GB"
+
+  - trigger: "::5P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pal airlines (5P), CL"
+
+  - trigger: "::C1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CanXpress (C1), CA"
+
+  - trigger: "::V5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Danube Wings (V5), SK"
+
+  - trigger: "::SH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sharp Airlines (SH), AU"
+
+  - trigger: "::C2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CanXplorer (C2), CA"
+
+  - trigger: "::QA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Click (Mexicana) (QA), MX"
+
+  - trigger: "::W1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "World Experience Airline (W1), CA"
+
+  - trigger: "::J4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ALAK (J4), RU"
+
+  - trigger: "::E9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AJT Air International (E9), RU"
+
+  - trigger: "::3E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Choice One (3E), US"
+
+  - trigger: "::KN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China United (KN), CN"
+
+  - trigger: "::ZQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Locair (ZQ), US"
+
+  - trigger: "::4Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Safi Airlines (4Q), AF"
+
+  - trigger: "::K5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SeaPort Airlines (K5), US"
+
+  - trigger: "::S6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Salmon Air (S6), US"
+
+  - trigger: "::IL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Illi (IL), US"
+
+  - trigger: "::01?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Bobb Air Freight (01), DE"
+
+  - trigger: "::V9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Star1 Airlines (V9), LT"
+
+  - trigger: "::6D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pelita (6D), ID"
+
+  - trigger: "::E8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alpi Eagles (E8), IT"
+
+  - trigger: "::J5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alaska Seaplane Service (J5), US"
+
+  - trigger: "::T8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TAN (T8), AR"
+
+  - trigger: "::I6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MexicanaLink (I6), MX"
+
+  - trigger: "::IP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Island Spirit (IP), IS"
+
+  - trigger: "::T0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TACA Peru (T0), PE"
+
+  - trigger: "::7Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pan Am World Airways Dominicana (7Q), DO"
+
+  - trigger: "::PF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Primera Air (PF), IS"
+
+  - trigger: "::3S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Antilles Express (3S), FR"
+
+  - trigger: "::P7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regional Paraguaya (P7), PY"
+
+  - trigger: "::V6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VIP Ecuador (V6), EC"
+
+  - trigger: "::P9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Peruvian Airlines (P9), PE"
+
+  - trigger: "::ЯП?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polar Airlines (ЯП), RU"
+
+  - trigger: "::OC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Catovair (OC), MU"
+
+  - trigger: "::7Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Halcyonair (7Z), CV"
+
+  - trigger: "::4P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Business Aviation (4P), CD"
+
+  - trigger: "::E9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Compagnie Africaine d'Aviation (E9), CD"
+
+  - trigger: "::K8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zambia Skyways (K8), ZM"
+
+  - trigger: "::UJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AlMasria Universal Airlines (UJ), EG"
+
+  - trigger: "::6Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SmartLynx Airlines (6Y), LV"
+
+  - trigger: "::K7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KoralBlue Airlines (K7), EG"
+
+  - trigger: "::E4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Elysian Airlines (E4), CM"
+
+  - trigger: "::HT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hellenic Imperial Airways (HT), GR"
+
+  - trigger: "::WD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Amsterdam Airlines (WD), NL"
+
+  - trigger: "::Q9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Arik Niger (Q9), NE"
+
+  - trigger: "::DA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dana Air (DA), NG"
+
+  - trigger: "::8F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "STP Airways (8F), ST"
+
+  - trigger: "::7Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Med Airways (7Y), LB"
+
+  - trigger: "::UQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skyjet Airlines (UQ), UG"
+
+  - trigger: "::G6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Volga (G6), RU"
+
+  - trigger: "::RL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal Falcon (RL), JO"
+
+  - trigger: "::4L?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Euroline (4L), GE"
+
+  - trigger: "::WG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Worldways (WG), CA"
+
+  - trigger: "::ZF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Athens Airways (ZF), GR"
+
+  - trigger: "::VQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Viking Hellas (VQ), GR"
+
+  - trigger: "::DZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Starline.kz (DZ), KZ"
+
+  - trigger: "::EH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Euro Harmony (EH), PT"
+
+  - trigger: "::L7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lugansk Airlines (L7), UA"
+
+  - trigger: "::6P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gryphon Airlines (6P), US"
+
+  - trigger: "::GP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gadair European Airlines (GP), ES"
+
+  - trigger: "::SM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spirit of Manila Airlines (SM), PH"
+
+  - trigger: "::OQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chongqing Airlines (OQ), CN"
+
+  - trigger: "::PN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "West Air China (PN), CN"
+
+  - trigger: "::IH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Falcon Air (IH), SE"
+
+  - trigger: "::C3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "QatXpress (C3), QA"
+
+  - trigger: "::1C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "OneChina (1C), CN"
+
+  - trigger: "::Y7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "NordStar Airlines (Y7), RU"
+
+  - trigger: "::JR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Joy Air (JR), CN"
+
+  - trigger: "::CD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air India Regional (CD), IN"
+
+  - trigger: "::9H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MDLR Airlines (9H), IN"
+
+  - trigger: "::Q2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maldivian (Q2), MV"
+
+  - trigger: "::XN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Xpressair (XN), ID"
+
+  - trigger: "::VC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Strategic Airlines (VC), AU"
+
+  - trigger: "::NA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Al-Naser Airlines (NA), IQ"
+
+  - trigger: "::MR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Homer Air (MR), DE"
+
+  - trigger: "::GM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flitestar (GM), ZA"
+
+  - trigger: "::WQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PanAm World Airways (WQ), US"
+
+  - trigger: "::YY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Virginwings (YY), DE"
+
+  - trigger: "::KY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KSY (KY), GR"
+
+  - trigger: "::BQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Buquebus Líneas Aéreas (BQ), UY"
+
+  - trigger: "::CQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SOCHI AIR (CQ), RU"
+
+  - trigger: "::WU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wizz Air Ukraine (WU), UA"
+
+  - trigger: "::LQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LCM AIRLINES (LQ), RU"
+
+  - trigger: "::BZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Brazil (BZ), BR"
+
+  - trigger: "::K6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cambodia Angkor Air (K6), KH"
+
+  - trigger: "::D5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skyline nepc (D5), IN"
+
+  - trigger: "::H3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "THREE (H3), CN"
+
+  - trigger: "::69?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal European Airlines (69), GB"
+
+  - trigger: "::AD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Azul (AD), BR"
+
+  - trigger: "::PQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LSM Airlines (PQ), RU"
+
+  - trigger: "::C4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LionXpress (C4), CM"
+
+  - trigger: "::X1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nik Airways (X1), SA"
+
+  - trigger: "::GK?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Genesis (GK), PK"
+
+  - trigger: "::XZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Congo Express (XZ), CD"
+
+  - trigger: "::FZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Dubai (FZ), AE"
+
+  - trigger: "::D1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Domenican Airlines (D1), DO"
+
+  - trigger: "::9A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Atlantic (9A), CA"
+
+  - trigger: "::CR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Ops (CR), SE"
+
+  - trigger: "::JY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aereonautica militare (JY), IT"
+
+  - trigger: "::YZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LSM AIRLINES (YZ), RU"
+
+  - trigger: "::YP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero Lloyd (YP) (YP), DE"
+
+  - trigger: "::UR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "UTair-Express (UR), RU"
+
+  - trigger: "::G5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Huaxia (G5), CN"
+
+  - trigger: "::ZP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zabaykalskii Airlines (ZP), RU"
+
+  - trigger: "::M4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Marysya Airlines (M4), RU"
+
+  - trigger: "::N1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "N1 (N1), PE"
+
+  - trigger: "::4Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Airlink (SAA) (4Z), ZA"
+
+  - trigger: "::3B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "JobAir (3B), CZ"
+
+  - trigger: "::OD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zuliana de Aviacion (OD), VE"
+
+  - trigger: "::BZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Black Stallion Airways (BZ), US"
+
+  - trigger: "::GM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "German International Air Lines (GM), DE"
+
+  - trigger: "::TB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TrasBrasil (TB), BR"
+
+  - trigger: "::TH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TransBrasil Airlines (TH), BR"
+
+  - trigger: "::9C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China SSS (9C), CN"
+
+  - trigger: "::NJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nihon.jet (NJ), JP"
+
+  - trigger: "::TJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Transportes Aéreos Nacionales de Selva (TJ), PE"
+
+  - trigger: "::P8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Mekong (P8), VN"
+
+  - trigger: "::H3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Harbour Air (Priv) (H3), CA"
+
+  - trigger: "::HH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Hamburg (AHO) (HH), DE"
+
+  - trigger: "::Z6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ZABAIKAL AIRLINES (Z6), RU"
+
+  - trigger: "::TI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TransHolding (TI), BR"
+
+  - trigger: "::YT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yeti Airways (YT), NP"
+
+  - trigger: "::Y1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yellowstone Club Private Shuttle (Y1), US"
+
+  - trigger: "::NS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Caucasus Airlines (NS), GE"
+
+  - trigger: "::S1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Serbian Airlines (S1), RS"
+
+  - trigger: "::WM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Windward Islands Airways (WM), NL"
+
+  - trigger: "::YO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TransHolding System (YO), BR"
+
+  - trigger: "::CB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CCML Airlines (CB), CO"
+
+  - trigger: "::SF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Charter International (SF), FR"
+
+  - trigger: "::F1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Brasil (F1), BR"
+
+  - trigger: "::3F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Colombia (3F), CO"
+
+  - trigger: "::T6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Trans Pas Air (T6), US"
+
+  - trigger: "::МИ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "KMV (МИ), RU"
+
+  - trigger: "::HC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Himalayan Airlines (HC), NP"
+
+  - trigger: "::G1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indya Airline Group (G1), IN"
+
+  - trigger: "::WG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sunwing (WG), CA"
+
+  - trigger: "::ZX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Japan Regio (ZX), JP"
+
+  - trigger: "::N0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Norte Lineas Aereas (N0), AR"
+
+  - trigger: "::W7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Austral Brasil (W7), BR"
+
+  - trigger: "::H9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "PEGASUS AIRLINES- (H9), TR"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirLiberté (IJ), FR"
+
+  - trigger: "::QC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Camair-co (QC), CM"
+
+  - trigger: "::N6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aerocontinente (Priv) (N6), PE"
+
+  - trigger: "::RS?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Regional (RS), CA"
+
+  - trigger: "::YI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TUR Avrupa Hava YollarÄ± (YI), TR"
+
+    - trigger: "::II?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "LSM International (II), RU"
+
+  - trigger: "::BU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Baikotovitchestrian Airlines (BU), WS"
+
+  - trigger: "::Z7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zimbabwean Airlines (Z7), ZW"
+
+  - trigger: "::6U?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Cargo Germany (6U), DE"
+
+  - trigger: "::7M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mongolian International Air Lines (7M), MN"
+
+  - trigger: "::2D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alaniya Airlines (2D), RU"
+
+  - trigger: "::TW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tway Airlines (TW), KR"
+
+  - trigger: "::HI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Papillon Grand Canyon Helicopters (HI), US"
+
+  - trigger: "::JX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jusur airways (JX), EG"
+
+  - trigger: "::XB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "NEXT Brasil (XB), BR"
+
+  - trigger: "::W4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AeroWorld (W4), RU"
+
+  - trigger: "::KH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Cook Island Air (KH), CK"
+
+  - trigger: "::E8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "US Africa Airways (E8), US"
+
+  - trigger: "::GN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "GNB Linhas Aereas (GN), BR"
+
+  - trigger: "::E1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Usa Sky Cargo (E1), US"
+
+  - trigger: "::HN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hankook Airline (HN), KR"
+
+  - trigger: "::RR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Red Jet America (RR), US"
+
+  - trigger: "::Z7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "REDjet (Z7), BB"
+
+  - trigger: "::1H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hellenic Airways (1H), GR"
+
+  - trigger: "::PT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Red Jet Andes (PT), PE"
+
+  - trigger: "::QY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Red Jet Canada (QY), CA"
+
+  - trigger: "::4X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Red Jet Mexico (4X), MX"
+
+  - trigger: "::Y8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Marusya Airways (Y8), RU"
+
+  - trigger: "::7H?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Era Alaska (7H), US"
+
+  - trigger: "::R8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirRussia (R8), RU"
+
+  - trigger: "::H1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hankook Air US (H1), US"
+
+  - trigger: "::D5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "NEPC Airlines (D5), IN"
+
+  - trigger: "::10?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Canadian World (10), CA"
+
+  - trigger: "::H5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "I-Fly (H5), RU"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "T.A.T (IJ), FR"
+
+  - trigger: "::DN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alinord (DN), IT"
+
+  - trigger: "::VB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pacific Express (VB), US"
+
+  - trigger: "::KT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VickJet (KT), FR"
+
+  - trigger: "::XV?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BVI Airways (XV), VG"
+
+  - trigger: "::SO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Salsa d'Haiti (SO), HT"
+
+  - trigger: "::ZJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zambezi Airlines (ZMA) (ZJ), ZM"
+
+  - trigger: "::YQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Polet Airlines (Priv) (YQ), RU"
+
+  - trigger: "::T1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "TROPICAL LINHAS AEREAS (T1), BR"
+
+  - trigger: "::12?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "12 North (12), IN"
+
+  - trigger: "::L6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Mauritania Airlines International (L6), MR"
+
+  - trigger: "::6F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MAT Airways (6F), MK"
+
+  - trigger: "::AW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Asian Wings Airways (AW), MM"
+
+  - trigger: "::E5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Arabia Egypt (E5), EG"
+
+  - trigger: "::CT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Alitalia Cityliner (CT), IT"
+
+  - trigger: "::OI?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Orchid Airlines (OI), AU"
+
+  - trigger: "::Y5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Asia Wings (Y5), KZ"
+
+  - trigger: "::XR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Skywest Australia (XR), AU"
+
+  - trigger: "::NP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nile Air (NP), EG"
+
+  - trigger: "::DN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Senegal Airlines (DN), SN"
+
+  - trigger: "::6I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly 6ix (6I), SL"
+
+  - trigger: "::S9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Starbow Airlines (S9), GH"
+
+  - trigger: "::0X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Copenhagen Express (0X), DK"
+
+  - trigger: "::8B?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BusinessAir (8B), TH"
+
+  - trigger: "::YR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SENIC AIRLINES (YR), US"
+
+  - trigger: "::C7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Sky Wing Pacific (C7), KR"
+
+  - trigger: "::PP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Indus (PP), PK"
+
+  - trigger: "::07?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Samurai Airlines (07), PK"
+
+  - trigger: "::00?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirOne Continental (00), SK"
+
+  - trigger: "::U1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirOne Polska (U1), PL"
+
+  - trigger: "::MM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Peach Aviation (MM), JP"
+
+  - trigger: "::U1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aviabus (U1), RU"
+
+  - trigger: "::DF?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Michael Airlines (DF), PR"
+
+  - trigger: "::ZC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Korongo Airlines (ZC), CD"
+
+  - trigger: "::I5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Indonesia Sky (I5), ID"
+
+    - trigger: "::9P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Pelangi (9P), MY"
+
+  - trigger: "::B0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aws express (B0), US"
+
+  - trigger: "::76?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southjet (76), US"
+
+  - trigger: "::77?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southjet connect (77), US"
+
+  - trigger: "::KP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Cape (KP), ZA"
+
+  - trigger: "::78?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Southjet cargo (78), US"
+
+  - trigger: "::I2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Iberia Express (I2), ES"
+
+  - trigger: "::4O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Interjet (ABC Aerolineas) (4O), MX"
+
+  - trigger: "::OG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirOnix (OG), UA"
+
+  - trigger: "::NJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nordic Global Airlines (NJ), FI"
+
+  - trigger: "::TZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Scoot (TZ), SG"
+
+  - trigger: "::SX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Starling Airlines Spain (SX), ES"
+
+  - trigger: "::5K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Hi Fly (5K), PT"
+
+  - trigger: "::WH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "China Northwest Airlines (WH) (WH), CN"
+
+  - trigger: "::ZN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Zenith International Airline (ZN), TH"
+
+  - trigger: "::O1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Orbit Airlines Azerbaijan (O1), AZ"
+
+  - trigger: "::A6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Alps Aviation (A6) (A6), AT"
+
+  - trigger: "::P4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Patriot Airways (P4), US"
+
+  - trigger: "::V2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vision Airlines (V2), US"
+
+  - trigger: "::C8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Chicago Express (C8), US"
+
+  - trigger: "::5Q?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BQB Lineas Aereas (5Q), UY"
+
+  - trigger: "::YE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yellowtail (YE), US"
+
+  - trigger: "::KG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal Airways (KG), US"
+
+  - trigger: "::FH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FlyHigh Airlines Ireland (FH), IE"
+
+  - trigger: "::2D?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aero VIP (2D) (2D), PT"
+
+  - trigger: "::YH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Yangon Airways Ltd. (YH), MM"
+
+  - trigger: "::TJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "T.J. Air (TJ), US"
+
+  - trigger: "::SX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SkyWork Airlines (SX), CH"
+
+  - trigger: "::J7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "ValueJet (J7), US"
+
+  - trigger: "::W2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maastricht Airlines (W2), NL"
+
+  - trigger: "::WL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "CheapFlyingInternational (WL), FR"
+
+  - trigger: "::E6?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Aviaexpresscruise (E6), RU"
+
+  - trigger: "::24?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Euro Jet (24), DE"
+
+  - trigger: "::00?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "AirOne Atlantic (00), SK"
+
+  - trigger: "::HQ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "HQ- Business Express (HQ), US"
+
+  - trigger: "::R1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal Southern Airlines. (R1), CO"
+
+  - trigger: "::Q3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SOCHI AIR CHATER (Q3), RU"
+
+  - trigger: "::J7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Denim Air (J7), NO"
+
+  - trigger: "::NO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "North Pacific Airlines (NO), US"
+
+  - trigger: "::OD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malindo Air (OD), MY"
+
+  - trigger: "::9F?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Tramm Airlines (9F), NL"
+
+  - trigger: "::GC?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Lina Congo (GC), CG"
+
+  - trigger: "::Z9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Flightlink Tanzania (Z9), TZ"
+
+  - trigger: "::I8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "IzAvia (I8), RU"
+
+  - trigger: "::3V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "3 Valleys Airlines (3V), FR"
+
+  - trigger: "::M1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Maryland Air (M1), US"
+
+  - trigger: "::7I?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Insel Air (7I/INC) (Priv) (7I), NL"
+
+  - trigger: "::5Z?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "VivaColombia (5Z), CO"
+
+  - trigger: "::ZM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Apache Air (ZM), US"
+
+  - trigger: "::M2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "MHS Aviation GmbH (M2), DE"
+
+  - trigger: "::NR?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jettor Airlines (NR), HK"
+
+  - trigger: "::GD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "GoDutch (GD), NL"
+
+  - trigger: "::SL?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai Lion Air (SL), TH"
+
+  - trigger: "::DW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Deutsche Luftverkehrsgesellschaft (DW), DE"
+
+  - trigger: "::N8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "National Air Cargo (N8), US"
+
+  - trigger: "::13?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eastern Atlantic Virtual Airlines (13), US"
+
+  - trigger: "::QG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Citilink Indonesia (QG), ID"
+
+  - trigger: "::GU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Gulisano airways (GU), IT"
+
+  - trigger: "::XP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Caribbean Wings (XP), TC"
+
+  - trigger: "::S8?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Snowbird Airlines (S8), FI"
+
+  - trigger: "::KH?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Kharkiv Airlines (KH), UA"
+
+  - trigger: "::XA?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "XAIR USA (XA), US"
+
+  - trigger: "::LB?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Costa (LB), IN"
+
+  - trigger: "::XP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "XPTO (XP), PT"
+
+  - trigger: "::3W?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Malawian Airlines (3W), MW"
+
+  - trigger: "::JU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Serbia (JU), RS"
+
+  - trigger: "::LT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Lituanica (LT), LT"
+
+  - trigger: "::RN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rainbow Air (RAI) (RN), US"
+
+  - trigger: "::RY?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rainbow Air Canada (RY), CA"
+
+  - trigger: "::RX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rainbow Air Polynesia (RX), US"
+
+  - trigger: "::RU?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rainbow Air Euro (RU), GB"
+
+  - trigger: "::RM?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Rainbow Air US (RM), US"
+
+  - trigger: "::QD?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dobrolet (QD), RU"
+
+  - trigger: "::S0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spike Airlines (S0), US"
+
+  - trigger: "::L1?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Argentina (L1), AR"
+
+  - trigger: "::A2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America (A2), US"
+
+  - trigger: "::L9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Asia (L9), CN"
+
+  - trigger: "::9A?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Africa (9A), ZA"
+
+  - trigger: "::N4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regionalia México (N4), MX"
+
+  - trigger: "::N9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Europe (N9), GB"
+
+  - trigger: "::N7?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Spain (N7), ES"
+
+  - trigger: "::9N?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regional Air Iceland (9N), IS"
+
+  - trigger: "::8K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Voestar (8K), BR"
+
+  - trigger: "::7O?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Colombia (7O), CO"
+
+  - trigger: "::2X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regionalia Uruguay (2X), UY"
+
+  - trigger: "::9X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regionalia Venezuela (9X), VE"
+
+  - trigger: "::9J?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Regionalia Chile (9J), CL"
+
+  - trigger: "::6C?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vuela Cuba (6C), CU"
+
+  - trigger: "::88?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Australia (88), AU"
+
+  - trigger: "::ER?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Europa (ER), ES"
+
+  - trigger: "::PO?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FlyPortugal (PO), PT"
+
+  - trigger: "::IJ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Spring Airlines Japan (IJ), JP"
+
+  - trigger: "::KP?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dense Airways (KP), US"
+
+  - trigger: "::KZ?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dense Connection (KZ), US"
+
+  - trigger: "::4S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Vuola Italia (4S), IT"
+
+  - trigger: "::1X?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Island Express Air (1X), CA"
+
+  - trigger: "::Z0?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All Argentina Express (Z0), AR"
+
+  - trigger: "::WE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Thai Smile Airways (WE), TH"
+
+  - trigger: "::I4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "International AirLink (I4), JM"
+
+  - trigger: "::RT?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Real Tonga (RT), TO"
+
+  - trigger: "::2R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America AR (2R), AR"
+
+  - trigger: "::1R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America CL (1R), CL"
+
+  - trigger: "::Q4?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "SOCHI AIR EXPRESS (Q4), RU"
+
+  - trigger: "::1Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America BR (1Y), BR"
+
+  - trigger: "::X9?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FRA Air (X9), DE"
+
+  - trigger: "::QN?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Royal (QN), CA"
+
+  - trigger: "::GX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "GREAT LAKES (GX), CA"
+
+  - trigger: "::9V?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Volotea Costa Rica (9V), CR"
+
+  - trigger: "::X5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly Romania (X5), RO"
+
+  - trigger: "::E2?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Eagle Atlantic Airlines (E2), GH"
+
+  - trigger: "::0Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America CO (0Y), CO"
+
+  - trigger: "::0M?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America MX (0M), MX"
+
+  - trigger: "::FX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "FOX Linhas Aereas (FX), BR"
+
+  - trigger: "::EX?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Wings of England (EX), GB"
+
+  - trigger: "::DW?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Deutsche Luftverkehrsgesellschaft (DLT) (DW), DE"
+
+  - trigger: "::K3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Atlantic Air Cargo (K3), US"
+
+  - trigger: "::W3?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "World Scale Airlines (W3), US"
+
+  - trigger: "::AG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America US (AG), US"
+
+  - trigger: "::1K?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "BudgetAir (1K), DE"
+
+  - trigger: "::F5?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Fly One (F5), MD"
+
+  - trigger: "::EE?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Nordica (EE), EE"
+
+  - trigger: "::0E?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Dummy (0E), FR"
+
+  - trigger: "::0P?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "All America BOPY (0P), PY"
+
+  - trigger: "::2Y?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Andaman (2Y) (2Y), TH"
+
+  - trigger: "::JG?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Jetgo Australia (JG), AU"
+
+  - trigger: "::2S?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Air Carnival (2S), IN"
+
+  - trigger: "::7R?"
+    label: "Provide the airline name based on IATA's two-character designators"
+    replace: "Svyaz Rossiya (7R), RU"

--- a/packages/air-codes/0.1.0/package.yml
+++ b/packages/air-codes/0.1.0/package.yml
@@ -1,7534 +1,5651 @@
 matches:
   # Provide airport data based on IATA's three-letter airport codes
   - trigger: "::LHR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "London Heathrow Airport, London, GB (LHR)"
 
   - trigger: "::LAX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Los Angeles / Tom Bradley International Airport, Los Angeles, US (LAX)"
 
   - trigger: "::ORD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chicago O'Hare International Airport, Chicago, US (ORD)"
 
   - trigger: "::JFK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "John F Kennedy International Airport, New York, US (JFK)"
 
   - trigger: "::ATL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hartsfield Jackson Atlanta International Airport, Atlanta, US (ATL)"
 
   - trigger: "::CDG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Charles de Gaulle International Airport, Paris, FR (CDG)"
 
   - trigger: "::SFO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "San Francisco International Airport, San Francisco, US (SFO)"
 
   - trigger: "::AMS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Amsterdam Airport Schiphol, Amsterdam, NL (AMS)"
 
   - trigger: "::FRA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Frankfurt Airport, Frankfurt am Main, DE (FRA)"
 
   - trigger: "::EWR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Newark Liberty International Airport, Newark, US (EWR)"
 
   - trigger: "::DFW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dallas Fort Worth International Airport, Dallas-Fort Worth, US (DFW)"
 
   - trigger: "::LAS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Harry Reid International Airport, Las Vegas, US (LAS)"
 
   - trigger: "::MCO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Orlando International Airport, Orlando, US (MCO)"
 
   - trigger: "::DEN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Denver International Airport, Denver, US (DEN)"
 
   - trigger: "::IAD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Washington Dulles International Airport, Dulles, US (IAD)"
 
   - trigger: "::LGA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "La Guardia Airport, New York, US (LGA)"
 
   - trigger: "::MIA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Miami International Airport, Miami, US (MIA)"
 
   - trigger: "::SEA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Seattle–Tacoma International Airport, Seattle, US (SEA)"
 
   - trigger: "::PHX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Phoenix Sky Harbor International Airport, Phoenix, US (PHX)"
 
   - trigger: "::BOS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Logan International Airport, Boston, US (BOS)"
 
   - trigger: "::PHL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Philadelphia International Airport, Philadelphia, US (PHL)"
 
   - trigger: "::CLT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Charlotte Douglas International Airport, Charlotte, US (CLT)"
 
   - trigger: "::LGW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "London Gatwick Airport, London, GB (LGW)"
 
   - trigger: "::IAH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "George Bush Intercontinental Houston Airport, Houston, US (IAH)"
 
   - trigger: "::DTW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Detroit Metropolitan Wayne County Airport, Detroit, US (DTW)"
 
   - trigger: "::DCA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ronald Reagan Washington National Airport, Washington, US (DCA)"
 
   - trigger: "::YYZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Toronto Lester B. Pearson International Airport, Toronto, CA (YYZ)"
 
   - trigger: "::MSP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Minneapolis–Saint Paul International Airport / Wold–Chamberlain Field, Minneapolis, US (MSP)"
 
   - trigger: "::MUC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Munich Airport, Munich, DE (MUC)"
 
   - trigger: "::BCN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Josep Tarradellas Barcelona-El Prat Airport, Barcelona, ES (BCN)"
 
   - trigger: "::FCO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Rome–Fiumicino Leonardo da Vinci International Airport, Rome, IT (FCO)"
 
   - trigger: "::MAD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Adolfo Suárez Madrid–Barajas Airport, Madrid, ES (MAD)"
 
   - trigger: "::SLC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Salt Lake City International Airport, Salt Lake City, US (SLC)"
 
   - trigger: "::FLL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Fort Lauderdale Hollywood International Airport, Fort Lauderdale, US (FLL)"
 
   - trigger: "::MDW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chicago Midway International Airport, Chicago, US (MDW)"
 
   - trigger: "::ZRH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Zürich Airport, Zurich, CH (ZRH)"
 
   - trigger: "::BWI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Baltimore/Washington International Thurgood Marshall Airport, Baltimore, US (BWI)"
 
   - trigger: "::SAN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "San Diego International Airport, San Diego, US (SAN)"
 
   - trigger: "::CPH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Copenhagen Kastrup Airport, Copenhagen, DK (CPH)"
 
   - trigger: "::BRU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Brussels Airport, Zaventem, BE (BRU)"
 
   - trigger: "::DUB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dublin Airport, Dublin, IE (DUB)"
 
   - trigger: "::SIN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Singapore Changi Airport, Singapore, SG (SIN)"
 
   - trigger: "::STL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "St Louis Lambert International Airport, St Louis, US (STL)"
 
   - trigger: "::DXB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dubai International Airport, Dubai, AE (DXB)"
 
   - trigger: "::VIE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Vienna International Airport, Vienna, AT (VIE)"
 
   - trigger: "::YVR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Vancouver International Airport, Vancouver, CA (YVR)"
 
   - trigger: "::NRT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Narita International Airport, Narita, JP (NRT)"
 
   - trigger: "::HNL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Daniel K Inouye International Airport, Honolulu, US (HNL)"
 
   - trigger: "::STN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "London Stansted Airport, London, GB (STN)"
 
   - trigger: "::PDX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Portland International Airport, Portland, US (PDX)"
 
   - trigger: "::YUL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Montreal / Pierre Elliott Trudeau International Airport, Montréal, CA (YUL)"
 
   - trigger: "::MSY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Louis Armstrong New Orleans International Airport, New Orleans, US (MSY)"
 
   - trigger: "::HKG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hong Kong International Airport, Islands, HK (HKG)"
 
   - trigger: "::ARN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Stockholm-Arlanda Airport, Stockholm, SE (ARN)"
 
   - trigger: "::TPA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tampa International Airport, Tampa, US (TPA)"
 
   - trigger: "::LIS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Humberto Delgado Airport (Lisbon Portela Airport), Lisbon, PT (LIS)"
 
   - trigger: "::BNA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nashville International Airport, Nashville, US (BNA)"
 
   - trigger: "::PRG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Václav Havel Airport Prague, Prague, CZ (PRG)"
 
   - trigger: "::CVG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cincinnati Northern Kentucky International Airport, Cincinnati / Covington, US (CVG)"
 
   - trigger: "::SYD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sydney Kingsford Smith International Airport, Sydney, AU (SYD)"
 
   - trigger: "::BKK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Suvarnabhumi Airport, Bangkok, TH (BKK)"
 
   - trigger: "::AUS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Austin Bergstrom International Airport, Austin, US (AUS)"
 
   - trigger: "::CUN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional de Cancún, Ciudad de Cancún, MX (CUN)"
 
   - trigger: "::PIT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Pittsburgh International Airport, Pittsburgh, US (PIT)"
 
   - trigger: "::MXP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Malpensa International Airport, Milan, IT (MXP)"
 
   - trigger: "::RDU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Raleigh Durham International Airport, Raleigh/Durham, US (RDU)"
 
   - trigger: "::ISL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "İstanbul Atatürk Airport, Bakırköy, Istanbul, TR (ISL)"
 
   - trigger: "::ATH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Athens Eleftherios Venizelos International Airport, Athens, GR (ATH)"
 
   - trigger: "::SJC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Norman Y. Mineta San Jose International Airport, San Jose, US (SJC)"
 
   - trigger: "::BUD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Budapest Liszt Ferenc International Airport, Budapest, HU (BUD)"
 
   - trigger: "::MCI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kansas City International Airport, Kansas City, US (MCI)"
 
   - trigger: "::OSL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Oslo Airport, Gardermoen, Oslo, NO (OSL)"
 
   - trigger: "::OAK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Metropolitan Oakland International Airport, Oakland, US (OAK)"
 
   - trigger: "::SAT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "San Antonio International Airport, San Antonio, US (SAT)"
 
   - trigger: "::MEM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Memphis International Airport, Memphis, US (MEM)"
 
   - trigger: "::SNA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "John Wayne Orange County International Airport, Santa Ana, US (SNA)"
 
   - trigger: "::PEK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Beijing Capital International Airport, Beijing, CN (PEK)"
 
   - trigger: "::KEF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Keflavik International Airport, Reykjavík, IS (KEF)"
 
   - trigger: "::MAN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Manchester Airport, Manchester, GB (MAN)"
 
   - trigger: "::HEL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Helsinki Vantaa Airport, Helsinki, FI (HEL)"
 
   - trigger: "::CLE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cleveland Hopkins International Airport, Cleveland, US (CLE)"
 
   - trigger: "::GVA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Geneva Cointrin International Airport, Geneva, CH (GVA)"
 
   - trigger: "::KUL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kuala Lumpur International Airport, Sepang, MY (KUL)"
 
   - trigger: "::ORY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Paris-Orly Airport, Paris, FR (ORY)"
 
   - trigger: "::IND?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Indianapolis International Airport, Indianapolis, US (IND)"
 
   - trigger: "::EDI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Edinburgh Airport, Edinburgh, GB (EDI)"
 
   - trigger: "::YYC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Calgary International Airport, Calgary, CA (YYC)"
 
   - trigger: "::DUS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Düsseldorf Airport, Düsseldorf, DE (DUS)"
 
   - trigger: "::MEX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Lic. Benito Juárez, Ciudad de México, MX (MEX)"
 
   - trigger: "::PMI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Palma de Mallorca Airport, Palma de Mallorca, ES (PMI)"
 
   - trigger: "::VCE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Venice Marco Polo Airport, Venice, IT (VCE)"
 
   - trigger: "::CMH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "John Glenn Columbus International Airport, Columbus, US (CMH)"
 
   - trigger: "::ICN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Incheon International Airport, Seoul, KR (ICN)"
 
   - trigger: "::LTN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "London Luton Airport, London, GB (LTN)"
 
   - trigger: "::WAW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Warsaw Chopin Airport, Warsaw, PL (WAW)"
 
   - trigger: "::MEL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Melbourne International Airport, Melbourne, AU (MEL)"
 
   - trigger: "::PVG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shanghai Pudong International Airport, Shanghai (Pudong), CN (PVG)"
 
   - trigger: "::MKE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "General Mitchell International Airport, Milwaukee, US (MKE)"
 
   - trigger: "::DEL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Indira Gandhi International Airport, New Delhi, IN (DEL)"
 
   - trigger: "::AGP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Málaga-Costa del Sol Airport, Málaga, ES (AGP)"
 
   - trigger: "::SJU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Luis Munoz Marin International Airport, San Juan, PR (SJU)"
 
   - trigger: "::NCE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nice-Côte d'Azur Airport, Nice, FR (NCE)"
 
   - trigger: "::JNB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "OR Tambo International Airport, Johannesburg, ZA (JNB)"
 
   - trigger: "::JAX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jacksonville International Airport, Jacksonville, US (JAX)"
 
   - trigger: "::HAM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hamburg Helmut Schmidt Airport, Hamburg, DE (HAM)"
 
   - trigger: "::TLV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ben Gurion International Airport, Tel Aviv, IL (TLV)"
 
   - trigger: "::AKL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Auckland International Airport, Auckland, NZ (AKL)"
 
   - trigger: "::BUF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Buffalo Niagara International Airport, Buffalo, US (BUF)"
 
   - trigger: "::ANC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ted Stevens Anchorage International Airport, Anchorage, US (ANC)"
 
   - trigger: "::YOW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ottawa Macdonald-Cartier International Airport, Ottawa, CA (YOW)"
 
   - trigger: "::GRU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Guarulhos - Governador André Franco Montoro International Airport, São Paulo, BR (GRU)"
 
   - trigger: "::SVO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sheremetyevo International Airport, Moscow, RU (SVO)"
 
   - trigger: "::GLA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Glasgow International Airport, Paisley, Renfrewshire, GB (GLA)"
 
   - trigger: "::DMK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Don Mueang International Airport, Bangkok, TH (DMK)"
 
   - trigger: "::HND?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tokyo Haneda International Airport, Tokyo, JP (HND)"
 
   - trigger: "::CAI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cairo International Airport, Cairo, EG (CAI)"
 
   - trigger: "::CGN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cologne Bonn Airport, Köln (Cologne), DE (CGN)"
 
   - trigger: "::EZE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Minister Pistarini International Airport, Buenos Aires (Ezeiza), AR (EZE)"
 
   - trigger: "::BNE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Brisbane International Airport, Brisbane, AU (BNE)"
 
   - trigger: "::BOM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chhatrapati Shivaji International Airport, Mumbai, IN (BOM)"
 
   - trigger: "::AUH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Abu Dhabi International Airport, Abu Dhabi, AE (AUH)"
 
   - trigger: "::TPE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Taiwan Taoyuan International Airport, Taoyuan (Dayuan), TW (TPE)"
 
   - trigger: "::LIM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jorge Chávez International Airport, Lima, PE (LIM)"
 
   - trigger: "::SMF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sacramento International Airport, Sacramento, US (SMF)"
 
   - trigger: "::DPS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ngurah Rai (Bali) International Airport, Denpasar, ID (DPS)"
 
   - trigger: "::OMA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Eppley Airfield, Omaha, US (OMA)"
 
   - trigger: "::MNL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ninoy Aquino International Airport, Manila, PH (MNL)"
 
   - trigger: "::PBI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Palm Beach International Airport, West Palm Beach, US (PBI)"
 
   - trigger: "::LPA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gran Canaria Airport, Gran Canaria Island, ES (LPA)"
 
   - trigger: "::RNO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Reno Tahoe International Airport, Reno, US (RNO)"
 
   - trigger: "::PVD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Theodore Francis Green State Airport, Warwick, US (PVD)"
 
   - trigger: "::SDF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Louisville Muhammad Ali International Airport, Louisville, US (SDF)"
 
   - trigger: "::CPT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cape Town International Airport, Cape Town, ZA (CPT)"
 
   - trigger: "::MLA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Malta International Airport, Valletta, MT (MLA)"
 
   - trigger: "::STR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Stuttgart Airport, Stuttgart, DE (STR)"
 
   - trigger: "::DOH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hamad International Airport, Doha, QA (DOH)"
 
   - trigger: "::GIG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Rio Galeão – Tom Jobim International Airport, Rio De Janeiro, BR (GIG)"
 
   - trigger: "::SCL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Comodoro Arturo Merino Benítez International Airport, Santiago, CL (SCL)"
 
   - trigger: "::BHX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Birmingham International Airport, Birmingham, GB (BHX)"
 
   - trigger: "::YEG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Edmonton International Airport, Edmonton, CA (YEG)"
 
   - trigger: "::YWG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Winnipeg / James Armstrong Richardson International Airport, Winnipeg, CA (YWG)"
 
   - trigger: "::SAV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Savannah Hilton Head International Airport, Savannah, US (SAV)"
 
   - trigger: "::RIC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Richmond International Airport, Richmond, US (RIC)"
 
   - trigger: "::RIX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Riga International Airport, Riga, LV (RIX)"
 
   - trigger: "::BGY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Milan Bergamo Airport, Milan, IT (BGY)"
 
   - trigger: "::RSW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Southwest Florida International Airport, Fort Myers, US (RSW)"
 
   - trigger: "::YHZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Halifax / Stanfield International Airport, Halifax, CA (YHZ)"
 
   - trigger: "::PTY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tocumen International Airport, Tocumen, PA (PTY)"
 
   - trigger: "::BGO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bergen Airport, Flesland, Bergen, NO (BGO)"
 
   - trigger: "::OPO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Francisco de Sá Carneiro Airport, Porto, PT (OPO)"
 
   - trigger: "::HKT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Phuket International Airport, Phuket, TH (HKT)"
 
   - trigger: "::SGN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tan Son Nhat International Airport, Ho Chi Minh City, VN (SGN)"
 
   - trigger: "::HER?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Heraklion International Nikos Kazantzakis Airport, Heraklion, GR (HER)"
 
   - trigger: "::OTP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Henri Coandă International Airport, Bucharest, RO (OTP)"
 
   - trigger: "::ONT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ontario International Airport, Ontario, US (ONT)"
 
   - trigger: "::CGK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Soekarno-Hatta International Airport, Jakarta, ID (CGK)"
 
   - trigger: "::AYT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Antalya International Airport, Antalya, TR (AYT)"
 
   - trigger: "::NBO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jomo Kenyatta International Airport, Nairobi, KE (NBO)"
 
   - trigger: "::SYR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Syracuse Hancock International Airport, Syracuse, US (SYR)"
 
   - trigger: "::LCA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Larnaca International Airport, Larnaca, CY (LCA)"
 
   - trigger: "::TFS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tenerife Sur Airport, Tenerife, ES (TFS)"
 
   - trigger: "::KRK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kraków John Paul II International Airport, Kraków, PL (KRK)"
 
   - trigger: "::KIX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kansai International Airport, Osaka, JP (KIX)"
 
   - trigger: "::TUL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tulsa International Airport, Tulsa, US (TUL)"
 
   - trigger: "::FAO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Faro Airport, Faro, PT (FAO)"
 
   - trigger: "::PWM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Portland International Jetport, Portland, US (PWM)"
 
   - trigger: "::ALC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Alicante-Elche Miguel Hernández Airport, Alicante, ES (ALC)"
 
   - trigger: "::BEG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Belgrade Nikola Tesla Airport, Belgrade, RS (BEG)"
 
   - trigger: "::MRS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Marseille Provence Airport, Marseille, FR (MRS)"
 
   - trigger: "::BLQ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bologna Guglielmo Marconi Airport, Bologna, IT (BLQ)"
 
   - trigger: "::CHC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Christchurch International Airport, Christchurch, NZ (CHC)"
 
   - trigger: "::ZAG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Zagreb Airport, Zagreb, HR (ZAG)"
 
   - trigger: "::YQB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Quebec Jean Lesage International Airport, Quebec, CA (YQB)"
 
   - trigger: "::GOT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gothenburg-Landvetter Airport, Gothenburg, SE (GOT)"
 
   - trigger: "::DME?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Domodedovo International Airport, Moscow, RU (DME)"
 
   - trigger: "::NAS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lynden Pindling International Airport, Nassau, BS (NAS)"
 
   - trigger: "::BOG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "El Dorado International Airport, Bogota, CO (BOG)"
 
   - trigger: "::PUJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Punta Cana International Airport, Punta Cana, DO (PUJ)"
 
   - trigger: "::NAP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Naples International Airport, Napoli, IT (NAP)"
 
   - trigger: "::PER?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Perth International Airport, Perth, AU (PER)"
 
   - trigger: "::HAN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Noi Bai International Airport, Hanoi (Soc Son), VN (HAN)"
 
   - trigger: "::BSL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "EuroAirport Basel-Mulhouse-Freiburg, Saint-Louis, FR (BSL)"
 
   - trigger: "::YYJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Victoria International Airport, Victoria, CA (YYJ)"
 
   - trigger: "::TLS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Toulouse-Blagnac Airport, Toulouse/Blagnac, FR (TLS)"
 
   - trigger: "::SAW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Istanbul Sabiha Gökçen International Airport, Pendik, Istanbul, TR (SAW)"
 
   - trigger: "::LED?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Pulkovo Airport, St. Petersburg, RU (LED)"
 
   - trigger: "::TLL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lennart Meri Tallinn Airport, Tallinn, EE (TLL)"
 
   - trigger: "::SNN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shannon Airport, Shannon, IE (SNN)"
 
   - trigger: "::HAV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "José Martí International Airport, Havana, CU (HAV)"
 
   - trigger: "::PVR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Lic. Gustavo Díaz Ordaz, Ciudad de Puerto Vallarta, MX (PVR)"
 
   - trigger: "::EIN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Eindhoven Airport, Eindhoven, NL (EIN)"
 
   - trigger: "::CMN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mohammed V International Airport, Casablanca, MA (CMN)"
 
   - trigger: "::PSA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Pisa International Airport, Pisa, IT (PSA)"
 
   - trigger: "::LYS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lyon Saint-Exupéry Airport, Lyon, FR (LYS)"
 
   - trigger: "::LUX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Luxembourg-Findel International Airport, Luxembourg, LU (LUX)"
 
   - trigger: "::NUE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nuremberg Airport, Nuremberg, DE (NUE)"
 
   - trigger: "::SOF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sofia Airport, Sofia, BG (SOF)"
 
   - trigger: "::MCT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Muscat International Airport, Muscat, OM (MCT)"
 
   - trigger: "::LJU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ljubljana Jože Pučnik Airport, Ljubljana, SI (LJU)"
 
   - trigger: "::IST?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "İstanbul Airport, Arnavutköy, Istanbul, TR (IST)"
 
   - trigger: "::CUZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Alejandro Velasco Astete International Airport, Cusco, PE (CUZ)"
 
   - trigger: "::KBP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Boryspil International Airport, Boryspil, UA (KBP)"
 
   - trigger: "::CMB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bandaranaike International Colombo Airport, Colombo, LK (CMB)"
 
   - trigger: "::AMM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Queen Alia International Airport, Amman, JO (AMM)"
 
   - trigger: "::SHA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shanghai Hongqiao International Airport, Shanghai (Minhang), CN (SHA)"
 
   - trigger: "::SJD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional de Los Cabos, Ciudad de San José del Cabo, MX (SJD)"
 
   - trigger: "::SFB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Orlando Sanford International Airport, Orlando, US (SFB)"
 
   - trigger: "::CNX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chiang Mai International Airport, Chiang Mai, TH (CNX)"
 
   - trigger: "::CAN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Guangzhou Baiyun International Airport, Guangzhou (Huadu), CN (CAN)"
 
   - trigger: "::SVG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Stavanger Airport, Sola, Stavanger, NO (SVG)"
 
   - trigger: "::CTA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Catania-Fontanarossa Airport, Catania, IT (CTA)"
 
   - trigger: "::TUN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tunis Carthage International Airport, Tunis, TN (TUN)"
 
   - trigger: "::VNO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Vilnius International Airport, Vilnius, LT (VNO)"
 
   - trigger: "::MAA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chennai International Airport, Chennai, IN (MAA)"
 
   - trigger: "::SKG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Thessaloniki Macedonia International Airport, Thessaloniki, GR (SKG)"
 
   - trigger: "::IBZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ibiza Airport, Ibiza (Eivissa), ES (IBZ)"
 
   - trigger: "::ADL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Adelaide International Airport, Adelaide, AU (ADL)"
 
   - trigger: "::TRD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Trondheim Airport, Værnes, Trondheim, NO (TRD)"
 
   - trigger: "::HAJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hannover Airport, Hannover, DE (HAJ)"
 
   - trigger: "::SXM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Princess Juliana International Airport, Saint Martin, SX (SXM)"
 
   - trigger: "::BFS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Belfast International Airport, Belfast, GB (BFS)"
 
   - trigger: "::BAH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bahrain International Airport, Manama, BH (BAH)"
 
   - trigger: "::AEP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jorge Newbery Airpark, Buenos Aires, AR (AEP)"
 
   - trigger: "::BLR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kempegowda International Airport, Bangalore, IN (BLR)"
 
   - trigger: "::BOD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bordeaux-Mérignac Airport, Bordeaux/Mérignac, FR (BOD)"
 
   - trigger: "::BLL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Billund Airport, Billund, DK (BLL)"
 
   - trigger: "::BTS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "M. R. Štefánik Airport, Bratislava, SK (BTS)"
 
   - trigger: "::HRG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hurghada International Airport, Hurghada, EG (HRG)"
 
   - trigger: "::ACE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "César Manrique-Lanzarote Airport, San Bartolomé, ES (ACE)"
 
   - trigger: "::REP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Siem Reap International Airport, Siem Reap, KH (REP)"
 
   - trigger: "::MLE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Malé International Airport, Malé, MV (MLE)"
 
   - trigger: "::FAI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Fairbanks International Airport, Fairbanks, US (FAI)"
 
   - trigger: "::KTM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tribhuvan International Airport, Kathmandu, NP (KTM)"
 
   - trigger: "::SDQ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Las Américas International Airport, Santo Domingo, DO (SDQ)"
 
   - trigger: "::CMA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Camarillo International Airport, Camarillo, US (CMA)"
 
   - trigger: "::GMP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gimpo International Airport, Seoul, KR (GMP)"
 
   - trigger: "::TRN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Turin Airport, Torino, IT (TRN)"
 
   - trigger: "::GDN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gdańsk Lech Wałęsa Airport, Gdańsk, PL (GDN)"
 
   - trigger: "::KWI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kuwait International Airport, Kuwait City, KW (KWI)"
 
   - trigger: "::YYT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "St. John's International Airport, St. John's, CA (YYT)"
 
   - trigger: "::GDL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Miguel Hidalgo, Ciudad de Tlajomulco de Zúñiga, MX (GDL)"
 
   - trigger: "::AUA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Queen Beatrix International Airport, Oranjestad, AW (AUA)"
 
   - trigger: "::ADB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Adnan Menderes International Airport, İzmir, TR (ADB)"
 
   - trigger: "::ADD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Addis Ababa Bole International Airport, Addis Ababa, ET (ADD)"
 
   - trigger: "::BER?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Berlin Brandenburg Airport, Berlin, DE (BER)"
 
   - trigger: "::PMO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Falcone–Borsellino Airport, Palermo, IT (PMO)"
 
   - trigger: "::DRW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Darwin International Airport / RAAF Darwin, Darwin, AU (DRW)"
 
   - trigger: "::WLG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Wellington International Airport, Wellington, NZ (WLG)"
 
   - trigger: "::FUE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Fuerteventura Airport, El Matorral, ES (FUE)"
 
   - trigger: "::TOS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tromsø Airport, Langnes, Tromsø, NO (TOS)"
 
   - trigger: "::JED?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Abdulaziz International Airport, Jeddah, SA (JED)"
 
   - trigger: "::GUA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "La Aurora Airport, Guatemala City, GT (GUA)"
 
   - trigger: "::BSB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Presidente Juscelino Kubitschek International Airport, Brasília, BR (BSB)"
 
   - trigger: "::XIY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Xi'an Xianyang International Airport, Xianyang (Weicheng), CN (XIY)"
 
   - trigger: "::SSH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sharm El Sheikh International Airport, Sharm El Sheikh, EG (SSH)"
 
   - trigger: "::CCS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Simón Bolívar International Airport, Caracas, VE (CCS)"
 
   - trigger: "::UIO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mariscal Sucre International Airport, Quito, EC (UIO)"
 
   - trigger: "::VRN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Verona-Villafranca Valerio Catullo Airport, Villafranca di Verona, IT (VRN)"
 
   - trigger: "::ITM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Osaka International Airport, Osaka, JP (ITM)"
 
   - trigger: "::PNH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Phnom Penh International Airport, Phnom Penh (Pou Senchey), KH (PNH)"
 
   - trigger: "::YXX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Abbotsford International Airport, Abbotsford, CA (YXX)"
 
   - trigger: "::MVD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Carrasco General Cesáreo L. Berisso International Airport, Ciudad de la Costa, UY (MVD)"
 
   - trigger: "::BEY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Beirut Rafic Hariri International Airport, Beirut, LB (BEY)"
 
   - trigger: "::ESB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Esenboğa International Airport, Ankara, TR (ESB)"
 
   - trigger: "::CTU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chengdu Shuangliu International Airport, Chengdu, CN (CTU)"
 
   - trigger: "::CCU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Netaji Subhash Chandra Bose International Airport, Kolkata, IN (CCU)"
 
   - trigger: "::CAG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cagliari Elmas Airport, Cagliari, IT (CAG)"
 
   - trigger: "::FNC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Madeira International Airport Cristiano Ronaldo, Funchal, PT (FNC)"
 
   - trigger: "::VKO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Vnukovo International Airport, Moscow, RU (VKO)"
 
   - trigger: "::PLS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Providenciales International Airport, Providenciales, TC (PLS)"
 
   - trigger: "::SZX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shenzhen Bao'an International Airport, Shenzhen (Bao'an), CN (SZX)"
 
   - trigger: "::CEB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mactan Cebu International Airport, Lapu-Lapu City, PH (CEB)"
 
   - trigger: "::ACC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kotoka International Airport, Accra, GH (ACC)"
 
   - trigger: "::GOI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dabolim Airport, Vasco da Gama, IN (GOI)"
 
   - trigger: "::MTY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Gral. Mariano Escobedo, Ciudad de Apodaca, MX (MTY)"
 
   - trigger: "::GCM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Owen Roberts International Airport, George Town, KY (GCM)"
 
   - trigger: "::KIN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Norman Manley International Airport, Kingston, JM (KIN)"
 
   - trigger: "::SCQ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Santiago-Rosalía de Castro Airport, Santiago de Compostela, ES (SCQ)"
 
   - trigger: "::LEJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Leipzig/Halle Airport, Schkeuditz, DE (LEJ)"
 
   - trigger: "::GYE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "José Joaquín de Olmedo International Airport, Guayaquil, EC (GYE)"
 
   - trigger: "::EBB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Entebbe International Airport, Kampala, UG (EBB)"
 
   - trigger: "::TBS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tbilisi International Airport, Tbilisi, GE (TBS)"
 
   - trigger: "::FUK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Fukuoka Airport, Fukuoka, JP (FUK)"
 
   - trigger: "::LOS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Murtala Muhammed International Airport, Lagos, NG (LOS)"
 
   - trigger: "::HYD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Rajiv Gandhi International Airport, Hyderabad, IN (HYD)"
 
   - trigger: "::BRI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bari Karol Wojtyła Airport, Bari, IT (BRI)"
 
   - trigger: "::DLM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dalaman International Airport, Dalaman, TR (DLM)"
 
   - trigger: "::ZNZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Abeid Amani Karume International Airport, Zanzibar, TZ (ZNZ)"
 
   - trigger: "::RUH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Khaled International Airport, Riyadh, SA (RUH)"
 
   - trigger: "::GYD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Heydar Aliyev International Airport, Baku, AZ (GYD)"
 
   - trigger: "::DAR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Julius Nyerere International Airport, Dar es Salaam, TZ (DAR)"
 
   - trigger: "::DAC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hazrat Shahjalal International Airport, Dhaka, BD (DAC)"
 
   - trigger: "::CTS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "New Chitose Airport, Sapporo, JP (CTS)"
 
   - trigger: "::KMG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kunming Changshui International Airport, Kunming, CN (KMG)"
 
   - trigger: "::CUR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hato International Airport, Willemstad, CW (CUR)"
 
   - trigger: "::COK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cochin International Airport, Kochi, IN (COK)"
 
   - trigger: "::MRU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sir Seewoosagur Ramgoolam International Airport, Plaine Magnien, MU (MRU)"
 
   - trigger: "::VRA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Juan Gualberto Gomez International Airport, Matanzas, CU (VRA)"
 
   - trigger: "::SSA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Deputado Luiz Eduardo Magalhães International Airport, Salvador, BR (SSA)"
 
   - trigger: "::YXS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Prince George Airport, Prince George, CA (YXS)"
 
   - trigger: "::BJV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Milas Bodrum International Airport, Bodrum, TR (BJV)"
 
   - trigger: "::PPT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Faa'a International Airport, Papeete, PF (PPT)"
 
   - trigger: "::MID?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Manuel Crescencio Rejón, Ciudad de Mérida, MX (MID)"
 
   - trigger: "::LIR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Guanacaste Airport, Liberia, CR (LIR)"
 
   - trigger: "::UVF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hewanorra International Airport, Vieux Fort, LC (UVF)"
 
   - trigger: "::MBA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Moi International Airport, Mombasa, KE (MBA)"
 
   - trigger: "::SAL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Monseñor Óscar Arnulfo Romero International Airport, San Salvador (San Luis Talpa), SV (SAL)"
 
   - trigger: "::BZE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Philip S. W. Goldson International Airport, Belize City, BZ (BZE)"
 
   - trigger: "::RGN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Yangon International Airport, Yangon, MM (RGN)"
 
   - trigger: "::SUB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Juanda International Airport, Surabaya, ID (SUB)"
 
   - trigger: "::ALA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Almaty International Airport, Almaty, KZ (ALA)"
 
   - trigger: "::BOJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Burgas Airport, Burgas, BG (BOJ)"
 
   - trigger: "::GUM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Antonio B. Won Pat International Airport, Hagåtña, GU (GUM)"
 
   - trigger: "::KHI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jinnah International Airport, Karachi, PK (KHI)"
 
   - trigger: "::IKA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Imam Khomeini International Airport, Tehran, IR (IKA)"
 
   - trigger: "::SKP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Skopje International Airport, Ilinden, MK (SKP)"
 
   - trigger: "::SEZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Seychelles International Airport, Mahe Island, SC (SEZ)"
 
   - trigger: "::PDL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "João Paulo II Airport, Ponta Delgada, PT (PDL)"
 
   - trigger: "::OKA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Naha Airport / JASDF Naha Air Base, Naha, JP (OKA)"
 
   - trigger: "::BWN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Brunei International Airport, Bandar Seri Begawan, BN (BWN)"
 
   - trigger: "::PUS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gimhae International Airport, Busan, KR (PUS)"
 
   - trigger: "::MSQ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Minsk National Airport, Minsk, BY (MSQ)"
 
   - trigger: "::MFM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Macau International Airport, Nossa Senhora do Carmo, MO (MFM)"
 
   - trigger: "::FDF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Martinique Aimé Césaire International Airport, Fort-de-France, MQ (FDF)"
 
   - trigger: "::ALG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Houari Boumediene Airport, Algiers, DZ (ALG)"
 
   - trigger: "::ACA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Juan N. Álvarez, Ciudad de Acapulco, MX (ACA)"
 
   - trigger: "::TIJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Gral. Abelardo Rodriguez, Ciudad de Tijuana, MX (TIJ)"
 
   - trigger: "::KRT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Khartoum International Airport, Khartoum, SD (KRT)"
 
   - trigger: "::TIA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tirana International Airport Mother Teresa, Tirana, AL (TIA)"
 
   - trigger: "::CJU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jeju International Airport, Jeju City, KR (CJU)"
 
   - trigger: "::MZT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Gral. Rafael Buelna, Ciudad de Mazatlàn, MX (MZT)"
 
   - trigger: "::VVI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Viru Viru International Airport, Santa Cruz, BO (VVI)"
 
   - trigger: "::TRV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Thiruvananthapuram International Airport, Thiruvananthapuram, IN (TRV)"
 
   - trigger: "::WDH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hosea Kutako International Airport, Windhoek, NA (WDH)"
 
   - trigger: "::CZM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional de Cozumel, Ciudad de Cozumel, MX (CZM)"
 
   - trigger: "::PAP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Toussaint Louverture International Airport, Port-au-Prince, HT (PAP)"
 
   - trigger: "::TAS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tashkent International Airport, Tashkent, UZ (TAS)"
 
   - trigger: "::CNF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tancredo Neves International Airport, Belo Horizonte, BR (CNF)"
 
   - trigger: "::LUN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kenneth Kaunda International Airport, Lusaka, ZM (LUN)"
 
   - trigger: "::MAO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Eduardo Gomes International Airport, Manaus, BR (MAO)"
 
   - trigger: "::PTP?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Pointe-à-Pitre Le Raizet International Airport, Pointe-à-Pitre, GP (PTP)"
 
   - trigger: "::SHJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sharjah International Airport, Sharjah, AE (SHJ)"
 
   - trigger: "::BJX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Del Bajío, Ciudad de Silao, MX (BJX)"
 
   - trigger: "::XMN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Xiamen Gaoqi International Airport, Xiamen, CN (XMN)"
 
   - trigger: "::NGO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chubu Centrair International Airport, Tokoname, JP (NGO)"
 
   - trigger: "::NQZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nursultan Nazarbayev International Airport, Nur-Sultan, KZ (NQZ)"
 
   - trigger: "::TGD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Podgorica Airport / Podgorica Golubovci Airbase, Podgorica, ME (TGD)"
 
   - trigger: "::VAR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Varna Airport, Varna, BG (VAR)"
 
   - trigger: "::HGH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hangzhou Xiaoshan International Airport, Hangzhou, CN (HGH)"
 
   - trigger: "::CKG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chongqing Jiangbei International Airport, Chongqing, CN (CKG)"
 
   - trigger: "::FRU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Manas International Airport, Bishkek, KG (FRU)"
 
   - trigger: "::KWL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Guilin Liangjiang International Airport, Guilin (Lingui), CN (KWL)"
 
   - trigger: "::WUH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Wuhan Tianhe International Airport, Wuhan (Huangpi), CN (WUH)"
 
   - trigger: "::SID?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Amílcar Cabral International Airport, Espargos, CV (SID)"
 
   - trigger: "::HMO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "General Ignacio P. Garcia International Airport, Hermosillo, MX (HMO)"
 
   - trigger: "::KGL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kigali International Airport, Kigali, RW (KGL)"
 
   - trigger: "::LAD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Quatro de Fevereiro International Airport, Luanda, AO (LAD)"
 
   - trigger: "::KHH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kaohsiung International Airport, Kaohsiung (Xiaogang), TW (KHH)"
 
   - trigger: "::EVN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Zvartnots International Airport, Yerevan, AM (EVN)"
 
   - trigger: "::FLN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hercílio Luz International Airport, Florianópolis, BR (FLN)"
 
   - trigger: "::JIB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Djibouti-Ambouli Airport, Djibouti City, DJ (JIB)"
 
   - trigger: "::FIH?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ndjili International Airport, Kinshasa, CD (FIH)"
 
   - trigger: "::BDS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Brindisi Airport, Brindisi, IT (BDS)"
 
   - trigger: "::DUR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Shaka International Airport, Durban, ZA (DUR)"
 
   - trigger: "::UPG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hasanuddin International Airport, Ujung Pandang, ID (UPG)"
 
   - trigger: "::THR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mehrabad International Airport, Tehran, IR (THR)"
 
   - trigger: "::HRE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Robert Gabriel Mugabe International Airport, Harare, ZW (HRE)"
 
   - trigger: "::ADW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Joint Base Andrews, Camp Springs, US (ADW)"
 
   - trigger: "::ABV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nnamdi Azikiwe International Airport, Abuja, NG (ABV)"
 
   - trigger: "::MPM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Maputo Airport, Maputo, MZ (MPM)"
 
   - trigger: "::ASU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Silvio Pettirossi, Asunción, PY (ASU)"
 
   - trigger: "::DAM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Damascus International Airport, Damascus, SY (DAM)"
 
   - trigger: "::LHE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Allama Iqbal International Airport, Lahore, PK (LHE)"
 
   - trigger: "::RUN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Roland Garros Airport, Sainte-Marie, RE (RUN)"
 
   - trigger: "::BJL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Banjul International Airport, Banjul, GM (BJL)"
 
   - trigger: "::TLC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Adolfo López Mateos, Ciudad de Toluca, MX (TLC)"
 
   - trigger: "::TNR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ivato Airport, Antananarivo, MG (TNR)"
 
   - trigger: "::DLC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dalian Zhoushuizi International Airport, Ganjingzi, Dalian, CN (DLC)"
 
   - trigger: "::HRB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Harbin Taiping International Airport, Harbin, CN (HRB)"
 
   - trigger: "::DMM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Fahd International Airport, Ad Dammam, SA (DMM)"
 
   - trigger: "::MED?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Prince Mohammad Bin Abdulaziz Airport, Medina, SA (MED)"
 
   - trigger: "::POM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Port Moresby Jacksons International Airport, Port Moresby, PG (POM)"
 
   - trigger: "::KOJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kagoshima Airport, Kagoshima, JP (KOJ)"
 
   - trigger: "::BEL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Val de Cans/Júlio Cezar Ribeiro International Airport, Belém, BR (BEL)"
 
   - trigger: "::NDJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "N'Djamena International Airport, N'Djamena, TD (NDJ)"
 
   - trigger: "::DWC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Al Maktoum International Airport, Jebel Ali, AE (DWC)"
 
   - trigger: "::ROB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Roberts International Airport, Monrovia, LR (ROB)"
 
   - trigger: "::OVB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Novosibirsk Tolmachevo Airport, Novosibirsk, RU (OVB)"
 
   - trigger: "::DNA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kadena Air Base, , JP (DNA)"
 
   - trigger: "::SYZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shiraz Shahid Dastghaib International Airport, Shiraz, IR (SYZ)"
 
   - trigger: "::AER?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sochi International Airport, Sochi, RU (AER)"
 
   - trigger: "::TSN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Tianjin Binhai International Airport, Tianjin, CN (TSN)"
 
   - trigger: "::GBE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sir Seretse Khama International Airport, Gaborone, BW (GBE)"
 
   - trigger: "::VLI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Bauerfield International Airport, Port Vila, VU (VLI)"
 
   - trigger: "::MDL?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mandalay International Airport, Mandalay, MM (MDL)"
 
   - trigger: "::BON?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Flamingo International Airport, Kralendijk, Bonaire, BQ (BON)"
 
   - trigger: "::KNO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kualanamu International Airport, Medan, ID (KNO)"
 
   - trigger: "::NKG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nanjing Lukou International Airport, Nanjing, CN (NKG)"
 
   - trigger: "::VIX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Eurico de Aguiar Salles Airport, Vitória, BR (VIX)"
 
   - trigger: "::LWO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lviv International Airport, Lviv, UA (LWO)"
 
   - trigger: "::SVX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Koltsovo Airport, Yekaterinburg, RU (SVX)"
 
   - trigger: "::PBM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Johan Adolf Pengel International Airport, Zandery, SR (PBM)"
 
   - trigger: "::NIM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Diori Hamani International Airport, Niamey, NE (NIM)"
 
   - trigger: "::BGW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Baghdad International Airport / New Al Muthana Air Base, Baghdad, IQ (BGW)"
 
   - trigger: "::BKO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Modibo Keita International Airport, Bamako, ML (BKO)"
 
   - trigger: "::TNA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Jinan Yaoqiang International Airport, Jinan, CN (TNA)"
 
   - trigger: "::PKX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Beijing Daxing International Airport, Beijing, CN (PKX)"
 
   - trigger: "::BPS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Porto Seguro Airport, Porto Seguro, BR (BPS)"
 
   - trigger: "::OKO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Yokota Air Base, Fussa, JP (OKO)"
 
   - trigger: "::CGO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Zhengzhou Xinzheng International Airport, Zhengzhou, CN (CGO)"
 
   - trigger: "::DJJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Dortheys Hiyo Eluay International Airport, Sentani, ID (DJJ)"
 
   - trigger: "::VVO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Vladivostok International Airport, Artyom, RU (VVO)"
 
   - trigger: "::URC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ürümqi Diwopu International Airport, Ürümqi, CN (URC)"
 
   - trigger: "::ASB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ashgabat International Airport, Ashgabat, TM (ASB)"
 
   - trigger: "::SHE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Shenyang Taoxian International Airport, Hunnan, Shenyang, CN (SHE)"
 
   - trigger: "::FNA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lungi International Airport, Freetown (Lungi-Town), SL (FNA)"
 
   - trigger: "::JUB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Juba International Airport, Juba, SS (JUB)"
 
   - trigger: "::NGB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ningbo Lishe International Airport, Ningbo, CN (NGB)"
 
   - trigger: "::SYX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sanya Phoenix International Airport, Sanya (Tianya), CN (SYX)"
 
   - trigger: "::DVO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Francisco Bangoy International Airport, Davao, PH (DVO)"
 
   - trigger: "::MHD?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mashhad International Airport, Mashhad, IR (MHD)"
 
   - trigger: "::BPN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sultan Aji Muhammad Sulaiman Sepinggan International Airport, Balikpapan, ID (BPN)"
 
   - trigger: "::CAY?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Cayenne – Félix Eboué Airport, Matoury, GF (CAY)"
 
   - trigger: "::KUF?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kurumoch International Airport, Samara, RU (KUF)"
 
   - trigger: "::KZN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Kazan International Airport, Kazan, RU (KZN)"
 
   - trigger: "::LHW?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Lanzhou Zhongchuan International Airport, Lanzhou (Yongdeng), CN (LHW)"
 
   - trigger: "::FOC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Fuzhou Changle International Airport, Fuzhou, CN (FOC)"
 
   - trigger: "::SDJ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Sendai Airport, Natori, JP (SDJ)"
 
   - trigger: "::BLA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "General José Antonio Anzoategui International Airport, Barcelona, VE (BLA)"
 
   - trigger: "::TYN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Taiyuan Wusu Airport, Taiyuan, CN (TYN)"
 
   - trigger: "::DSS?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Blaise Diagne International Airport, Dakar, SN (DSS)"
 
   - trigger: "::HIR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Honiara International Airport, Honiara, SB (HIR)"
 
   - trigger: "::KJA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Krasnoyarsk International Airport, Krasnoyarsk, RU (KJA)"
 
   - trigger: "::ISB?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Islamabad International Airport, Attock, PK (ISB)"
 
   - trigger: "::UFA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ufa International Airport, Ufa, RU (UFA)"
 
   - trigger: "::HAK?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Haikou Meilan International Airport, Haikou (Meilan), CN (HAK)"
 
   - trigger: "::CGQ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Changchun Longjia International Airport, Changchun, CN (CGQ)"
 
   - trigger: "::NKC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nouakchott–Oumtounsy International Airport, Nouakchott, MR (NKC)"
 
   - trigger: "::GEA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nouméa Magenta Airport, Nouméa, NC (GEA)"
 
   - trigger: "::MJI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mitiga International Airport, Tripoli, LY (MJI)"
 
   - trigger: "::DGO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Gral, Guadalupe Victoria, Ciudad de Durango, MX (DGO)"
 
   - trigger: "::UBN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ulaanbaatar Chinggis Khaan International Airport, Ulaanbaatar (Sergelen), MN (UBN)"
 
   - trigger: "::DHA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Abdulaziz Air Base, Dhahran, SA (DHA)"
 
   - trigger: "::CSX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Changsha Huanghua International Airport, Changsha (Changsha), CN (CSX)"
 
   - trigger: "::AGT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Guaraní, Ciudad del Este, PY (AGT)"
 
   - trigger: "::ETM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ramon International Airport, Eilat, IL (ETM)"
 
   - trigger: "::HET?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hohhot Baita International Airport, Hohhot, CN (HET)"
 
   - trigger: "::WNZ?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Wenzhou Longwan International Airport, Wenzhou, CN (WNZ)"
 
   - trigger: "::KWE?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Guiyang Longdongbao International Airport, Guiyang (Nanming), CN (KWE)"
 
   - trigger: "::TAO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Qingdao Jiaodong International Airport, Jiaozhou, Qingdao, CN (TAO)"
 
   - trigger: "::KHN?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nanchang Changbei International Airport, Nanchang, CN (KHN)"
 
   - trigger: "::YNT?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Yantai Penglai International Airport, Yantai, CN (YNT)"
 
   - trigger: "::NNG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Nanning Wuxu Airport, Nanning (Jiangnan), CN (NNG)"
 
   - trigger: "::DQM?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Duqm International Airport, Duqm, OM (DQM)"
 
   - trigger: "::NLU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional General Felipe Ángeles, Mexico City, MX (NLU)"
 
   - trigger: "::SHO?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "King Mswati III International Airport, Mpaka, SZ (SHO)"
 
   - trigger: "::ROV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Platov International Airport, Rostov-on-Don, RU (ROV)"
 
   - trigger: "::HSA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Hazrat Sultan International Airport, , KZ (HSA)"
 
   - trigger: "::HRI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Mattala Rajapaksa International Airport, , LK (HRI)"
 
   - trigger: "::TFU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Chengdu Tianfu International Airport, Chengdu (Jianyang), CN (TFU)"
 
   - trigger: "::ZIA?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Zhukovsky International Airport, Moscow, RU (ZIA)"
 
   - trigger: "::MWX?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Muan International Airport, Piseo-ri (Muan), KR (MWX)"
 
   - trigger: "::ESG?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Dr. Luis Maria Argaña, Mariscal Estigarribia, PY (ESG)"
 
   - trigger: "::EHU?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Ezhou Huahu Airport, Ezhou, CN (EHU)"
 
   - trigger: "::GSV?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Gagarin International Airport, Saratov, RU (GSV)"
 
   - trigger: "::SAI?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Siem Reap-Angkor International Airport, Siem Reap, KH (SAI)"
 
   - trigger: "::PJC?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Aeropuerto Internacional Dr. Augusto Roberto Fuster, Pedro Juan Caballero, PY (PJC)"
 
   - trigger: "::HSR?"
-    label: "Provide the full airport name and data based on IATA's three-letter airport codes"
     replace: "Rajkot International Airport, Rajkot, IN (HSR)"
 
   # Provide airline name based on IATA's two-character designators
   - trigger: "::1T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "1Time Airline (1T), ZA"
 
   - trigger: "::Q5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "40-Mile Air (Q5), US"
 
   - trigger: "::AN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ansett Australia (AN), AU"
 
   - trigger: "::1B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Abacus International (1B), SG"
 
   - trigger: "::W9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Abelag Aviation (W9), BE"
 
   - trigger: "::ZI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aigle Azur (ZI), FR"
 
   - trigger: "::AQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aloha Airlines (AQ), US"
 
   - trigger: "::AA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "American Airlines (AA), US"
 
   - trigger: "::OZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Asiana Airlines (OZ), KR"
 
   - trigger: "::4K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Askari Aviation (4K), PK"
 
   - trigger: "::8U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Afriqiyah Airways (8U), LY"
 
   - trigger: "::Q9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Afrinat International Airlines (Q9), GM"
 
   - trigger: "::G4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Allegiant Air (G4), US"
 
   - trigger: "::K5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aban Air (K5), IR"
 
   - trigger: "::M3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ABSA - Aerolinhas Brasileiras (M3), BR"
 
   - trigger: "::O4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Antrak Air (O4), GH"
 
   - trigger: "::GB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airborne Express (GB), US"
 
   - trigger: "::8V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Astral Aviation (8V), KE"
 
   - trigger: "::E4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Asia International (E4), PK"
 
   - trigger: "::YT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Togo (YT), TG"
 
   - trigger: "::4G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Advance Leasing Company (4G), US"
 
   - trigger: "::7A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aztec Worldwide Airlines (7A), US"
 
   - trigger: "::8T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Tindi (8T), CA"
 
   - trigger: "::ZY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ada Air (ZY), AL"
 
   - trigger: "::Z7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ADC Airlines (Z7), NG"
 
   - trigger: "::JP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Adria Airways (JP), SI"
 
   - trigger: "::UX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Europa (UX), ES"
 
   - trigger: "::EM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Benin (EM), BJ"
 
   - trigger: "::A3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aegean Airlines (A3), GR"
 
   - trigger: "::KI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Atlantique (KI), GB"
 
   - trigger: "::PE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Europe (PE), IT"
 
   - trigger: "::KO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alaska Central Express (KO), US"
 
   - trigger: "::5W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Astraeus (5W), GB"
 
   - trigger: "::VV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerosvit Airlines (VV), UA"
 
   - trigger: "::I9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Italy (I9), IT"
 
   - trigger: "::WK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "American Falcon (WK), AR"
 
   - trigger: "::QQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alliance Airlines (QQ), AU"
 
   - trigger: "::FG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ariana Afghan Airlines (FG), AF"
 
   - trigger: "::SU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroflot Russian Airlines (SU), RU"
 
   - trigger: "::JA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Bosna (JA), BA"
 
   - trigger: "::AF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air France (AF), FR"
 
   - trigger: "::SB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Caledonie International (SB), FR"
 
   - trigger: "::GN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Gabon (GN), GA"
 
   - trigger: "::2O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Salone (2O), SL"
 
   - trigger: "::2Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Cargo Carriers (2Q), US"
 
   - trigger: "::V7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Senegal International (V7), SN"
 
   - trigger: "::SW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Namibia (SW), NA"
 
   - trigger: "::5D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerolitoral (5D), MX"
 
   - trigger: "::1A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Amadeus Global Travel Distribution (1A), ES"
 
   - trigger: "::7T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Glaciers (7T), CH"
 
   - trigger: "::PL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroper (PL), PE"
 
   - trigger: "::8A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlas Blue (8A), MA"
 
   - trigger: "::GD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Alpha Greenland (GD), DK"
 
   - trigger: "::LD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Hong Kong (LD), HK"
 
   - trigger: "::HT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeromist-Kharkiv (HT), UA"
 
   - trigger: "::J2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Azerbaijan Airlines (J2), AZ"
 
   - trigger: "::U3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avies (U3), EE"
 
   - trigger: "::AP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airbus Industrie (AP), FR"
 
   - trigger: "::5A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alpine Air Express (5A), US"
 
   - trigger: "::ED?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airblue (ED), PK"
 
   - trigger: "::AB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Berlin (AB), DE"
 
   - trigger: "::AG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Contractors (AG), IE"
 
   - trigger: "::AI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air India Limited (AI), IN"
 
   - trigger: "::ZB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Bourbon (ZB), FR"
 
   - trigger: "::CC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Atlanta Icelandic (CC), IS"
 
   - trigger: "::RB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Srpska (RB), BA"
 
   - trigger: "::TN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Tahiti Nui (TN), FR"
 
   - trigger: "::W4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Services Executive (W4), FR"
 
   - trigger: "::IZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arkia Israel Airlines (IZ), IL"
 
   - trigger: "::JM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Jamaica (JM), JM"
 
   - trigger: "::AP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air One (AP), IT"
 
   - trigger: "::S2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Sahara (S2), IN"
 
   - trigger: "::KM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Malta (KM), MT"
 
   - trigger: "::M6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Amerijet International (M6), US"
 
   - trigger: "::NQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Japan (NQ), JP"
 
   - trigger: "::4A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Kiribati (4A), KI"
 
   - trigger: "::EH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Nippon Network Co. Ltd. (EH), JP"
 
   - trigger: "::HP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "America West Airlines (HP), US"
 
   - trigger: "::ZW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Wisconsin (ZW), US"
 
   - trigger: "::U9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tatarstan Airlines (U9), RU"
 
   - trigger: "::VD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Libert (VD), FR"
 
   - trigger: "::TT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Lithuania (TT), LT"
 
   - trigger: "::QM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Malawi (QM), MW"
 
   - trigger: "::BM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Sicilia (BM), IT"
 
   - trigger: "::NX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Macau (NX), MO"
 
   - trigger: "::ZV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Midwest (ZV), US"
 
   - trigger: "::HM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Seychelles (HM), SC"
 
   - trigger: "::AM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AeroMéxico (AM), MX"
 
   - trigger: "::NH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Nippon Airways (NH), JP"
 
   - trigger: "::YW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Nostrum (YW), ES"
 
   - trigger: "::PX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Niugini (PX), PG"
 
   - trigger: "::G9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Arabia (G9), AE"
 
   - trigger: "::AC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Canada (AC), CA"
 
   - trigger: "::BT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Baltic (BT), LV"
 
   - trigger: "::EL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Nippon (EL), JP"
 
   - trigger: "::TL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airnorth (TL), AU"
 
   - trigger: "::4N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air North Charter - Canada (4N), CA"
 
   - trigger: "::IW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AOM French Airlines (IW), FR"
 
   - trigger: "::NZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air New Zealand (NZ), NZ"
 
   - trigger: "::J6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AVCOM (J6), RU"
 
   - trigger: "::2D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero VIP (2D), AR"
 
   - trigger: "::6V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Vegas (6V), US"
 
   - trigger: "::XM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alitalia Express (XM), IT"
 
   - trigger: "::OE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly One Airlines S.R.L. (OE), RO"
 
   - trigger: "::GV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Flight (GV), DE"
 
   - trigger: "::JW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arrow Air (JW), US"
 
   - trigger: "::W3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arik Air (W3), NG"
 
   - trigger: "::2B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerocondor (2B), PT"
 
   - trigger: "::4C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LATAM Airlines Colombia (4C), CO"
 
   - trigger: "::AR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerolineas Argentinas (AR), AR"
 
   - trigger: "::QN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Armenia (QN), AM"
 
   - trigger: "::AS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alaska Airlines (AS), US"
 
   - trigger: "::4D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Sinai (4D), EG"
 
   - trigger: "::PL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airstars (PL), RU"
 
   - trigger: "::EV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlantic Southeast Airlines (EV), US"
 
   - trigger: "::OB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Astrakhan Airlines (OB), RU"
 
   - trigger: "::TC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Tanzania (TC), TZ"
 
   - trigger: "::2J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Burkina (2J), BF"
 
   - trigger: "::HC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero-Tropics Air Services (HC), AU"
 
   - trigger: "::FO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airlines Of Tasmania (FO), AU"
 
   - trigger: "::PJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Saint Pierre (PJ), FR"
 
   - trigger: "::8C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Transport International (8C), US"
 
   - trigger: "::OS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Austrian Airlines (OS), AT"
 
   - trigger: "::IQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Augsburg Airways (IQ), DE"
 
   - trigger: "::RU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirBridge Cargo (RU), RU"
 
   - trigger: "::MO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Abu Dhabi Amiri Flight (MO), AE"
 
   - trigger: "::5N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroflot-Nord (5N), RU"
 
   - trigger: "::GR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aurigny Air Services (GR), GB"
 
   - trigger: "::NO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aus-Air (NO), AU"
 
   - trigger: "::AU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Austral Lineas Aereas (AU), AR"
 
   - trigger: "::AO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Australian Airlines (AO), AU"
 
   - trigger: "::AV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avianca - Aerovias Nacionales de Colombia (AV), CO"
 
   - trigger: "::NF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Vanuatu (NF), VU"
 
   - trigger: "::K8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airlink Zambia (K8), ZM"
 
   - trigger: "::B9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Bangladesh (B9), BD"
 
   - trigger: "::DR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mediterranee (DR), FR"
 
   - trigger: "::7E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroline GmbH (7E), DE"
 
   - trigger: "::6G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Wales (6G), GB"
 
   - trigger: "::TX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Caraïbes (TX), FR"
 
   - trigger: "::IX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air India Express (IX), IN"
 
   - trigger: "::HJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Asian Express Airlines (HJ), AU"
 
   - trigger: "::XT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Exel (XT), NL"
 
   - trigger: "::AK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirAsia (AK), MY"
 
   - trigger: "::6V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Axis Airways (6V), FR"
 
   - trigger: "::3G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlant-Soyuz Airlines (3G), RU"
 
   - trigger: "::AZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alitalia (AZ), IT"
 
   - trigger: "::ZE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arcus-Air Logistic (ZE), DE"
 
   - trigger: "::Z8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Amaszonas (Z8), BO"
 
   - trigger: "::UM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Zimbabwe (UM), ZW"
 
   - trigger: "::R7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aserca Airlines (R7), VE"
 
   - trigger: "::FV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rossiya-Russian Airlines (FV), RU"
 
   - trigger: "::RX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aviaexpress (RX), HU"
 
   - trigger: "::MQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "American Eagle Airlines (MQ), US"
 
   - trigger: "::FF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airshop (FF), NL"
 
   - trigger: "::ML?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "African Transport Trading and Investment Company (ML), SD"
 
   - trigger: "::VU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Ivoire (VU), CI"
 
   - trigger: "::BP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Botswana (BP), BW"
 
   - trigger: "::GS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Foyle (GS), GB"
 
   - trigger: "::VT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Tahiti (VT), FR"
 
   - trigger: "::3N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Urga (3N), UA"
 
   - trigger: "::VL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air VIA (VL), BG"
 
   - trigger: "::FK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Africa West (FK), TG"
 
   - trigger: "::G2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avirex (G2), GA"
 
   - trigger: "::V8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ATRAN Cargo Airlines (V8), RU"
 
   - trigger: "::VE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avensa (VE), VE"
 
   - trigger: "::V5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avolar Aerolineas (V5), MX"
 
   - trigger: "::CA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air China (CA), CN"
 
   - trigger: "::Q6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Condor Peru (Q6), PE"
 
   - trigger: "::5F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arctic Circle Air Service (5F), US"
 
   - trigger: "::QC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Corridor (QC), MZ"
 
   - trigger: "::NV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Central (NV), JP"
 
   - trigger: "::CV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Chathams (CV), NZ"
 
   - trigger: "::CW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Marshall Islands (CW), MH"
 
   - trigger: "::ZA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Access Air (ZA), US"
 
   - trigger: "::AH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Algerie (AH), DZ"
 
   - trigger: "::KI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Adam Air (KI), ID"
 
   - trigger: "::ER?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Astar Air Cargo (ER), US"
 
   - trigger: "::HO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Antinea Airlines (HO), DZ"
 
   - trigger: "::EN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Dolomiti (EN), IT"
 
   - trigger: "::D9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroflot-Don (D9), RU"
 
   - trigger: "::NM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Madrid (NM), ES"
 
   - trigger: "::EE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Airlines (EE), EE"
 
   - trigger: "::4F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air City (4F), DE"
 
   - trigger: "::EI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aer Lingus (EI), IE"
 
   - trigger: "::E8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alpi Eagles (E8), IT"
 
   - trigger: "::KY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air S (KY), ST"
 
   - trigger: "::PC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Fiji (PC), FJ"
 
   - trigger: "::OF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Finland (OF), FI"
 
   - trigger: "::FJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Pacific (FJ), FJ"
 
   - trigger: "::RC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlantic Airways (RC), FO"
 
   - trigger: "::QH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Florida (QH), US"
 
   - trigger: "::NY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Iceland (NY), IS"
 
   - trigger: "::2P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Philippines (2P), PH"
 
   - trigger: "::ZX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Georgian (ZX), CA"
 
   - trigger: "::2U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Guinee Express (2U), GN"
 
   - trigger: "::0A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Amber Air (0A), LT"
 
   - trigger: "::DA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Georgia (DA), GE"
 
   - trigger: "::GL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Greenland (GL), DK"
 
   - trigger: "::LL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Allegro (LL), MX"
 
   - trigger: "::5Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlas Air (5Y), US"
 
   - trigger: "::GG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Guyane (GG), FR"
 
   - trigger: "::H9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air D'Ayiti (H9), HT"
 
   - trigger: "::GG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Comores International (GG), KM"
 
   - trigger: "::8C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Horizon (8C), TG"
 
   - trigger: "::W9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Bagan (W9), MM"
 
   - trigger: "::IP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atyrau Air Ways (IP), KZ"
 
   - trigger: "::QK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Canada Jazz (QK), CA"
 
   - trigger: "::KK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlasjet (KK), TR"
 
   - trigger: "::JS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Koryo (JS), KP"
 
   - trigger: "::KC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Astana (KC), KZ"
 
   - trigger: "::LV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Albanian Airlines (LV), AL"
 
   - trigger: "::D4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alidaunia (D4), IT"
 
   - trigger: "::CD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alliance Air (CD), IN"
 
   - trigger: "::XL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerolane (XL), EC"
 
   - trigger: "::A6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Alps Aviation (A6), AT"
 
   - trigger: "::TD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlantis European Airways (TD), AM"
 
   - trigger: "::L8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Luxor GB (L8), GW"
 
   - trigger: "::LK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Luxor (LK), PT"
 
   - trigger: "::MK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mauritius (MK), MU"
 
   - trigger: "::MD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Madagascar (MD), MG"
 
   - trigger: "::9U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Moldova (9U), MD"
 
   - trigger: "::M0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Mongolia (M0), MN"
 
   - trigger: "::A7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Plus Comet (A7), ES"
 
   - trigger: "::QO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeromexpress (QO), MX"
 
   - trigger: "::MR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mauritanie (MR), MR"
 
   - trigger: "::3S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeroland Airways (3S), GR"
 
   - trigger: "::8D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Astair (8D), RU"
 
   - trigger: "::F4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Albarka Air (F4), NG"
 
   - trigger: "::AJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Contractors (AJ), NG"
 
   - trigger: "::8Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Burundi (8Y), BI"
 
   - trigger: "::OT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeropelican Air Services (OT), AU"
 
   - trigger: "::AD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Paradise International (AD), ID"
 
   - trigger: "::QD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Class Lineas Aereas (QD), UY"
 
   - trigger: "::QS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "African Safari Airways (QS), KE"
 
   - trigger: "::4Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airbus France (4Y), FR"
 
   - trigger: "::MC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mobility Command (MC), US"
 
   - trigger: "::RE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aer Arann (RE), IE"
 
   - trigger: "::UU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Austral (UU), FR"
 
   - trigger: "::6K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Asian Spirit (6K), PH"
 
   - trigger: "::RK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Afrique (RK), CI"
 
   - trigger: "::A5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airlinair (A5), FR"
 
   - trigger: "::QL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Lanka (QL), LK"
 
   - trigger: "::MV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Armenian International Airways (MV), AM"
 
   - trigger: "::20?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Salone (20), SL"
 
   - trigger: "::U8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Armavia (U8), AM"
 
   - trigger: "::BQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeromar (BQ), DO"
 
   - trigger: "::P5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AeroRep (P5), CO"
 
   - trigger: "::BF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero-Service (BF), CG"
 
   - trigger: "::5L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerosur (5L), BO"
 
   - trigger: "::EX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Santo Domingo (EX), DO"
 
   - trigger: "::JR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero California (JR), MX"
 
   - trigger: "::Z3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avient Aviation (Z3), ZW"
 
   - trigger: "::M3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Service (M3), MK"
 
   - trigger: "::GM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Slovakia (GM), SK"
 
   - trigger: "::R3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aircompany Yakutia (R3), RU"
 
   - trigger: "::VW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aeromar (VW), MX"
 
   - trigger: "::JY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Turks and Caicos (JY), TC"
 
   - trigger: "::OR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arkefly (OR), NL"
 
   - trigger: "::CG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airlines PNG (CG), PG"
 
   - trigger: "::TY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Cal (TY), FR"
 
   - trigger: "::FL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirTran Airways (FL), US"
 
   - trigger: "::TS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Transat (TS), CA"
 
   - trigger: "::EC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Avialeasing Aviation Company (EC), UZ"
 
   - trigger: "::VO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tyrolean Airways (VO), AT"
 
   - trigger: "::DW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero-Charter Ukraine (DW), UA"
 
   - trigger: "::6U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Ukraine (6U), UA"
 
   - trigger: "::2K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerolineas Galapagos (Aerogal) (2K), EC"
 
   - trigger: "::6R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alrosa Mirny Air Enterprise (6R), RU"
 
   - trigger: "::8Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Baker Aviation (8Q), US"
 
   - trigger: "::BA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "British Airways (BA), GB"
 
   - trigger: "::BG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Biman Bangladesh Airlines (BG), BD"
 
   - trigger: "::BF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bluebird Cargo (BF), IS"
 
   - trigger: "::B4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BACH Flugbetriebsges (B4), AT"
 
   - trigger: "::BZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue Dart Aviation (BZ), IN"
 
   - trigger: "::JA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "B&H Airlines (JA), BA"
 
   - trigger: "::J4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Buffalo Airways (J4), CA"
 
   - trigger: "::A8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Benin Golf Air (A8), BJ"
 
   - trigger: "::4T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Belair Airlines (4T), CH"
 
   - trigger: "::UP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bahamasair (UP), BS"
 
   - trigger: "::E6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bringer Air Cargo Taxi Aereo (E6), BR"
 
   - trigger: "::TH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BA Connect (TH), GB"
 
   - trigger: "::BS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "British International Helicopters (BS), GB"
 
   - trigger: "::B4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bankair (B4), US"
 
   - trigger: "::PG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bangkok Airways (PG), TH"
 
   - trigger: "::KF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue1 (KF), FI"
 
   - trigger: "::JV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bearskin Lake Air Service (JV), CA"
 
   - trigger: "::B3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bellview Airlines (B3), NG"
 
   - trigger: "::BD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "bmi (BD), GB"
 
   - trigger: "::WW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "bmibaby (WW), GB"
 
   - trigger: "::CH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bemidji Airlines (CH), US"
 
   - trigger: "::5Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bismillah Airlines (5Z), BD"
 
   - trigger: "::BO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bouraq Indonesia Airlines (BO), ID"
 
   - trigger: "::BV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue Panorama Airlines (BV), IT"
 
   - trigger: "::7R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BRA-Transportes Aereos (7R), BR"
 
   - trigger: "::8E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bering Air (8E), US"
 
   - trigger: "::B2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Belavia Belarusian Airlines (B2), BY"
 
   - trigger: "::K6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bravo Air Congo (K6), CD"
 
   - trigger: "::BN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Braniff International Airways (BN), US"
 
   - trigger: "::GQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Big Sky Airlines (GQ), US"
 
   - trigger: "::V9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BAL Bashkirian Airlines (V9), RU"
 
   - trigger: "::7P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Metro Batavia (7P), ID"
 
   - trigger: "::J8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Berjaya Air (J8), MY"
 
   - trigger: "::QW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue Wings (QW), DE"
 
   - trigger: "::BM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bayu Indonesia Air (BM), ID"
 
   - trigger: "::DB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Brit Air (DB), FR"
 
   - trigger: "::E9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Boston-Maine Airways (E9), US"
 
   - trigger: "::SN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Brussels Airlines (SN), BE"
 
   - trigger: "::NT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Binter Canarias (NT), ES"
 
   - trigger: "::0B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue Air (0B), RO"
 
   - trigger: "::KJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "British Mediterranean Airways (KJ), GB"
 
   - trigger: "::FB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bulgaria Air (FB), BG"
 
   - trigger: "::8N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Barents AirLink (8N), SE"
 
   - trigger: "::5C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CAL Cargo Air Lines (5C), IL"
 
   - trigger: "::AW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CHC Airways (AW), NL"
 
   - trigger: "::XG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Calima Aviacion (XG), ES"
 
   - trigger: "::MO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Calm Air (MO), CA"
 
   - trigger: "::R9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Camai Air (R9), US"
 
   - trigger: "::UY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cameroon Airlines (UY), CM"
 
   - trigger: "::C6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CanJet (C6), CA"
 
   - trigger: "::CP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Canadian Airlines (CP), CA"
 
   - trigger: "::5T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Canadian North (5T), CA"
 
   - trigger: "::W2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Canadian Western Airlines (W2), CA"
 
   - trigger: "::9K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cape Air (9K), US"
 
   - trigger: "::PT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Capital Cargo International Airlines (PT), US"
 
   - trigger: "::GG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cargo 360 (GG), US"
 
   - trigger: "::2G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cargoitalia (2G), IT"
 
   - trigger: "::W8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cargojet Airways (W8), CA"
 
   - trigger: "::CV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cargolux (CV), LU"
 
   - trigger: "::BW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Caribbean Airlines (BW), TT"
 
   - trigger: "::8B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Caribbean Star Airlines (8B), AG"
 
   - trigger: "::V3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Carpatair (V3), RO"
 
   - trigger: "::RV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Caspian Airlines (RV), IR"
 
   - trigger: "::CX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cathay Pacific (CX), HK"
 
   - trigger: "::KX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cayman Airways (KX), KY"
 
   - trigger: "::5J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cebu Pacific (5J), PH"
 
   - trigger: "::7N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Centavia (7N), RS"
 
   - trigger: "::C0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Centralwings (C0), PL"
 
   - trigger: "::J7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Centre-Avia (J7), RU"
 
   - trigger: "::WE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Centurion Air Cargo (WE), US"
 
   - trigger: "::OP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chalk's Ocean Airways (OP), US"
 
   - trigger: "::MG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Champion Air (MG), US"
 
   - trigger: "::2Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Changan Airlines (2Z), CN"
 
   - trigger: "::S8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chari Aviation Services (S8), TD"
 
   - trigger: "::RP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chautauqua Airlines (RP), US"
 
   - trigger: "::C8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chicago Express (C8), US"
 
   - trigger: "::CI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Airlines (CI), TW"
 
   - trigger: "::CK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Cargo Airlines (CK), CN"
 
   - trigger: "::MU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Eastern Airlines (MU), CN"
 
   - trigger: "::CJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Northern Airlines (CJ), CN"
 
   - trigger: "::WH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Northwest Airlines (WH), CN"
 
   - trigger: "::8Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Postal Airlines (8Y), CN"
 
   - trigger: "::CZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Southern Airlines (CZ), CN"
 
   - trigger: "::HR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China United Airlines (HR), CN"
 
   - trigger: "::XO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Xinhua Airlines (XO), CN"
 
   - trigger: "::3Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yunnan Airlines (3Q), CN"
 
   - trigger: "::X7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chitaavia (X7), RU"
 
   - trigger: "::A2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cielos Airlines (A2), PE"
 
   - trigger: "::QI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cimber Air (QI), DK"
 
   - trigger: "::C9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cirrus Airlines (C9), DE"
 
   - trigger: "::CF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "City Airline (CF), SE"
 
   - trigger: "::G3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "City Connexion Airlines (G3), BI"
 
   - trigger: "::WX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CityJet (WX), IE"
 
   - trigger: "::CJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BA CityFlyer (CJ), GB"
 
   - trigger: "::CT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Civil Air Transport (CT), TW"
 
   - trigger: "::6P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Club Air (6P), IT"
 
   - trigger: "::BX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Coast Air (BX), NO"
 
   - trigger: "::DQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Coastal Air (DQ), US"
 
   - trigger: "::9L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Colgan Air (9L), US"
 
   - trigger: "::OH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Comair (OH), US"
 
   - trigger: "::MN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Comair (MN), ZA"
 
   - trigger: "::C5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CommutAir (C5), US"
 
   - trigger: "::KR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Comores Airlines (KR), KM"
 
   - trigger: "::GJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Compania Mexicargo (GJ), MX"
 
   - trigger: "::CP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Compass Airlines (CP), US"
 
   - trigger: "::DE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Condor Flugdienst (DE), DE"
 
   - trigger: "::6A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Consorcio Aviaxsa (6A), MX"
 
   - trigger: "::C3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Contact Air (C3), DE"
 
   - trigger: "::CO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Continental Airlines (CO), US"
 
   - trigger: "::PC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Continental Airways (PC), RU"
 
   - trigger: "::CO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Continental Express (CO), US"
 
   - trigger: "::CS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Continental Micronesia (CS), US"
 
   - trigger: "::V0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Conviasa (V0), VE"
 
   - trigger: "::CM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Copa Airlines (CM), PA"
 
   - trigger: "::SS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Corsairfly (SS), FR"
 
   - trigger: "::XK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Corse-Mediterranee (XK), FR"
 
   - trigger: "::OU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Croatia Airlines (OU), HR"
 
   - trigger: "::QE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Crossair Europe (QE), CH"
 
   - trigger: "::CU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cubana de Aviación (CU), CU"
 
   - trigger: "::CY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cyprus Airways (CY), CY"
 
   - trigger: "::YK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cyprus Turkish Airlines (YK), TR"
 
   - trigger: "::OK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Czech Airlines (OK), CZ"
 
   - trigger: "::WD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "DAS Air Cargo (WD), UG"
 
   - trigger: "::DX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "DAT Danish Air Transport (DX), DK"
 
   - trigger: "::ES?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "DHL International (ES), BH"
 
   - trigger: "::L3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "DHL de Guatemala (L3), GT"
 
   - trigger: "::D3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Daallo Airlines (D3), DJ"
 
   - trigger: "::N2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dagestan Airlines (N2), RU"
 
   - trigger: "::H8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dalavia (H8), RU"
 
   - trigger: "::0D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Darwin Airline (0D), CH"
 
   - trigger: "::D5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dauair (D5), DE"
 
   - trigger: "::DL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Delta Air Lines (DL), US"
 
   - trigger: "::2A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Deutsche Bahn (2A), DE"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Deutsche Rettungsflugwacht (1I), DE"
 
   - trigger: "::D7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dinar (D7), AR"
 
   - trigger: "::AW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dirgantara Air Service (AW), ID"
 
   - trigger: "::DH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Discovery Airways (DH), US"
 
   - trigger: "::D8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Djibouti Airlines (D8), DJ"
 
   - trigger: "::DO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dominicana de Aviaci (DO), DO"
 
   - trigger: "::E3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Domodedovo Airlines (E3), RU"
 
   - trigger: "::KA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dragonair (KA), HK"
 
   - trigger: "::KB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Druk Air (KB), BT"
 
   - trigger: "::DI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "dba (DI), DE"
 
   - trigger: "::1C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Electronic Data Systems (1C), CH"
 
   - trigger: "::VE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "EUjet (VE), IE"
 
   - trigger: "::BR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "EVA Air (BR), TW"
 
   - trigger: "::H7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eagle Air (H7), UG"
 
   - trigger: "::QU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "East African (QU), UG"
 
   - trigger: "::S9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "East African Safari Air (S9), KE"
 
   - trigger: "::T3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eastern Airways (T3), GB"
 
   - trigger: "::DK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eastland Air (DK), AU"
 
   - trigger: "::W9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eastwind Airlines (W9), US"
 
   - trigger: "::WK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Edelweiss Air (WK), CH"
 
   - trigger: "::MS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Egyptair (MS), EG"
 
   - trigger: "::LY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "El Al Israel Airlines (LY), IL"
 
   - trigger: "::UZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "El-Buraq Air Transport (UZ), LY"
 
   - trigger: "::EK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Emirates (EK), AE"
 
   - trigger: "::EM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Empire Airlines (EM), US"
 
   - trigger: "::EU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Empresa Ecuatoriana De Aviacion (EU), EC"
 
   - trigger: "::E0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eos Airlines (E0), US"
 
   - trigger: "::B8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eritrean Airlines (B8), ER"
 
   - trigger: "::E7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Estafeta Carga Aerea (E7), MX"
 
   - trigger: "::OV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Estonian Air (OV), EE"
 
   - trigger: "::ET?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ethiopian Airlines (ET), ET"
 
   - trigger: "::EY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Etihad Airways (EY), AE"
 
   - trigger: "::RZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Euro Exec Express (RZ), SE"
 
   - trigger: "::UI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eurocypria Airlines (UI), CY"
 
   - trigger: "::GJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eurofly Service (GJ), IT"
 
   - trigger: "::K2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eurolot (K2), PL"
 
   - trigger: "::3W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Euromanx Airways (3W), AT"
 
   - trigger: "::EA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "European Air Express (EA), DE"
 
   - trigger: "::QY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "European Air Transport (QY), BE"
 
   - trigger: "::E7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "European Aviation Air Charter (E7), GB"
 
   - trigger: "::EW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eurowings (EW), DE"
 
   - trigger: "::EZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Evergreen International Airlines (EZ), US"
 
   - trigger: "::JN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Excel Airways (JN), GB"
 
   - trigger: "::MB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Execair Aviation (MB), CA"
 
   - trigger: "::OW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Executive Airlines (OW), US"
 
   - trigger: "::8D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Expo Aviation (8D), LK"
 
   - trigger: "::EO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Express One International (EO), US"
 
   - trigger: "::XE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ExpressJet (XE), US"
 
   - trigger: "::U2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "easyJet (U2), GB"
 
   - trigger: "::IH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Falcon Aviation (IH), SE"
 
   - trigger: "::EF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Far Eastern Air Transport (EF), TW"
 
   - trigger: "::F6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Faroejet (F6), FO"
 
   - trigger: "::F3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Faso Airways (F3), BF"
 
   - trigger: "::FX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Federal Express (FX), US"
 
   - trigger: "::N8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fika Salaama Airlines (N8), UG"
 
   - trigger: "::4S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Finalair Congo (4S), CG"
 
   - trigger: "::AY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Finnair (AY), FI"
 
   - trigger: "::FC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Finncomm Airlines (FC), FI"
 
   - trigger: "::FY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Firefly (FY), MY"
 
   - trigger: "::7F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "First Air (7F), CA"
 
   - trigger: "::DP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "First Choice Airways (DP), GB"
 
   - trigger: "::8F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fischer Air (8F), CZ"
 
   - trigger: "::B5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flightline (B5), GB"
 
   - trigger: "::PA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Florida Coastal Airlines (PA), US"
 
   - trigger: "::RF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Florida West International Airways (RF), US"
 
   - trigger: "::F2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Air (F2), TR"
 
   - trigger: "::SH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Me Sweden (SH), SE"
 
   - trigger: "::D7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirAsia X (D7), MY"
 
   - trigger: "::TE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FlyLal (TE), LT"
 
   - trigger: "::LF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FlyNordic (LF), SE"
 
   - trigger: "::F7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flybaboo (F7), CH"
 
   - trigger: "::BE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flybe (BE), GB"
 
   - trigger: "::B4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flyglobespan (B4), GB"
 
   - trigger: "::VY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Formosa Airlines (VY), TW"
 
   - trigger: "::BN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Forward Air International Airlines (BN), US"
 
   - trigger: "::HK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Four Star Aviation / Four Star Cargo (HK), US"
 
   - trigger: "::FP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Freedom Air (FP), US"
 
   - trigger: "::F9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Frontier Airlines (F9), US"
 
   - trigger: "::2F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Frontier Flying Service (2F), US"
 
   - trigger: "::FH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Futura International Airways (FH), ES"
 
   - trigger: "::GT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "GB Airways (GT), GB"
 
   - trigger: "::7O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Galaxy Air (7O), KG"
 
   - trigger: "::1G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Galileo International (1G), US"
 
   - trigger: "::GC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gambia International Airlines (GC), GM"
 
   - trigger: "::G7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gandalf Airlines (G7), IT"
 
   - trigger: "::GA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Garuda Indonesia (GA), ID"
 
   - trigger: "::4G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gazpromavia (4G), RU"
 
   - trigger: "::A9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Georgian Airways (A9), GE"
 
   - trigger: "::QB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Georgian National Airlines (QB), GE"
 
   - trigger: "::ST?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Germania (ST), DE"
 
   - trigger: "::4U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Germanwings (4U), DE"
 
   - trigger: "::GP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gestair (GP), ES"
 
   - trigger: "::G0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ghana International Airlines (G0), GH"
 
   - trigger: "::G8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Go Air (G8), IN"
 
   - trigger: "::GK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Go One Airways (GK), GB"
 
   - trigger: "::G7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "GoJet Airlines (G7), US"
 
   - trigger: "::G3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gol Transportes Aéreos (G3), BR"
 
   - trigger: "::DC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Golden Air (DC), SE"
 
   - trigger: "::G1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gorkha Airlines (G1), NP"
 
   - trigger: "::GS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Grant Aviation (GS), US"
 
   - trigger: "::ZK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Great Lakes Airlines (ZK), US"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Great Wall Airlines (IJ), CN"
 
   - trigger: "::TA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Grupo TACA (TA), CR"
 
   - trigger: "::G6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Guine Bissaur Airlines (G6), GW"
 
   - trigger: "::J9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Guinee Airlines (J9), GN"
 
   - trigger: "::G8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gujarat Airways (G8), IN"
 
   - trigger: "::GF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gulf Air Bahrain (GF), BH"
 
   - trigger: "::H6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hageland Aviation Services (H6), US"
 
   - trigger: "::HR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hahn Air (HR), DE"
 
   - trigger: "::HU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hainan Airlines (HU), CN"
 
   - trigger: "::1R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hainan Phoenix Information Systems (1R), CN"
 
   - trigger: "::2T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Haiti Ambassador Airlines (2T), HT"
 
   - trigger: "::4R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hamburg International (4R), DE"
 
   - trigger: "::X3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUIfly (X3), DE"
 
   - trigger: "::HF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hapagfly (HF), DE"
 
   - trigger: "::HB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Harbor Airlines (HB), US"
 
   - trigger: "::HQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Harmony Airways (HQ), CA"
 
   - trigger: "::HA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hawaiian Airlines (HA), US"
 
   - trigger: "::HP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hawaiian Pacific Airlines (HP), US"
 
   - trigger: "::BH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hawkair (BH), CA"
 
   - trigger: "::HN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Heavylift Cargo Airlines (HN), AU"
 
   - trigger: "::8H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Heli France (8H), FR"
 
   - trigger: "::JB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Helijet (JB), CA"
 
   - trigger: "::ZU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Helios Airways (ZU), CY"
 
   - trigger: "::T4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hellas Jet (T4), GR"
 
   - trigger: "::HW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hello (HW), CH"
 
   - trigger: "::2L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Helvetic Airways (2L), CH"
 
   - trigger: "::DU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hemus Air (DU), BG"
 
   - trigger: "::EO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hewa Bora Airways (EO), CD"
 
   - trigger: "::UD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hex'Air (UD), FR"
 
   - trigger: "::5K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hi Fly (5K), PT"
 
   - trigger: "::HD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hokkaido International Airlines (HD), JP"
 
   - trigger: "::H5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hola Airlines (H5), ES"
 
   - trigger: "::HX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hong Kong Airlines (HX), HK"
 
   - trigger: "::UO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hong Kong Express Airways (UO), HK"
 
   - trigger: "::HH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hope Air (HH), CA"
 
   - trigger: "::QX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Horizon Air (QX), US"
 
   - trigger: "::BN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Horizon Airlines (BN), AU"
 
   - trigger: "::H4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Héli Sécurité Helicopter Airlines (H4), FR"
 
   - trigger: "::II?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "IBC Airways (II), US"
 
   - trigger: "::C3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ICAR Airlines (C3), UA"
 
   - trigger: "::1F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "INFINI Travel Information (1F), JP"
 
   - trigger: "::IB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iberia Airlines (IB), ES"
 
   - trigger: "::TY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iberworld (TY), ES"
 
   - trigger: "::FW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ibex Airlines (FW), JP"
 
   - trigger: "::FI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Icelandair (FI), IS"
 
   - trigger: "::IK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Imair Airlines (IK), AZ"
 
   - trigger: "::DH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Independence Air (DH), US"
 
   - trigger: "::6E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "IndiGo Airlines (6E), IN"
 
   - trigger: "::IC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indian Airlines (IC), IN"
 
   - trigger: "::I9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indigo (I9), US"
 
   - trigger: "::QZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indonesia AirAsia (QZ), ID"
 
   - trigger: "::IO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indonesian Airlines (IO), ID"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "InteliJet Airways (IJ), CO"
 
   - trigger: "::H4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Inter Islands Airlines (H4), CV"
 
   - trigger: "::D6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Interair South Africa (D6), ZA"
 
   - trigger: "::ZA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Interavia Airlines (ZA), RU"
 
   - trigger: "::RS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Intercontinental de Aviaci (RS), CO"
 
   - trigger: "::ID?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Interlink Airlines (ID), ZA"
 
   - trigger: "::6I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "International Business Air (6I), SE"
 
   - trigger: "::3L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Intersky (3L), AT"
 
   - trigger: "::I4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Interstate Airline (I4), NL"
 
   - trigger: "::IR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iran Air (IR), IR"
 
   - trigger: "::EP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iran Aseman Airlines (EP), IR"
 
   - trigger: "::IA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iraqi Airways (IA), IQ"
 
   - trigger: "::IS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Island Airlines (IS), US"
 
   - trigger: "::2S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Island Express (2S), US"
 
   - trigger: "::8L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cargo Plus Aviation (8L), AE"
 
   - trigger: "::CN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Islands Nationair (CN), PG"
 
   - trigger: "::IF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Islas Airways (IF), ES"
 
   - trigger: "::WC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Islena De Inversiones (WC), HN"
 
   - trigger: "::6H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Israir (6H), IL"
 
   - trigger: "::9X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Itali Airlines (9X), IT"
 
   - trigger: "::GI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Itek Air (GI), KG"
 
   - trigger: "::H9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Izair (H9), TR"
 
   - trigger: "::JC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JAL Express (JC), JP"
 
   - trigger: "::JO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JALways (JO), JP"
 
   - trigger: "::1M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JSC Transport Automated Information Systems (1M), RU"
 
   - trigger: "::JL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Airlines (JL), JP"
 
   - trigger: "::JL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Airlines Domestic (JL), JP"
 
   - trigger: "::EG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Asia Airways (EG), JP"
 
   - trigger: "::NU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Transocean Air (NU), JP"
 
   - trigger: "::JU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jat Airways (JU), RS"
 
   - trigger: "::VJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jatayu Airlines (VJ), ID"
 
   - trigger: "::J9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jazeera Airways (J9), KW"
 
   - trigger: "::7C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jeju Air (7C), KR"
 
   - trigger: "::9W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jet Airways (9W), IN"
 
   - trigger: "::QJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jet Airways (QJ), US"
 
   - trigger: "::0J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetclub (0J), CH"
 
   - trigger: "::3K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetstar Asia Airways (3K), SG"
 
   - trigger: "::LS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jet2.com (LS), GB"
 
   - trigger: "::8J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jet4You (8J), MA"
 
   - trigger: "::B6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JetBlue Airways (B6), US"
 
   - trigger: "::JF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetairfly (JF), BE"
 
   - trigger: "::0J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetclub (0J), CH"
 
   - trigger: "::SG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JetsGo (SG), CA"
 
   - trigger: "::JQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetstar Airways (JQ), AU"
 
   - trigger: "::JX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jett8 Airlines Cargo (JX), SG"
 
   - trigger: "::GX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetx Airlines (GX), IS"
 
   - trigger: "::R5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jordan Aviation (R5), JO"
 
   - trigger: "::HO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Juneyao Airlines (HO), CN"
 
   - trigger: "::KD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KD Avia (KD), RU"
 
   - trigger: "::WA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KLM Cityhopper (WA), NL"
 
   - trigger: "::KL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KLM Royal Dutch Airlines (KL), NL"
 
   - trigger: "::N2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kabo Air (N2), NG"
 
   - trigger: "::K4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kalitta Air (K4), US"
 
   - trigger: "::RQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kam Air (RQ), AF"
 
   - trigger: "::E2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kampuchea Airlines (E2), KH"
 
   - trigger: "::V2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Karat (V2), RU"
 
   - trigger: "::KV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kavminvodyavia (KV), RU"
 
   - trigger: "::M5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kenmore Air (M5), US"
 
   - trigger: "::KQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kenya Airways (KQ), KE"
 
   - trigger: "::BZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Keystone Air Services (BZ), CA"
 
   - trigger: "::IT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kingfisher Airlines (IT), IN"
 
   - trigger: "::Y9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kish Air (Y9), IR"
 
   - trigger: "::KP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kiwi International Air Lines (KP), US"
 
   - trigger: "::7K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kogalymavia Air Company (7K), RU"
 
   - trigger: "::8J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Komiinteravia (8J), RU"
 
   - trigger: "::KE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Korean Air (KE), KR"
 
   - trigger: "::7B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Krasnojarsky Airlines (7B), RU"
 
   - trigger: "::K9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Krylo Airlines (K9), RU"
 
   - trigger: "::GW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kuban Airlines (GW), RU"
 
   - trigger: "::VD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kunpeng Airlines (VD), CN"
 
   - trigger: "::KU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kuwait Airways (KU), KW"
 
   - trigger: "::GO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kuzu Airlines Cargo (GO), TR"
 
   - trigger: "::N5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kyrgyz Airlines (N5), KG"
 
   - trigger: "::QH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kyrgyzstan (QH), KG"
 
   - trigger: "::R8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kyrgyzstan Airlines (R8), KG"
 
   - trigger: "::KY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kibris T (KY), TR"
 
   - trigger: "::JF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "L.A.B. Flying Service (JF), US"
 
   - trigger: "::LR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LACSA (LR), CR"
 
   - trigger: "::KG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAI - Linea Aerea IAACA (KG), VE"
 
   - trigger: "::LA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAN Airlines (LA), CL"
 
   - trigger: "::4M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAN Argentina (4M), AR"
 
   - trigger: "::LU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAN Express (LU), CL"
 
   - trigger: "::LP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAN Peru (LP), PE"
 
   - trigger: "::LO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LOT Polish Airlines (LO), PL"
 
   - trigger: "::XO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LTE International Airways (XO), ES"
 
   - trigger: "::L3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LTU Austria (L3), AT"
 
   - trigger: "::LT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LTU International (LT), DE"
 
   - trigger: "::N6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lagun Air (N6), ES"
 
   - trigger: "::IK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lankair (IK), LK"
 
   - trigger: "::QV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lao Airlines (QV), LA"
 
   - trigger: "::L7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Laoag International Airlines (L7), PH"
 
   - trigger: "::NG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lauda Air (NG), AT"
 
   - trigger: "::LQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lebanese Air Transport (LQ), LB"
 
   - trigger: "::LI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Leeward Islands Air Transport (LI), AG"
 
   - trigger: "::LN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Libyan Arab Airlines (LN), LY"
 
   - trigger: "::L7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Linea Aerea SAPSA (L7), CL"
 
   - trigger: "::8z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Linea Aerea de Servicio Ejecutivo Regional (8z), VE"
 
   - trigger: "::LD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Linea Turistica Aerotuy (LD), VE"
 
   - trigger: "::ZE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lineas Aereas Azteca (ZE), MX"
 
   - trigger: "::LM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Linhas A (LM), MZ"
 
   - trigger: "::JT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lion Mentari Airlines (JT), ID"
 
   - trigger: "::LM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Livingston (LM), IT"
 
   - trigger: "::LB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lloyd Aereo Boliviano (LB), BO"
 
   - trigger: "::HE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Luftfahrtgesellschaft Walter (HE), DE"
 
   - trigger: "::LH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufthansa (LH), DE"
 
   - trigger: "::LH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufthansa Cargo (LH), DE"
 
   - trigger: "::CL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufthansa CityLine (CL), DE"
 
   - trigger: "::L1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufthansa Systems (L1), DE"
 
   - trigger: "::DV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufttaxi Fluggesellschaft (DV), DE"
 
   - trigger: "::L5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lufttransport (L5), NO"
 
   - trigger: "::LG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Luxair (LG), LU"
 
   - trigger: "::5V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lviv Airlines (5V), UA"
 
   - trigger: "::L2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lynden Air Cargo (L2), US"
 
   - trigger: "::MJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LAPA – Líneas Aéreas Privadas Argentinas (MJ), AR"
 
   - trigger: "::M7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MasAir (M7), MX"
 
   - trigger: "::IN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MAT Macedonian Airlines (IN), MK"
 
   - trigger: "::OM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MIAT Mongolian Airlines (OM), MN"
 
   - trigger: "::MB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MNG Airlines (MB), TR"
 
   - trigger: "::CC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Macair Airlines (CC), AU"
 
   - trigger: "::DM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maersk (DM), DK"
 
   - trigger: "::W5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mahan Air (W5), IR"
 
   - trigger: "::M2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mahfooz Aviation (M2), GM"
 
   - trigger: "::MH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malaysia Airlines (MH), MY"
 
   - trigger: "::TF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malmö Aviation (TF), SE"
 
   - trigger: "::R5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malta Air Charter (R5), MT"
 
   - trigger: "::MA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malév (MA), HU"
 
   - trigger: "::RI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mandala Airlines (RI), ID"
 
   - trigger: "::AE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mandarin Airlines (AE), TW"
 
   - trigger: "::JE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mango (JE), ZA"
 
   - trigger: "::6V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mars RK (6V), UA"
 
   - trigger: "::M7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Marsland Aviation (M7), SD"
 
   - trigger: "::MP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Martinair (MP), NL"
 
   - trigger: "::Q4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mastertop Linhas Aereas (Q4), BR"
 
   - trigger: "::H5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mavial Magadan Airlines (H5), RU"
 
   - trigger: "::8M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maxair (8M), SE"
 
   - trigger: "::MY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maxjet Airways (MY), US"
 
   - trigger: "::MW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maya Island Air (MW), BZ"
 
   - trigger: "::IM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Menajet (IM), LB"
 
   - trigger: "::IG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Meridiana (IG), IT"
 
   - trigger: "::MZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Merpati Nusantara Airlines (MZ), ID"
 
   - trigger: "::YV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mesa Airlines (YV), US"
 
   - trigger: "::XJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mesaba Airlines (XJ), US"
 
   - trigger: "::MX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mexicana de Aviaci (MX), MX"
 
   - trigger: "::GL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Miami Air International (GL), US"
 
   - trigger: "::ME?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Middle East Airlines (ME), LB"
 
   - trigger: "::JI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Midway Airlines (JI), US"
 
   - trigger: "::YX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Midwest Airlines (YX), US"
 
   - trigger: "::MY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Midwest Airlines (Egypt) (MY), EG"
 
   - trigger: "::2M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Moldavian Airlines (2M), MD"
 
   - trigger: "::ZB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Monarch Airlines (ZB), GB"
 
   - trigger: "::8I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Myway Airlines (8I), IT"
 
   - trigger: "::YM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Montenegro Airlines (YM), ME"
 
   - trigger: "::3R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Moskovia Airlines (3R), RU"
 
   - trigger: "::M9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Motor Sich (M9), UA"
 
   - trigger: "::NM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mount Cook Airlines (NM), NZ"
 
   - trigger: "::N4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mountain Air Company (N4), SL"
 
   - trigger: "::VZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MyTravel Airways (VZ), GB"
 
   - trigger: "::UB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Myanma Airways (UB), MM"
 
   - trigger: "::8M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Myanmar Airways International (8M), MM"
 
   - trigger: "::DV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nantucket Airlines (DV), US"
 
   - trigger: "::P9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nas Air (P9), ML"
 
   - trigger: "::UE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nasair (UE), ER"
 
   - trigger: "::N4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Airlines (N4), CL"
 
   - trigger: "::N7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Airlines (N7), US"
 
   - trigger: "::NA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Airlines (NA), US"
 
   - trigger: "::9O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Airways Cameroon (9O), CM"
 
   - trigger: "::NC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Jet Systems (NC), AU"
 
   - trigger: "::CE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nationwide Airlines (CE), ZA"
 
   - trigger: "::ON?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nauru Air Corporation (ON), NR"
 
   - trigger: "::1N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Navitaire (1N), US"
 
   - trigger: "::RA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nepal Airlines (RA), NP"
 
   - trigger: "::NO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Neos (NO), IT"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "NetJets (1I), US"
 
   - trigger: "::EJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "New England Airlines (EJ), US"
 
   - trigger: "::2N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "NextJet (2N), SE"
 
   - trigger: "::HG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Niki (HG), AT"
 
   - trigger: "::KZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nippon Cargo Airlines (KZ), JP"
 
   - trigger: "::DD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nok Air (DD), TH"
 
   - trigger: "::JH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nordeste Linhas Aereas Regionais (JH), BR"
 
   - trigger: "::6N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nordic Regional (6N), SE"
 
   - trigger: "::N9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "North Coast Aviation (N9), PG"
 
   - trigger: "::M3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "North Flying (M3), DK"
 
   - trigger: "::HW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "North-Wright Airways (HW), CA"
 
   - trigger: "::NC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Northern Air Cargo (NC), US"
 
   - trigger: "::U7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Northern Dene Airways (U7), CA"
 
   - trigger: "::NW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Northwest Airlines (NW), US"
 
   - trigger: "::FY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Northwest Regional Airlines (FY), AU"
 
   - trigger: "::J3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Northwestern Air (J3), CA"
 
   - trigger: "::DY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Norwegian Air Shuttle (DY), NO"
 
   - trigger: "::BJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nouvel Air Tunisie (BJ), TN"
 
   - trigger: "::M4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nova Airline (M4), SD"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Novair (1I), SE"
 
   - trigger: "::N6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nuevo Continente (N6), PE"
 
   - trigger: "::XY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nas Air (XY), SA"
 
   - trigger: "::UQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "O'Connor Airlines (UQ), AU"
 
   - trigger: "::CR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "OAG (CR), GB"
 
   - trigger: "::O8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Oasis Hong Kong Airlines (O8), HK"
 
   - trigger: "::VC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ocean Airlines (VC), IT"
 
   - trigger: "::O6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Oceanair (O6), BR"
 
   - trigger: "::O2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Oceanic Airlines (O2), GN"
 
   - trigger: "::OA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Olympic Airlines (OA), GR"
 
   - trigger: "::WY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Oman Air (WY), OM"
 
   - trigger: "::OY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Omni Air International (OY), US"
 
   - trigger: "::N3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Omskavia Airline (N3), RU"
 
   - trigger: "::8Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Onur Air (8Q), TR"
 
   - trigger: "::R2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Orenburg Airlines (R2), RU"
 
   - trigger: "::OX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Orient Thai Airlines (OX), TH"
 
   - trigger: "::QO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Origin Pacific Airways (QO), NZ"
 
   - trigger: "::OL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ostfriesische Lufttransport (OL), DE"
 
   - trigger: "::ON?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Our Airline (ON), NR"
 
   - trigger: "::OJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Overland Airways (OJ), NG"
 
   - trigger: "::OZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ozark Air Lines (OZ), US"
 
   - trigger: "::O7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ozjet Airlines (O7), AU"
 
   - trigger: "::PV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PAN Air (PV), ES"
 
   - trigger: "::9Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PB Air (9Q), TH"
 
   - trigger: "::PU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PLUNA (PU), UY"
 
   - trigger: "::U4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PMTair (U4), KH"
 
   - trigger: "::Y5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pace Airlines (Y5), US"
 
   - trigger: "::BL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetstar Pacific (BL), VN"
 
   - trigger: "::DJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific Blue (DJ), NZ"
 
   - trigger: "::8P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific Coastal Airline (8P), CA"
 
   - trigger: "::Q8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific East Asia Cargo Airlines (Q8), PH"
 
   - trigger: "::PS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific Southwest Airlines (PS), US"
 
   - trigger: "::LW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific Wings (LW), US"
 
   - trigger: "::GX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacificair (GX), PH"
 
   - trigger: "::PK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pakistan International Airlines (PK), PK"
 
   - trigger: "::GP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Palau Trans Pacific Airline (GP), PW"
 
   - trigger: "::PF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Palestinian Airlines (PF), EG"
 
   - trigger: "::NR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pamir Airways (NR), AF"
 
   - trigger: "::PA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pan American Airways (PA), US"
 
   - trigger: "::PA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pan American World Airways (PA), US"
 
   - trigger: "::PQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Panafrican Airways (PQ), CI"
 
   - trigger: "::P8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pantanal Linhas Aéreas (P8), BR"
 
   - trigger: "::I7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Paramount Airways (I7), IN"
 
   - trigger: "::HP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pearl Airways (HP), HT"
 
   - trigger: "::PC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pegasus Airlines (PC), TR"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pegasus Hava Tasimaciligi (1I), TR"
 
   - trigger: "::KS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Peninsula Airways (KS), US"
 
   - trigger: "::P9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Perm Airlines (P9), RU"
 
   - trigger: "::PR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Philippine Airlines (PR), PH"
 
   - trigger: "::HP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Phoenix Airways (HP), CH"
 
   - trigger: "::9R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Phuket Air (9R), TH"
 
   - trigger: "::PI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Piedmont Airlines (1948-1989) (PI), US"
 
   - trigger: "::9E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pinnacle Airlines (9E), US"
 
   - trigger: "::PO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polar Air Cargo (PO), US"
 
   - trigger: "::PH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polynesian Airlines (PH), WS"
 
   - trigger: "::DJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polynesian Blue (DJ), NZ"
 
   - trigger: "::1U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polyot Sirena (1U), RU"
 
   - trigger: "::PD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Porter Airlines (PD), CA"
 
   - trigger: "::NI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Portugalia (NI), PT"
 
   - trigger: "::BK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Potomac Air (BK), US"
 
   - trigger: "::PW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Precision Air (PW), TZ"
 
   - trigger: "::TO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "President Airlines (TO), KH"
 
   - trigger: "::FE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Primaris Airlines (FE), US"
 
   - trigger: "::8W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Private Wings Flugcharter (8W), DE"
 
   - trigger: "::P0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Proflight Commuter Services (P0), ZM"
 
   - trigger: "::QF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Qantas (QF), AU"
 
   - trigger: "::QR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Qatar Airways (QR), QA"
 
   - trigger: "::R6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "RACSA (R6), GT"
 
   - trigger: "::1D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Radixx Solutions International (1D), US"
 
   - trigger: "::8L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Redhill Aviation (8L), GB"
 
   - trigger: "::V4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Reem Air (V4), KG"
 
   - trigger: "::FN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regional Airlines (FN), MA"
 
   - trigger: "::ZL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regional Express (ZL), AU"
 
   - trigger: "::3C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "RegionsAir (3C), US"
 
   - trigger: "::QQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Reno Air (QQ), US"
 
   - trigger: "::RW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rwandair Express (WB), RW"
 
   - trigger: "::RD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ryan International Airlines (RD), US"
 
   - trigger: "::FR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ryanair (FR), IE"
 
   - trigger: "::YS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Régional (YS), FR"
 
   - trigger: "::S4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SATA International (S4), PT"
 
   - trigger: "::SA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "South African Airways (SA), ZA"
 
   - trigger: "::NL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shaheen Air International (NL), PK"
 
   - trigger: "::SK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Scandinavian Airlines System (SK), SE"
 
   - trigger: "::S7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "S7 Airlines (S7), RU"
 
   - trigger: "::BB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Seaborne Airlines (BB), US"
 
   - trigger: "::UL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SriLankan Airlines (UL), LK"
 
   - trigger: "::SY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sun Country Airlines (SY), US"
 
   - trigger: "::G3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Express (G3), GR"
 
   - trigger: "::SG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spicejet (SG), IN"
 
   - trigger: "::I6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Eyes (I6), TH"
 
   - trigger: "::EH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SAETA (EH), EC"
 
   - trigger: "::7G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Star Flyer (7G), JP"
 
   - trigger: "::FA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Safair (FA), ZA"
 
   - trigger: "::N5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skagway Air Service (N5), US"
 
   - trigger: "::SP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SATA Air Acores (SP), PT"
 
   - trigger: "::SQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Singapore Airlines (SQ), SG"
 
   - trigger: "::5M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sibaviatrans (5M), RU"
 
   - trigger: "::SI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skynet Airlines (SI), IE"
 
   - trigger: "::XS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SITA (XS), BE"
 
   - trigger: "::SJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sriwijaya Air (SJ), ID"
 
   - trigger: "::ZS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sama Airlines (ZS), SA"
 
   - trigger: "::FT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Siem Reap Airways (FT), KH"
 
   - trigger: "::SX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Work Airlines (SX), CH"
 
   - trigger: "::SM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Swedline Express (SM), SE"
 
   - trigger: "::DG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "South East Asian Airlines (DG), PH"
 
   - trigger: "::VD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SwedJet Airways (VD), SE"
 
   - trigger: "::5G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skyservice Airlines (5G), CA"
 
   - trigger: "::FS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Servicios de Transportes A (FS), AR"
 
   - trigger: "::SD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sudan Airways (SD), SD"
 
   - trigger: "::PI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sun Air (Fiji) (PI), FJ"
 
   - trigger: "::EZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sun Air of Scandinavia (EZ), DK"
 
   - trigger: "::SV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Saudi Arabian Airlines (SV), SA"
 
   - trigger: "::WN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southwest Airlines (WN), US"
 
   - trigger: "::A4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southern Winds Airlines (A4), AR"
 
   - trigger: "::WG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sunwing Airlines (WG), CA"
 
   - trigger: "::LX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Swiss International Air Lines (LX), CH"
 
   - trigger: "::SR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Swissair (SR), CH"
 
   - trigger: "::WV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Swe Fly (WV), SE"
 
   - trigger: "::S8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shovkoviy Shlyah (S8), UA"
 
   - trigger: "::XQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SunExpress (XQ), TR"
 
   - trigger: "::RB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Syrian Arab Airlines (RB), SY"
 
   - trigger: "::AL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skywalk Airlines (AL), US"
 
   - trigger: "::ZP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Silk Way Airlines (ZP), AZ"
 
   - trigger: "::E5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Samara Airlines (E5), RU"
 
   - trigger: "::SC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shandong Airlines (SC), CN"
 
   - trigger: "::9S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spring Airlines (9S), CN"
 
   - trigger: "::3U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sichuan Airlines (3U), CN"
 
   - trigger: "::FM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shanghai Airlines (FM), CN"
 
   - trigger: "::ZH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shenzhen Airlines (ZH), CN"
 
   - trigger: "::8C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shanxi Airlines (8C), CN"
 
   - trigger: "::7L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sun D'Or (7L), IL"
 
   - trigger: "::NE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SkyEurope (NE), SK"
 
   - trigger: "::CQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sunshine Express Airlines (CQ), AU"
 
   - trigger: "::SO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Superior Aviation (SO), US"
 
   - trigger: "::JK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spanair (JK), ES"
 
   - trigger: "::2G?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "San Juan Airlines (2G), US"
 
   - trigger: "::1Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sabre Pacific (1Z), AU"
 
   - trigger: "::1S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sabre (1S), US"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sierra Nevada Airlines (1I), US"
 
   - trigger: "::1H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Siren-Travel (1H), RU"
 
   - trigger: "::1Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sirena (1Q), RU"
 
   - trigger: "::1K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southern Cross Distribution (1K), AU"
 
   - trigger: "::1K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sutra (1K), US"
 
   - trigger: "::2C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SNCF (2C), FR"
 
   - trigger: "::2S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Star Equatorial Airlines (2S), GN"
 
   - trigger: "::NK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spirit Airlines (NK), US"
 
   - trigger: "::9R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SATENA (9R), CO"
 
   - trigger: "::S0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Slok Air Gambia (S0), GM"
 
   - trigger: "::SO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sosoliso Airlines (SO), NG"
 
   - trigger: "::1I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Trek International Airlines (1I), US"
 
   - trigger: "::SX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skybus Airlines (SX), US"
 
   - trigger: "::RU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SkyKing Turks and Caicos Airways (RU), TC"
 
   - trigger: "::S3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Santa Barbara Airlines (S3), VE"
 
   - trigger: "::H2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Airline (H2), CL"
 
   - trigger: "::OO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SkyWest (OO), US"
 
   - trigger: "::JZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skyways Express (JZ), SE"
 
   - trigger: "::BC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skymark Airlines (BC), JP"
 
   - trigger: "::LJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sierra National Airlines (LJ), SL"
 
   - trigger: "::MI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SilkAir (MI), SG"
 
   - trigger: "::6Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Slovak Airlines (6Q), SK"
 
   - trigger: "::PY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Surinam Airways (PY), SR"
 
   - trigger: "::8D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Servant Air (8D), US"
 
   - trigger: "::NB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sterling Airlines (NB), DK"
 
   - trigger: "::6J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skynet Asia Airways (6J), JP"
 
   - trigger: "::IE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Solomon Airlines (IE), SB"
 
   - trigger: "::6W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Saratov Aviation Division (6W), RU"
 
   - trigger: "::HZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sat Airlines (HZ), KZ"
 
   - trigger: "::S5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Shuttle America (S5), US"
 
   - trigger: "::DV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Scat Air (DV), KZ"
 
   - trigger: "::S6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Star Air (S6), DK"
 
   - trigger: "::EQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAME (EQ), EC"
 
   - trigger: "::JJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAM Brazilian Airlines (JJ), BR"
 
   - trigger: "::TP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAP Portugal (TP), PT"
 
   - trigger: "::TU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tunisair (TU), TN"
 
   - trigger: "::3V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TNT Airways (3V), BE"
 
   - trigger: "::M7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tropical Airways (M7), HT"
 
   - trigger: "::T2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai Air Cargo (T2), TH"
 
   - trigger: "::FQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thomas Cook Airlines (FQ), BE"
 
   - trigger: "::MT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thomas Cook Airlines (MT), GB"
 
   - trigger: "::TQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tandem Aero (TQ), MD"
 
   - trigger: "::L9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Teamline Air (L9), AT"
 
   - trigger: "::UE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Transeuropean Airlines (UE), RU"
 
   - trigger: "::ZT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Titan Airways (ZT), GB"
 
   - trigger: "::TR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tiger Airways (TR), SG"
 
   - trigger: "::TT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tiger Airways Australia (TT), AU"
 
   - trigger: "::TG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai Airways International (TG), TH"
 
   - trigger: "::FD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai AirAsia (FD), TH"
 
   - trigger: "::TK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Turkish Airlines (TK), TR"
 
   - trigger: "::T7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Twin Jet (T7), FR"
 
   - trigger: "::9I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai Sky Airlines (9I), TH"
 
   - trigger: "::TD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tulip Air (TD), NL"
 
   - trigger: "::TL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Trans Mediterranean Airlines (TL), LB"
 
   - trigger: "::GY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tri-MG Intra Asia Airlines (GY), ID"
 
   - trigger: "::3P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tiara Air (3P), AW"
 
   - trigger: "::7T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tobruk Air (7T), LY"
 
   - trigger: "::TI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tol-Air Services (TI), US"
 
   - trigger: "::BY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Transaviaexport (BY), BY"
 
   - trigger: "::6B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUIfly Nordic (6B), SE"
 
   - trigger: "::DT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAAG Angola Airlines (DT), AO"
 
   - trigger: "::SF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tassili Airlines (SF), DZ"
 
   - trigger: "::PZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAM Mercosur (PZ), PY"
 
   - trigger: "::AX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Trans States Airlines (AX), US"
 
   - trigger: "::1E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Travelsky Technology (1E), CN"
 
   - trigger: "::2H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thalys (2H), BE"
 
   - trigger: "::RO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tarom (RO), RO"
 
   - trigger: "::3T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Turan Air (3T), AZ"
 
   - trigger: "::8R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TRIP Linhas A (8R), BR"
 
   - trigger: "::U5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "USA3000 Airlines (U5), US"
 
   - trigger: "::UA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "United Airlines (UA), US"
 
   - trigger: "::U2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "United Feeder Service (U2), US"
 
   - trigger: "::U7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "USA Jet Airlines (U7), US"
 
   - trigger: "::U6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ural Airlines (U6), RU"
 
   - trigger: "::UF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "UM Airlines (UF), UA"
 
   - trigger: "::6Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ukrainian Cargo Airways (6Z), UA"
 
   - trigger: "::5X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "United Parcel Service (5X), US"
 
   - trigger: "::US?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "US Airways (US), US"
 
   - trigger: "::UT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "UTair Aviation (UT), RU"
 
   - trigger: "::HY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Uzbekistan Airways (HY), UZ"
 
   - trigger: "::PS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ukraine International Airlines (PS), UA"
 
   - trigger: "::UH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "US Helicopter Corporation (UH), US"
 
   - trigger: "::VA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "V Australia Airlines (VA), AU"
 
   - trigger: "::VF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Valuair (VF), SG"
 
   - trigger: "::VC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Voyageur Airways (VC), CA"
 
   - trigger: "::VN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vietnam Airlines (VN), VN"
 
   - trigger: "::NN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VIM Airlines (NN), RU"
 
   - trigger: "::2R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VIA Rail Canada (2R), CA"
 
   - trigger: "::VA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Viasa (VA), VE"
 
   - trigger: "::Y4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Volaris (Y4), MX"
 
   - trigger: "::VI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Volga-Dnepr Airlines (VI), RU"
 
   - trigger: "::VX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin America (VX), US"
 
   - trigger: "::TV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Express (TV), BE"
 
   - trigger: "::VK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Nigeria Airways (VK), NG"
 
   - trigger: "::VS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Atlantic Airways (VS), GB"
 
   - trigger: "::ZG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Viva Macau (ZG), MO"
 
   - trigger: "::VE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Volare Airlines (VE), IT"
 
   - trigger: "::VY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vueling Airlines (VY), ES"
 
   - trigger: "::XF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vladivostok Air (XF), RU"
 
   - trigger: "::LC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Varig Log (LC), BR"
 
   - trigger: "::VM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Viaggio Air (VM), BG"
 
   - trigger: "::VA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Australia (VA), AU"
 
   - trigger: "::DJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Blue (DJ), AU"
 
   - trigger: "::RG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VRG Linhas Aereas (RG), BR"
 
   - trigger: "::VP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VASP (VP), BR"
 
   - trigger: "::VG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VLM Airlines (VG), BE"
 
   - trigger: "::7W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wayraper (7W), PE"
 
   - trigger: "::WJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "WebJet Linhas A (WJ), BR"
 
   - trigger: "::2W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Welcome Air (2W), AT"
 
   - trigger: "::PT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "West Air Sweden (PT), SE"
 
   - trigger: "::8O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "West Coast Air (8O), CA"
 
   - trigger: "::WS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "WestJet (WS), CA"
 
   - trigger: "::WA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Western Airlines (WA), US"
 
   - trigger: "::CN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Westward Airways (CN), US"
 
   - trigger: "::WF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Widerøe (WF), NO"
 
   - trigger: "::IV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wind Jet (IV), IT"
 
   - trigger: "::IW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wings Air (IW), ID"
 
   - trigger: "::K5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wings of Alaska (K5), US"
 
   - trigger: "::W6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wizz Air (W6), HU"
 
   - trigger: "::8Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wizz Air Hungary (8Z), BG"
 
   - trigger: "::WO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "World Airways (WO), US"
 
   - trigger: "::1P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Worldspan (1P), US"
 
   - trigger: "::8V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wright Air Service (8V), US"
 
   - trigger: "::SE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "XL Airways France (SE), FR"
 
   - trigger: "::MF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Xiamen Airlines (MF), CN"
 
   - trigger: "::XP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Xtra Airways (XP), US"
 
   - trigger: "::YL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yamal Airlines (YL), RU"
 
   - trigger: "::Y8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yangtze River Express (Y8), CN"
 
   - trigger: "::IY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yemenia (IY), YE"
 
   - trigger: "::Q3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zambian Airways (Q3), ZM"
 
   - trigger: "::3J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zip (3J), CA"
 
   - trigger: "::C4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zimex Aviation (C4), CH"
 
   - trigger: "::Z4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zoom Airlines (Z4), CA"
 
   - trigger: "::UK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vistara (UK), IN"
 
   - trigger: "::8Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maldivian Air Taxi (8Q), MV"
 
   - trigger: "::XW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Express (XW), RU"
 
   - trigger: "::Y0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yellow Air Taxi (Y0), US"
 
   - trigger: "::VJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal Air Cambodge (VJ), KH"
 
   - trigger: "::6T?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mandalay (6T), MM"
 
   - trigger: "::SH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAN-SAHSA (SH), HN"
 
   - trigger: "::BX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Busan (BX), KR"
 
   - trigger: "::TB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUI Airlines Belgium (TB), BE"
 
   - trigger: "::GH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Globus (GH), RU"
 
   - trigger: "::9Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Kazakhstan (9Y), KZ"
 
   - trigger: "::JD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Air System (JD), JP"
 
   - trigger: "::ZQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Annsett New Zealand (ZQ), NZ"
 
   - trigger: "::DS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "EasyJet (DS), CH"
 
   - trigger: "::2I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Star Peru (2I), PE"
 
   - trigger: "::KW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Carnival Air Lines (KW), US"
 
   - trigger: "::4H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "United Airways (4H), BD"
 
   - trigger: "::M8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Trans Maldivian Airways (M8), MV"
 
   - trigger: "::5H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly540 (5H), KE"
 
   - trigger: "::TO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Transavia France (TO), FR"
 
   - trigger: "::WP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Island Air (WP), US"
 
   - trigger: "::OG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "1-2-go (OG), TH"
 
   - trigger: "::B7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Uni Air (B7), TW"
 
   - trigger: "::YD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gomelavia (YD), BY"
 
   - trigger: "::WZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Red Wings (WZ), RU"
 
   - trigger: "::11?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUIfly (X3) (11), DE"
 
   - trigger: "::FU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Felix Airways (FU), YE"
 
   - trigger: "::K1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kostromskie avialinii (K1), RU"
 
   - trigger: "::XX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Greenfly (XX), ES"
 
   - trigger: "::7J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tajik Air (7J), TJ"
 
   - trigger: "::TM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mozambique (TM), MZ"
 
   - trigger: "::GY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gabon Airlines (GY), GA"
 
   - trigger: "::ML?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maldivo Airlines (ML), MV"
 
   - trigger: "::VH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virgin Pacific (VH), FJ"
 
   - trigger: "::Z2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zest Air (Z2), PH"
 
   - trigger: "::HK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yangon Airways (HK), MM"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Transport Aérien Transrégional (IJ), FR"
 
   - trigger: "::N4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Minerva Airlines (N4), IT"
 
   - trigger: "::ZE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eastar Jet (ZE), KR"
 
   - trigger: "::LJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jin Air (LJ), KR"
 
   - trigger: "::SH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aéris (Priv) (SH), FR"
 
   - trigger: "::3O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Arabia Maroc (3O), MA"
 
   - trigger: "::B1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Baltic Air lines (B1), LV"
 
   - trigger: "::YC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ciel Canadien (YC), CA"
 
   - trigger: "::CN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Canadian National Airways (CN), CA"
 
   - trigger: "::FA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Epic Holiday (FA), US"
 
   - trigger: "::3I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Comet Chile (3I), CL"
 
   - trigger: "::DN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Voronezhskie Airlanes (DN), RU"
 
   - trigger: "::L8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Line Blue (L8), DE"
 
   - trigger: "::BU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Blue Sky America (BU), US"
 
   - trigger: "::XS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Texas Spirit (XS), US"
 
   - trigger: "::IL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Illinois Airways (IL), US"
 
   - trigger: "::SZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Salzburg arrows (SZ), AT"
 
   - trigger: "::TQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Texas Wings (TQ), US"
 
   - trigger: "::KT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "California Western (KT), US"
 
   - trigger: "::DH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dennis Sky (DH), IL"
 
   - trigger: "::ZZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zz (ZZ), BE"
 
   - trigger: "::A1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atifly (A1), US"
 
   - trigger: "::UK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air UK (UK), GB"
 
   - trigger: "::CB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Suckling Airways (CB), GB"
 
   - trigger: "::RY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Reno Sky (RY), US"
 
   - trigger: "::99?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Ciao Air (99), IT"
 
   - trigger: "::VB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Birmingham European (VB), GB"
 
   - trigger: "::5P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pal airlines (5P), CL"
 
   - trigger: "::C1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CanXpress (C1), CA"
 
   - trigger: "::V5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Danube Wings (V5), SK"
 
   - trigger: "::SH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sharp Airlines (SH), AU"
 
   - trigger: "::C2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CanXplorer (C2), CA"
 
   - trigger: "::QA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Click (Mexicana) (QA), MX"
 
   - trigger: "::W1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "World Experience Airline (W1), CA"
 
   - trigger: "::J4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ALAK (J4), RU"
 
   - trigger: "::E9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AJT Air International (E9), RU"
 
   - trigger: "::3E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Choice One (3E), US"
 
   - trigger: "::KN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China United (KN), CN"
 
   - trigger: "::ZQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Locair (ZQ), US"
 
   - trigger: "::4Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Safi Airlines (4Q), AF"
 
   - trigger: "::K5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SeaPort Airlines (K5), US"
 
   - trigger: "::S6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Salmon Air (S6), US"
 
   - trigger: "::IL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Illi (IL), US"
 
   - trigger: "::01?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Bobb Air Freight (01), DE"
 
   - trigger: "::V9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Star1 Airlines (V9), LT"
 
   - trigger: "::6D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pelita (6D), ID"
 
   - trigger: "::E8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alpi Eagles (E8), IT"
 
   - trigger: "::J5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alaska Seaplane Service (J5), US"
 
   - trigger: "::T8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TAN (T8), AR"
 
   - trigger: "::I6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MexicanaLink (I6), MX"
 
   - trigger: "::IP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Island Spirit (IP), IS"
 
   - trigger: "::T0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TACA Peru (T0), PE"
 
   - trigger: "::7Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pan Am World Airways Dominicana (7Q), DO"
 
   - trigger: "::PF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Primera Air (PF), IS"
 
   - trigger: "::3S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Antilles Express (3S), FR"
 
   - trigger: "::P7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regional Paraguaya (P7), PY"
 
   - trigger: "::V6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VIP Ecuador (V6), EC"
 
   - trigger: "::P9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Peruvian Airlines (P9), PE"
 
   - trigger: "::ЯП?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polar Airlines (ЯП), RU"
 
   - trigger: "::OC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Catovair (OC), MU"
 
   - trigger: "::7Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Halcyonair (7Z), CV"
 
   - trigger: "::4P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Business Aviation (4P), CD"
 
   - trigger: "::E9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Compagnie Africaine d'Aviation (E9), CD"
 
   - trigger: "::K8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zambia Skyways (K8), ZM"
 
   - trigger: "::UJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AlMasria Universal Airlines (UJ), EG"
 
   - trigger: "::6Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SmartLynx Airlines (6Y), LV"
 
   - trigger: "::K7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KoralBlue Airlines (K7), EG"
 
   - trigger: "::E4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Elysian Airlines (E4), CM"
 
   - trigger: "::HT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hellenic Imperial Airways (HT), GR"
 
   - trigger: "::WD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Amsterdam Airlines (WD), NL"
 
   - trigger: "::Q9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Arik Niger (Q9), NE"
 
   - trigger: "::DA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dana Air (DA), NG"
 
   - trigger: "::8F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "STP Airways (8F), ST"
 
   - trigger: "::7Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Med Airways (7Y), LB"
 
   - trigger: "::UQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skyjet Airlines (UQ), UG"
 
   - trigger: "::G6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Volga (G6), RU"
 
   - trigger: "::RL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal Falcon (RL), JO"
 
   - trigger: "::4L?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Euroline (4L), GE"
 
   - trigger: "::WG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Worldways (WG), CA"
 
   - trigger: "::ZF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Athens Airways (ZF), GR"
 
   - trigger: "::VQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Viking Hellas (VQ), GR"
 
   - trigger: "::DZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Starline.kz (DZ), KZ"
 
   - trigger: "::EH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Euro Harmony (EH), PT"
 
   - trigger: "::L7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lugansk Airlines (L7), UA"
 
   - trigger: "::6P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gryphon Airlines (6P), US"
 
   - trigger: "::GP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gadair European Airlines (GP), ES"
 
   - trigger: "::SM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spirit of Manila Airlines (SM), PH"
 
   - trigger: "::OQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chongqing Airlines (OQ), CN"
 
   - trigger: "::PN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "West Air China (PN), CN"
 
   - trigger: "::IH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Falcon Air (IH), SE"
 
   - trigger: "::C3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "QatXpress (C3), QA"
 
   - trigger: "::1C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "OneChina (1C), CN"
 
   - trigger: "::Y7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "NordStar Airlines (Y7), RU"
 
   - trigger: "::JR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Joy Air (JR), CN"
 
   - trigger: "::CD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air India Regional (CD), IN"
 
   - trigger: "::9H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MDLR Airlines (9H), IN"
 
   - trigger: "::Q2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maldivian (Q2), MV"
 
   - trigger: "::XN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Xpressair (XN), ID"
 
   - trigger: "::VC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Strategic Airlines (VC), AU"
 
   - trigger: "::NA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Al-Naser Airlines (NA), IQ"
 
   - trigger: "::MR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Homer Air (MR), DE"
 
   - trigger: "::GM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flitestar (GM), ZA"
 
   - trigger: "::WQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PanAm World Airways (WQ), US"
 
   - trigger: "::YY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Virginwings (YY), DE"
 
   - trigger: "::KY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KSY (KY), GR"
 
   - trigger: "::BQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Buquebus Líneas Aéreas (BQ), UY"
 
   - trigger: "::CQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SOCHI AIR (CQ), RU"
 
   - trigger: "::WU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wizz Air Ukraine (WU), UA"
 
   - trigger: "::LQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LCM AIRLINES (LQ), RU"
 
   - trigger: "::BZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Brazil (BZ), BR"
 
   - trigger: "::K6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cambodia Angkor Air (K6), KH"
 
   - trigger: "::D5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skyline nepc (D5), IN"
 
   - trigger: "::H3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "THREE (H3), CN"
 
   - trigger: "::69?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal European Airlines (69), GB"
 
   - trigger: "::AD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Azul (AD), BR"
 
   - trigger: "::PQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LSM Airlines (PQ), RU"
 
   - trigger: "::C4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LionXpress (C4), CM"
 
   - trigger: "::X1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nik Airways (X1), SA"
 
   - trigger: "::GK?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Genesis (GK), PK"
 
   - trigger: "::XZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Congo Express (XZ), CD"
 
   - trigger: "::FZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Dubai (FZ), AE"
 
   - trigger: "::D1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Domenican Airlines (D1), DO"
 
   - trigger: "::9A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Atlantic (9A), CA"
 
   - trigger: "::CR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Ops (CR), SE"
 
   - trigger: "::JY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aereonautica militare (JY), IT"
 
   - trigger: "::YZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LSM AIRLINES (YZ), RU"
 
   - trigger: "::YP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero Lloyd (YP) (YP), DE"
 
   - trigger: "::UR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "UTair-Express (UR), RU"
 
   - trigger: "::G5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Huaxia (G5), CN"
 
   - trigger: "::ZP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zabaykalskii Airlines (ZP), RU"
 
   - trigger: "::M4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Marysya Airlines (M4), RU"
 
   - trigger: "::N1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "N1 (N1), PE"
 
   - trigger: "::4Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Airlink (SAA) (4Z), ZA"
 
   - trigger: "::3B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "JobAir (3B), CZ"
 
   - trigger: "::OD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zuliana de Aviacion (OD), VE"
 
   - trigger: "::BZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Black Stallion Airways (BZ), US"
 
   - trigger: "::GM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "German International Air Lines (GM), DE"
 
   - trigger: "::TB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TrasBrasil (TB), BR"
 
   - trigger: "::TH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TransBrasil Airlines (TH), BR"
 
   - trigger: "::9C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China SSS (9C), CN"
 
   - trigger: "::NJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nihon.jet (NJ), JP"
 
   - trigger: "::TJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Transportes Aéreos Nacionales de Selva (TJ), PE"
 
   - trigger: "::P8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Mekong (P8), VN"
 
   - trigger: "::H3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Harbour Air (Priv) (H3), CA"
 
   - trigger: "::HH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Hamburg (AHO) (HH), DE"
 
   - trigger: "::Z6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ZABAIKAL AIRLINES (Z6), RU"
 
   - trigger: "::TI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TransHolding (TI), BR"
 
   - trigger: "::YT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yeti Airways (YT), NP"
 
   - trigger: "::Y1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yellowstone Club Private Shuttle (Y1), US"
 
   - trigger: "::NS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Caucasus Airlines (NS), GE"
 
   - trigger: "::S1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Serbian Airlines (S1), RS"
 
   - trigger: "::WM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Windward Islands Airways (WM), NL"
 
   - trigger: "::YO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TransHolding System (YO), BR"
 
   - trigger: "::CB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CCML Airlines (CB), CO"
 
   - trigger: "::SF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Charter International (SF), FR"
 
   - trigger: "::F1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Brasil (F1), BR"
 
   - trigger: "::3F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Colombia (3F), CO"
 
   - trigger: "::T6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Trans Pas Air (T6), US"
 
   - trigger: "::МИ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "KMV (МИ), RU"
 
   - trigger: "::HC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Himalayan Airlines (HC), NP"
 
   - trigger: "::G1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indya Airline Group (G1), IN"
 
   - trigger: "::WG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sunwing (WG), CA"
 
   - trigger: "::ZX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Japan Regio (ZX), JP"
 
   - trigger: "::N0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Norte Lineas Aereas (N0), AR"
 
   - trigger: "::W7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Austral Brasil (W7), BR"
 
   - trigger: "::H9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "PEGASUS AIRLINES- (H9), TR"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirLiberté (IJ), FR"
 
   - trigger: "::QC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Camair-co (QC), CM"
 
   - trigger: "::N6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aerocontinente (Priv) (N6), PE"
 
   - trigger: "::RS?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Regional (RS), CA"
 
   - trigger: "::YI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TUR Avrupa Hava YollarÄ± (YI), TR"
 
   - trigger: "::II?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "LSM International (II), RU"
 
   - trigger: "::BU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Baikotovitchestrian Airlines (BU), WS"
 
   - trigger: "::Z7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zimbabwean Airlines (Z7), ZW"
 
   - trigger: "::6U?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Cargo Germany (6U), DE"
 
   - trigger: "::7M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mongolian International Air Lines (7M), MN"
 
   - trigger: "::2D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alaniya Airlines (2D), RU"
 
   - trigger: "::TW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tway Airlines (TW), KR"
 
   - trigger: "::HI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Papillon Grand Canyon Helicopters (HI), US"
 
   - trigger: "::JX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jusur airways (JX), EG"
 
   - trigger: "::XB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "NEXT Brasil (XB), BR"
 
   - trigger: "::W4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AeroWorld (W4), RU"
 
   - trigger: "::KH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Cook Island Air (KH), CK"
 
   - trigger: "::E8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "US Africa Airways (E8), US"
 
   - trigger: "::GN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "GNB Linhas Aereas (GN), BR"
 
   - trigger: "::E1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Usa Sky Cargo (E1), US"
 
   - trigger: "::HN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hankook Airline (HN), KR"
 
   - trigger: "::RR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Red Jet America (RR), US"
 
   - trigger: "::Z7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "REDjet (Z7), BB"
 
   - trigger: "::1H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hellenic Airways (1H), GR"
 
   - trigger: "::PT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Red Jet Andes (PT), PE"
 
   - trigger: "::QY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Red Jet Canada (QY), CA"
 
   - trigger: "::4X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Red Jet Mexico (4X), MX"
 
   - trigger: "::Y8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Marusya Airways (Y8), RU"
 
   - trigger: "::7H?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Era Alaska (7H), US"
 
   - trigger: "::R8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirRussia (R8), RU"
 
   - trigger: "::H1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hankook Air US (H1), US"
 
   - trigger: "::D5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "NEPC Airlines (D5), IN"
 
   - trigger: "::10?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Canadian World (10), CA"
 
   - trigger: "::H5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "I-Fly (H5), RU"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "T.A.T (IJ), FR"
 
   - trigger: "::DN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alinord (DN), IT"
 
   - trigger: "::VB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pacific Express (VB), US"
 
   - trigger: "::KT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VickJet (KT), FR"
 
   - trigger: "::XV?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BVI Airways (XV), VG"
 
   - trigger: "::SO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Salsa d'Haiti (SO), HT"
 
   - trigger: "::ZJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zambezi Airlines (ZMA) (ZJ), ZM"
 
   - trigger: "::YQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Polet Airlines (Priv) (YQ), RU"
 
   - trigger: "::T1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "TROPICAL LINHAS AEREAS (T1), BR"
 
   - trigger: "::12?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "12 North (12), IN"
 
   - trigger: "::L6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Mauritania Airlines International (L6), MR"
 
   - trigger: "::6F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MAT Airways (6F), MK"
 
   - trigger: "::AW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Asian Wings Airways (AW), MM"
 
   - trigger: "::E5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Arabia Egypt (E5), EG"
 
   - trigger: "::CT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Alitalia Cityliner (CT), IT"
 
   - trigger: "::OI?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Orchid Airlines (OI), AU"
 
   - trigger: "::Y5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Asia Wings (Y5), KZ"
 
   - trigger: "::XR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Skywest Australia (XR), AU"
 
   - trigger: "::NP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nile Air (NP), EG"
 
   - trigger: "::DN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Senegal Airlines (DN), SN"
 
   - trigger: "::6I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly 6ix (6I), SL"
 
   - trigger: "::S9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Starbow Airlines (S9), GH"
 
   - trigger: "::0X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Copenhagen Express (0X), DK"
 
   - trigger: "::8B?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BusinessAir (8B), TH"
 
   - trigger: "::YR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SENIC AIRLINES (YR), US"
 
   - trigger: "::C7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Sky Wing Pacific (C7), KR"
 
   - trigger: "::PP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Indus (PP), PK"
 
   - trigger: "::07?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Samurai Airlines (07), PK"
 
   - trigger: "::00?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirOne Continental (00), SK"
 
   - trigger: "::U1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirOne Polska (U1), PL"
 
   - trigger: "::MM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Peach Aviation (MM), JP"
 
   - trigger: "::U1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aviabus (U1), RU"
 
   - trigger: "::DF?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Michael Airlines (DF), PR"
 
   - trigger: "::ZC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Korongo Airlines (ZC), CD"
 
   - trigger: "::I5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Indonesia Sky (I5), ID"
 
   - trigger: "::9P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Pelangi (9P), MY"
 
   - trigger: "::B0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aws express (B0), US"
 
   - trigger: "::76?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southjet (76), US"
 
   - trigger: "::77?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southjet connect (77), US"
 
   - trigger: "::KP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Cape (KP), ZA"
 
   - trigger: "::78?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Southjet cargo (78), US"
 
   - trigger: "::I2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Iberia Express (I2), ES"
 
   - trigger: "::4O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Interjet (ABC Aerolineas) (4O), MX"
 
   - trigger: "::OG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirOnix (OG), UA"
 
   - trigger: "::NJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nordic Global Airlines (NJ), FI"
 
   - trigger: "::TZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Scoot (TZ), SG"
 
   - trigger: "::SX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Starling Airlines Spain (SX), ES"
 
   - trigger: "::5K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Hi Fly (5K), PT"
 
   - trigger: "::WH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "China Northwest Airlines (WH) (WH), CN"
 
   - trigger: "::ZN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Zenith International Airline (ZN), TH"
 
   - trigger: "::O1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Orbit Airlines Azerbaijan (O1), AZ"
 
   - trigger: "::A6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Alps Aviation (A6) (A6), AT"
 
   - trigger: "::P4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Patriot Airways (P4), US"
 
   - trigger: "::V2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vision Airlines (V2), US"
 
   - trigger: "::C8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Chicago Express (C8), US"
 
   - trigger: "::5Q?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BQB Lineas Aereas (5Q), UY"
 
   - trigger: "::YE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yellowtail (YE), US"
 
   - trigger: "::KG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal Airways (KG), US"
 
   - trigger: "::FH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FlyHigh Airlines Ireland (FH), IE"
 
   - trigger: "::2D?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aero VIP (2D) (2D), PT"
 
   - trigger: "::YH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Yangon Airways Ltd. (YH), MM"
 
   - trigger: "::TJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "T.J. Air (TJ), US"
 
   - trigger: "::SX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SkyWork Airlines (SX), CH"
 
   - trigger: "::J7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "ValueJet (J7), US"
 
   - trigger: "::W2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maastricht Airlines (W2), NL"
 
   - trigger: "::WL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "CheapFlyingInternational (WL), FR"
 
   - trigger: "::E6?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Aviaexpresscruise (E6), RU"
 
   - trigger: "::24?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Euro Jet (24), DE"
 
   - trigger: "::00?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "AirOne Atlantic (00), SK"
 
   - trigger: "::HQ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "HQ- Business Express (HQ), US"
 
   - trigger: "::R1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal Southern Airlines. (R1), CO"
 
   - trigger: "::Q3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SOCHI AIR CHATER (Q3), RU"
 
   - trigger: "::J7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Denim Air (J7), NO"
 
   - trigger: "::NO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "North Pacific Airlines (NO), US"
 
   - trigger: "::OD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malindo Air (OD), MY"
 
   - trigger: "::9F?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Tramm Airlines (9F), NL"
 
   - trigger: "::GC?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Lina Congo (GC), CG"
 
   - trigger: "::Z9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Flightlink Tanzania (Z9), TZ"
 
   - trigger: "::I8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "IzAvia (I8), RU"
 
   - trigger: "::3V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "3 Valleys Airlines (3V), FR"
 
   - trigger: "::M1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Maryland Air (M1), US"
 
   - trigger: "::7I?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Insel Air (7I/INC) (Priv) (7I), NL"
 
   - trigger: "::5Z?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "VivaColombia (5Z), CO"
 
   - trigger: "::ZM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Apache Air (ZM), US"
 
   - trigger: "::M2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "MHS Aviation GmbH (M2), DE"
 
   - trigger: "::NR?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jettor Airlines (NR), HK"
 
   - trigger: "::GD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "GoDutch (GD), NL"
 
   - trigger: "::SL?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai Lion Air (SL), TH"
 
   - trigger: "::DW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Deutsche Luftverkehrsgesellschaft (DW), DE"
 
   - trigger: "::N8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "National Air Cargo (N8), US"
 
   - trigger: "::13?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eastern Atlantic Virtual Airlines (13), US"
 
   - trigger: "::QG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Citilink Indonesia (QG), ID"
 
   - trigger: "::GU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Gulisano airways (GU), IT"
 
   - trigger: "::XP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Caribbean Wings (XP), TC"
 
   - trigger: "::S8?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Snowbird Airlines (S8), FI"
 
   - trigger: "::KH?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Kharkiv Airlines (KH), UA"
 
   - trigger: "::XA?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "XAIR USA (XA), US"
 
   - trigger: "::LB?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Costa (LB), IN"
 
   - trigger: "::XP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "XPTO (XP), PT"
 
   - trigger: "::3W?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Malawian Airlines (3W), MW"
 
   - trigger: "::JU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Serbia (JU), RS"
 
   - trigger: "::LT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Lituanica (LT), LT"
 
   - trigger: "::RN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rainbow Air (RAI) (RN), US"
 
   - trigger: "::RY?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rainbow Air Canada (RY), CA"
 
   - trigger: "::RX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rainbow Air Polynesia (RX), US"
 
   - trigger: "::RU?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rainbow Air Euro (RU), GB"
 
   - trigger: "::RM?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Rainbow Air US (RM), US"
 
   - trigger: "::QD?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dobrolet (QD), RU"
 
   - trigger: "::S0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spike Airlines (S0), US"
 
   - trigger: "::L1?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Argentina (L1), AR"
 
   - trigger: "::A2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America (A2), US"
 
   - trigger: "::L9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Asia (L9), CN"
 
   - trigger: "::9A?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Africa (9A), ZA"
 
   - trigger: "::N4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regionalia México (N4), MX"
 
   - trigger: "::N9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Europe (N9), GB"
 
   - trigger: "::N7?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Spain (N7), ES"
 
   - trigger: "::9N?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regional Air Iceland (9N), IS"
 
   - trigger: "::8K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Voestar (8K), BR"
 
   - trigger: "::7O?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Colombia (7O), CO"
 
   - trigger: "::2X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regionalia Uruguay (2X), UY"
 
   - trigger: "::9X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regionalia Venezuela (9X), VE"
 
   - trigger: "::9J?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Regionalia Chile (9J), CL"
 
   - trigger: "::6C?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vuela Cuba (6C), CU"
 
   - trigger: "::88?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Australia (88), AU"
 
   - trigger: "::ER?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Europa (ER), ES"
 
   - trigger: "::PO?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FlyPortugal (PO), PT"
 
   - trigger: "::IJ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Spring Airlines Japan (IJ), JP"
 
   - trigger: "::KP?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dense Airways (KP), US"
 
   - trigger: "::KZ?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dense Connection (KZ), US"
 
   - trigger: "::4S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Vuola Italia (4S), IT"
 
   - trigger: "::1X?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Island Express Air (1X), CA"
 
   - trigger: "::Z0?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All Argentina Express (Z0), AR"
 
   - trigger: "::WE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Thai Smile Airways (WE), TH"
 
   - trigger: "::I4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "International AirLink (I4), JM"
 
   - trigger: "::RT?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Real Tonga (RT), TO"
 
   - trigger: "::2R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America AR (2R), AR"
 
   - trigger: "::1R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America CL (1R), CL"
 
   - trigger: "::Q4?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "SOCHI AIR EXPRESS (Q4), RU"
 
   - trigger: "::1Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America BR (1Y), BR"
 
   - trigger: "::X9?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FRA Air (X9), DE"
 
   - trigger: "::QN?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Royal (QN), CA"
 
   - trigger: "::GX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "GREAT LAKES (GX), CA"
 
   - trigger: "::9V?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Volotea Costa Rica (9V), CR"
 
   - trigger: "::X5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly Romania (X5), RO"
 
   - trigger: "::E2?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Eagle Atlantic Airlines (E2), GH"
 
   - trigger: "::0Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America CO (0Y), CO"
 
   - trigger: "::0M?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America MX (0M), MX"
 
   - trigger: "::FX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "FOX Linhas Aereas (FX), BR"
 
   - trigger: "::EX?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Wings of England (EX), GB"
 
   - trigger: "::DW?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Deutsche Luftverkehrsgesellschaft (DLT) (DW), DE"
 
   - trigger: "::K3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Atlantic Air Cargo (K3), US"
 
   - trigger: "::W3?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "World Scale Airlines (W3), US"
 
   - trigger: "::AG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America US (AG), US"
 
   - trigger: "::1K?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "BudgetAir (1K), DE"
 
   - trigger: "::F5?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Fly One (F5), MD"
 
   - trigger: "::EE?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Nordica (EE), EE"
 
   - trigger: "::0E?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Dummy (0E), FR"
 
   - trigger: "::0P?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "All America BOPY (0P), PY"
 
   - trigger: "::2Y?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Andaman (2Y) (2Y), TH"
 
   - trigger: "::JG?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Jetgo Australia (JG), AU"
 
   - trigger: "::2S?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Air Carnival (2S), IN"
 
   - trigger: "::7R?"
-    label: "Provide the airline name based on IATA's two-character designators"
     replace: "Svyaz Rossiya (7R), RU"


### PR DESCRIPTION
Hello,
I would like to submit a package I have created to the Espanso hub.
This package is related to airports and airlines.

The **air-codes** package can become a resource for air transportation data, offering convenient access to:
- Properly formatted airport names and locations based on their IATA codes.
- Accurate airline names associated with their respective IATA 2-letter airline identifiers.

Don't hesitate to review the _readme.md_ file for further information.
If needed, don't hesitate to contact me.

Thank you.