### PR TITLE
New versions of autocomplete-en & accented-words

### DIFF
--- a/packages/accented-words/1.2.0/LICENSE
+++ b/packages/accented-words/1.2.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Joshua J. Hall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/accented-words/1.2.0/README.md
+++ b/packages/accented-words/1.2.0/README.md
@@ -1,0 +1,26 @@
+# Espanso Accented Words
+
+Simple package to extend [Espanso](https://espanso.org) with commonly accented words used in English.
+
+## Installation
+
+```
+espanso install accented-words
+```
+
+## Usage
+
+Just type the word. Words that may or may not require accents in English will only be accented after a trailing apostrphe (') is added. For example, both `rose` and `rosé` are separate words in English with very different meanings, so only `rose'` will exapnd to `rosé`. Here are a few examples...
+
+* cafe > café
+* rose' > rosé
+* resume' > résumé
+* angstrom > ångström
+* Champs-Elysees > Champs-Élysées
+* Francois > François
+
+The number of words included is now extensive and some (e.g. "hotel") may need to be commented out for everyday use, or the package confined to an app-specific configuration.
+
+## Contributions
+
+Contributions are welcome. Feel free to fork and submit PRs with additional words to add to this list. This is far from an exhaustive list.

--- a/packages/accented-words/1.2.0/_manifest.yml
+++ b/packages/accented-words/1.2.0/_manifest.yml
@@ -1,0 +1,7 @@
+name: accented-words
+title: Accented Words
+description: Automatically accent commonly accented words and proper nouns in English.
+version: 1.2.0
+author: Joshua Hall, additions by smeech
+homepage: "https://github.com/joshjhall/espanso-accented-words"
+tags: ["english", "languages", "accents"]

--- a/packages/accented-words/1.2.0/package.yml
+++ b/packages/accented-words/1.2.0/package.yml
@@ -1,0 +1,1256 @@
+# Accented Words
+# Various additions from https://en-academic.com/dic.nsf/enwiki/3894487#sel=9:12,9:16
+# A number of these may need to be commented out for everyday use, unless
+# restricted to an app-specific configuration.
+
+matches:
+
+  - trigger: a bas
+    replace: à bas
+    propagate_case: true
+    word: true
+
+  - trigger: a la
+    replace: à la
+    propagate_case: true
+    word: true
+
+  - trigger: a gogo
+    replace: à gogo
+    propagate_case: true
+    word: true
+
+  - trigger: ago-go
+    replace: àgo-go
+    propagate_case: true
+    word: true
+
+  - trigger: aide-memoire
+    replace: aide-mémoire
+    propagate_case: true
+    word: true
+
+  - trigger: abbe
+    replace: abbé
+    propagate_case: true
+    word: true
+
+  - trigger: adios
+    replace: adiós
+    propagate_case: true
+    word: true
+
+  - trigger: agrement
+    replace: agrément
+    propagate_case: true
+    word: true
+
+  - trigger: Ancien Regime
+    replace: Ancien Régime
+    propagate_case: true
+    word: true
+
+  - trigger: angstrom
+    replace: ångström
+    propagate_case: true
+    word: true
+
+  - trigger: anime
+    replace: animé
+    propagate_case: true
+    word: true
+
+  - trigger: anu
+    replace: añu
+    propagate_case: true
+    word: true
+
+  - trigger: ao dai
+    replace: áo dài
+    propagate_case: true
+    word: true
+
+  - trigger: aperitif
+    replace: apéritif
+    propagate_case: true
+    word: true
+
+  - trigger: applique
+    replace: appliqué
+    propagate_case: true
+    word: true
+
+  - trigger: apres-ski
+    replace: après-ski
+    propagate_case: true
+    word: true
+
+  - trigger: arete
+    replace: arête
+    propagate_case: true
+    word: true
+
+  - trigger: attache
+    replace: attaché
+    propagate_case: true
+    word: true
+
+  - trigger: auto-da-fe
+    replace: auto-da-fé
+    propagate_case: true
+    word: true
+
+  - trigger: Beardface
+    replace: Beardfacé
+    propagate_case: true
+    word: true
+
+  - trigger: belle epoque
+    replace: belle époque
+    propagate_case: true
+    word: true
+
+  - trigger: bete noire
+    replace: bête noire
+    propagate_case: true
+    word: true
+
+  - trigger: betise
+    replace: bêtise
+    propagate_case: true
+    word: true
+
+  - trigger: blase
+    replace: blasé
+    propagate_case: true
+    word: true
+
+  - trigger: boite
+    replace: boîte
+    propagate_case: true
+    word: true
+
+  - trigger: Bon
+    replace: Bön
+    propagate_case: true
+    word: true
+
+  - trigger: Bootes
+    replace: Boötes
+    propagate_case: true
+    word: true
+
+  - trigger: boutonniere
+    replace: boutonnière
+    propagate_case: true
+    word: true
+
+  - trigger: bric-a-brac
+    replace: bric-à-brac
+    propagate_case: true
+    word: true
+
+  - trigger: brulee
+    replace: brûlée
+    propagate_case: true
+    word: true
+
+  - trigger: cafe
+    replace: café
+    propagate_case: true
+    word: true
+
+  - trigger: cafetiere
+    replace: cafetière
+    propagate_case: true
+    word: true
+
+  - trigger: canape
+    replace: canapé
+    propagate_case: true
+    word: true
+
+  - trigger: canon'
+    replace: cañon
+    propagate_case: true
+    word: true
+
+  - trigger: Champs-Elysees
+    replace: Champs-Élysées
+    propagate_case: true
+    word: true
+
+  - trigger: chateau
+    replace: château
+    propagate_case: true
+    word: true
+
+  - trigger: charge d'affaires
+    replace: chargé d'affaires
+    propagate_case: true
+    word: true
+
+  - trigger: celebre
+    replace: célèbre
+    propagate_case: true
+    word: true
+
+  - trigger: chaines
+    replace: chaînés
+    propagate_case: true
+    word: true
+
+  - trigger: cinema verite
+    replace: cinéma vérité
+    propagate_case: true
+    word: true
+
+  - trigger: cliche
+    replace: cliché
+    propagate_case: true
+    word: true
+
+  - trigger: cloisonne
+    replace: cloisonné
+    propagate_case: true
+    word: true
+
+  - trigger: consomme
+    replace: consommé
+    propagate_case: true
+    word: true
+
+  - trigger: communique
+    replace: communiqué
+    propagate_case: true
+    word: true
+
+  - trigger: confrere
+    replace: confrère
+    propagate_case: true
+    word: true
+
+  - trigger: continuum
+    replace: continuüm
+    propagate_case: true
+    word: true
+
+  - trigger: cooperate
+    replace: coöperate
+    propagate_case: true
+    word: true
+
+  - trigger: coopt
+    replace: coöpt
+    propagate_case: true
+    word: true
+
+  - trigger: coordinate
+    replace: coördinate
+    propagate_case: true
+    word: true
+
+  - trigger: cortege
+    replace: cortège
+    propagate_case: true
+    word: true
+
+  - trigger: coup d'etat
+    replace: coup d'état
+    propagate_case: true
+    word: true
+
+  - trigger: coup de grace
+    replace: coup de grâce
+    propagate_case: true
+    word: true
+
+  - trigger: creche
+    replace: crèche
+    propagate_case: true
+    word: true
+
+  - trigger: coulee
+    replace: coulée
+    propagate_case: true
+    word: true
+
+  - trigger: creme
+    replace: crème
+    propagate_case: true
+    word: true
+
+  - trigger: creme brulee
+    replace: crème brûlée
+    propagate_case: true
+    word: true
+
+  - trigger: crepe
+    replace: crêpe
+    propagate_case: true
+    word: true
+
+  - trigger: Creusa
+    replace: Creüsa
+    propagate_case: true
+    word: true
+
+  - trigger: crouton
+    replace: croûton
+    propagate_case: true
+    word: true
+
+  - trigger: crudites
+    replace: crudités
+    propagate_case: true
+    word: true
+
+  - trigger: Curacao
+    replace: Curaçao
+    propagate_case: true
+    word: true
+
+  - trigger: dais
+    replace: daïs
+    propagate_case: true
+    word: true
+
+  - trigger: dau hoi
+    replace: dấu hỏi
+    propagate_case: true
+    word: true
+
+  - trigger: debacle
+    replace: débâcle
+    propagate_case: true
+    word: true
+
+  - trigger: debutante
+    replace: débutante
+    propagate_case: true
+    word: true
+
+  - trigger: declasse
+    replace: déclassé
+    propagate_case: true
+    word: true
+
+  - trigger: decolletage
+    replace: décolletage
+    propagate_case: true
+    word: true
+
+  - trigger: decollete
+    replace: décolleté
+    propagate_case: true
+    word: true
+
+  - trigger: decor
+    replace: décor
+    propagate_case: true
+    word: true
+
+  - trigger: decoupage
+    replace: découpage
+    propagate_case: true
+    word: true
+
+  - trigger: degage
+    replace: dégagé
+    propagate_case: true
+    word: true
+
+  - trigger: deja vu
+    replace: déjà vu
+    propagate_case: true
+    word: true
+
+  - trigger: demode
+    replace: démodé
+    propagate_case: true
+    word: true
+
+  - trigger: denouement
+    replace: dénouement
+    propagate_case: true
+    word: true
+
+  - trigger: depot
+    replace: dépôt
+    propagate_case: true
+    word: true
+
+  - trigger: derailleur
+    replace: dérailleur
+    propagate_case: true
+    word: true
+
+  - trigger: derriere
+    replace: derrière
+    propagate_case: true
+    word: true
+
+  - trigger: deshabille
+    replace: déshabillé
+    propagate_case: true
+    word: true
+
+  - trigger: detente
+    replace: détente
+    propagate_case: true
+    word: true
+
+  - trigger: diamante
+    replace: diamanté
+    propagate_case: true
+    word: true
+
+  - trigger: discotheque
+    replace: discothèque
+    propagate_case: true
+    word: true
+
+  - trigger: divorce
+    replace: divorcé
+    propagate_case: true
+    word: true
+
+  - trigger: divorcee
+    replace: divorcée
+    propagate_case: true
+    word: true
+
+  - trigger: Dona
+    replace: Doña
+    propagate_case: true
+    word: true
+
+  - trigger: doppelganger
+    replace: doppelgänger
+    propagate_case: true
+    word: true
+
+  - trigger: eclair
+    replace: éclair
+    propagate_case: true
+    word: true
+
+  - trigger: eclat
+    replace: éclat
+    propagate_case: true
+    word: true
+
+  - trigger: Eire
+    replace: Éire
+    propagate_case: true
+    word: true
+
+  - trigger: El Nino
+    replace: El Niño
+    propagate_case: true
+    word: true
+
+  - trigger: elan
+    replace: élan
+    propagate_case: true
+    word: true
+
+  - trigger: elite
+    replace: élite
+    propagate_case: true
+    word: true
+
+  - trigger: emigre
+    replace: émigré
+    propagate_case: true
+    word: true
+
+  - trigger: entree
+    replace: entrée
+    propagate_case: true
+    word: true
+
+  - trigger: entrepot
+    replace: entrepôt
+    propagate_case: true
+    word: true
+
+  - trigger: entrecote
+    replace: entrecôte
+    propagate_case: true
+    word: true
+
+  - trigger: epee
+    replace: épée
+    propagate_case: true
+    word: true
+
+  - trigger: etouffee
+    replace: étouffée
+    propagate_case: true
+    word: true
+
+  - trigger: etude
+    replace: étude
+    propagate_case: true
+    word: true
+
+  - trigger: expose'
+    replace: exposé
+    propagate_case: true
+    word: true
+
+  - trigger: facade
+    replace: façade
+    propagate_case: true
+    word: true
+
+  - trigger: fete
+    replace: fête
+    propagate_case: true
+    word: true
+
+  - trigger: faience
+    replace: faïence
+    propagate_case: true
+    word: true
+
+  - trigger: fiance
+    replace: fiancé
+    propagate_case: true
+    word: true
+
+  - trigger: fiancee
+    replace: fiancée
+    propagate_case: true
+    word: true
+
+  - trigger: filmjolk
+    replace: filmjölk
+    propagate_case: true
+    word: true
+
+  - trigger: fin de siecle
+    replace: fin de siècle
+    propagate_case: true
+    word: true
+
+  - trigger: flambe
+    replace: flambé
+    propagate_case: true
+    word: true
+
+  - trigger: fleche
+    replace: flèche
+    propagate_case: true
+    word: true
+
+  - trigger: fohn wind
+    replace: föhn wind
+    propagate_case: true
+    word: true
+
+  - trigger: folie a deux
+    replace: folie à deux
+    propagate_case: true
+    word: true
+
+  - trigger: fouette
+    replace: fouetté
+    propagate_case: true
+    word: true
+
+  - trigger: francais
+    replace: français
+    propagate_case: true
+    word: true
+
+  - trigger: Francois
+    replace: François
+    propagate_case: true
+    word: true
+
+  - trigger: frappe
+    replace: frappé
+    propagate_case: true
+    word: true
+
+  - trigger: fraulein
+    replace: fräulein
+    propagate_case: true
+    word: true
+
+  - trigger: Fuhrer
+    replace: Führer
+    propagate_case: true
+    word: true
+
+  - trigger: garcon
+    replace: garçon
+    propagate_case: true
+    word: true
+
+  - trigger: gateau
+    replace: gâteau
+    propagate_case: true
+    word: true
+
+  - trigger: gateaux
+    replace: gâteaux
+    propagate_case: true
+    word: true
+
+  - trigger: gemutlichkeit
+    replace: gemütlichkeit
+    propagate_case: true
+    word: true
+
+  - trigger: glace
+    replace: glacé
+    propagate_case: true
+    word: true
+
+  - trigger: glogg
+    replace: glögg
+    propagate_case: true
+    word: true
+
+  - trigger: Gewurztraminer
+    replace: Gewürztraminer
+    propagate_case: true
+    word: true
+
+  - trigger: Gotterdammerung
+    replace: Götterdämmerung
+    propagate_case: true
+    word: true
+
+  - trigger: Grafenberg
+    replace: Gräfenberg
+    propagate_case: true
+    word: true
+
+  - trigger: habitue
+    replace: habitué
+    propagate_case: true
+    word: true
+
+  - trigger: hacek
+    replace: háček
+    propagate_case: true
+    word: true
+
+  - trigger: Hawaii
+    replace: Hawaií
+    propagate_case: true
+    word: true
+
+  - trigger: hotel
+    replace: hôtel
+    propagate_case: true
+    word: true
+
+  - trigger: hors d'oeuvre
+    replace: hors d'œuvre
+    propagate_case: true
+    word: true
+
+  - trigger: ingenue
+    replace: ingénue
+    propagate_case: true
+    word: true
+
+  - trigger: jager
+    replace: jäger
+    propagate_case: true
+    word: true
+
+  - trigger: jalapeno
+    replace: jalapeño
+    propagate_case: true
+    word: true
+
+  - trigger: jardiniere
+    replace: jardinière
+    propagate_case: true
+    word: true
+
+  - trigger: krouzek
+    replace: kroužek
+    propagate_case: true
+    word: true
+
+  - trigger: kummel
+    replace: kümmel
+    propagate_case: true
+    word: true
+
+  - trigger: kaldolmar
+    replace: kåldolmar
+    propagate_case: true
+    word: true
+
+  - trigger: karaoke
+    replace: karaōke
+    propagate_case: true
+    word: true
+
+  - trigger: lame
+    replace: lamé
+    propagate_case: true
+    word: true
+
+  - trigger: landler
+    replace: ländler
+    propagate_case: true
+    word: true
+
+  - trigger: langue d'oil
+    replace: langue d'oïl
+    propagate_case: true
+    word: true
+
+  - trigger: La Nina
+    replace: La Niña
+    propagate_case: true
+    word: true
+
+  - trigger: litterateur
+    replace: littérateur
+    propagate_case: true
+    word: true
+
+  - trigger: lycee
+    replace: lycée
+    propagate_case: true
+    word: true
+
+  - trigger: macedoine
+    replace: macédoine
+    propagate_case: true
+    word: true
+
+  - trigger: macrame
+    replace: macramé
+    propagate_case: true
+    word: true
+
+  - trigger: maitre
+    replace: maître
+    propagate_case: true
+    word: true
+
+  - trigger: malaguena
+    replace: malagueña
+    propagate_case: true
+    word: true
+
+  - trigger: manana
+    replace: mañana
+    propagate_case: true
+    word: true
+
+  - trigger: manege
+    replace: manège
+    propagate_case: true
+    word: true
+
+  - trigger: manque
+    replace: manqué
+    propagate_case: true
+    word: true
+
+  - trigger: mate
+    replace: maté
+    propagate_case: true
+    word: true
+
+  - trigger: materiel
+    replace: matériel
+    propagate_case: true
+    word: true
+
+  - trigger: matinee
+    replace: matinée
+    propagate_case: true
+    word: true
+
+  - trigger: melange
+    replace: mélange
+    propagate_case: true
+    word: true
+
+  - trigger: melee
+    replace: mêlée
+    propagate_case: true
+    word: true
+
+  - trigger: menage a trois
+    replace: ménage à trois
+    propagate_case: true
+    word: true
+
+  - trigger: mesalliance
+    replace: mésalliance
+    propagate_case: true
+    word: true
+
+  - trigger: metier
+    replace: métier
+    propagate_case: true
+    word: true
+
+  - trigger: Metis
+    replace: Métis
+    propagate_case: true
+    word: true
+
+  - trigger: minaudiere
+    replace: minaudière
+    propagate_case: true
+    word: true
+
+  - trigger: moire
+    replace: moiré
+    propagate_case: true
+    word: true
+
+  - trigger: naif
+    replace: naïf
+    propagate_case: true
+    word: true
+
+  - trigger: naive
+    replace: naïve
+    propagate_case: true
+    word: true
+
+  - trigger: naivete
+    replace: naïveté
+    propagate_case: true
+    word: true
+
+  - trigger: ne
+    replace: né
+    propagate_case: true
+    word: true
+
+  - trigger: nee
+    replace: née
+    propagate_case: true
+    word: true
+
+  - trigger: negligee
+    replace: negligée
+    propagate_case: true
+    word: true
+
+  - trigger: Neufchatel
+    replace: Neufchâtel
+    propagate_case: true
+    word: true
+
+  - trigger: Nez Perce
+    replace: Nez Percé
+    propagate_case: true
+    word: true
+
+  - trigger: Noel
+    replace: Noël
+    propagate_case: true
+    word: true
+
+  - trigger: noone'
+    replace: noöne
+    propagate_case: true
+    word: true
+
+  - trigger: numero
+    replace: número
+    propagate_case: true
+    word: true
+
+  - trigger: Montano
+    replace: Montaño
+    propagate_case: true
+    word: true
+
+  - trigger: objet trouve
+    replace: objet trouvé
+    propagate_case: true
+    word: true
+
+  - trigger: ole
+    replace: olé
+    propagate_case: true
+    word: true
+
+  - trigger: ombre
+    replace: ombré
+    propagate_case: true
+    word: true
+
+  - trigger: omerta
+    replace: omertà
+    propagate_case: true
+    word: true
+
+  - trigger: oology
+    replace: oölogy
+    propagate_case: true
+    word: true
+
+  - trigger: opera bouffe
+    replace: opéra bouffe
+    propagate_case: true
+    word: true
+
+  - trigger: opera comique
+    replace: opéra comique
+    propagate_case: true
+    word: true
+
+  - trigger: opium
+    replace: opïum
+    propagate_case: true
+    word: true
+
+  - trigger: ore
+    replace: öre
+    propagate_case: true
+    word: true
+
+  - trigger: ore
+    replace: øre
+    propagate_case: true
+    word: true
+
+  - trigger: outre
+    replace: outré
+    propagate_case: true
+    word: true
+
+  - trigger: papier-mache
+    replace: papier-mâché
+    propagate_case: true
+    word: true
+
+  - trigger: passe
+    replace: passé
+    propagate_case: true
+    word: true
+
+  - trigger: pate
+    replace: pâté
+    propagate_case: true
+    word: true
+
+  - trigger: pho
+    replace: phở
+    propagate_case: true
+    word: true
+
+  - trigger: piece de resistance
+    replace: pièce de résistance
+    propagate_case: true
+    word: true
+
+  - trigger: pied-a-terre
+    replace: pied-à-terre
+    propagate_case: true
+    word: true
+
+  - trigger: plisse
+    replace: plissé
+    propagate_case: true
+    word: true
+
+  - trigger: pina colada
+    replace: piña colada
+    propagate_case: true
+    word: true
+
+  - trigger: pinata
+    replace: piñata
+    propagate_case: true
+    word: true
+
+  - trigger: pinon
+    replace: piñon
+    propagate_case: true
+    word: true
+
+  - trigger: pirana
+    replace: piraña
+    propagate_case: true
+    word: true
+
+  - trigger: pique
+    replace: piqué
+    propagate_case: true
+    word: true
+
+  - trigger: piu
+    replace: più
+    propagate_case: true
+    word: true
+
+  - trigger: plie
+    replace: plié
+    propagate_case: true
+    word: true
+
+  - trigger: precis
+    replace: précis
+    propagate_case: true
+    word: true
+
+  - trigger: polsa
+    replace: pölsa
+    propagate_case: true
+    word: true
+
+  - trigger: preempt
+    replace: preëmpt
+    propagate_case: true
+    word: true
+
+  - trigger: premiere
+    replace: première
+    propagate_case: true
+    word: true
+
+  - trigger: premiere danseuse
+    replace: première danseuse
+    propagate_case: true
+    word: true
+
+  - trigger: pret-a-porter
+    replace: prêt-à-porter
+    propagate_case: true
+    word: true
+
+  - trigger: protege
+    replace: protégé
+    propagate_case: true
+    word: true
+
+  - trigger: protegee
+    replace: protégée
+    propagate_case: true
+    word: true
+
+  - trigger: puree
+    replace: purée
+    propagate_case: true
+    word: true
+
+  - trigger: Quebec
+    replace: Québec
+    propagate_case: true
+    word: true
+
+  - trigger: Quebecois
+    replace: Québécois
+    propagate_case: true
+    word: true
+
+  - trigger: d'etre
+    replace: d'être
+    propagate_case: true
+    word: true
+
+  - trigger: recherche
+    replace: recherché
+    propagate_case: true
+    word: true
+
+  - trigger: reclame
+    replace: réclame
+    propagate_case: true
+    word: true
+
+  - trigger: reenter'
+    replace: reënter
+    propagate_case: true
+    word: true
+
+  - trigger: regime
+    replace: régime
+    propagate_case: true
+    word: true
+
+  - trigger: resume
+    replace: résumé
+    propagate_case: true
+    word: true
+
+  - trigger: residuum
+    replace: residuüm
+    propagate_case: true
+    word: true
+
+  - trigger: retrousse
+    replace: retroussé
+    propagate_case: true
+    word: true
+
+  - trigger: risque
+    replace: risqué
+    propagate_case: true
+    word: true
+
+  - trigger: role
+    replace: rôle
+    propagate_case: true
+    word: true
+
+  - trigger: riviere
+    replace: rivière
+    propagate_case: true
+    word: true
+
+  - trigger: roman a clef
+    replace: roman à clef
+    propagate_case: true
+    word: true
+
+  - trigger: rose'
+    replace: rosé
+    propagate_case: true
+    word: true
+
+  - trigger: roue
+    replace: roué
+    propagate_case: true
+    word: true
+
+  - trigger: saute
+    replace: sauté
+    propagate_case: true
+    word: true
+
+  - trigger: seance
+    replace: séance
+    propagate_case: true
+    word: true
+
+  - trigger: senor
+    replace: señor
+    propagate_case: true
+    word: true
+
+  - trigger: senora
+    replace: señora
+    propagate_case: true
+    word: true
+
+  - trigger: senorita
+    replace: señorita
+    propagate_case: true
+    word: true
+
+  - trigger: Sinn Fein
+    replace: Sinn Féin
+    propagate_case: true
+    word: true
+
+  - trigger: smorgasbord
+    replace: smörgåsbord
+    propagate_case: true
+    word: true
+
+  - trigger: smorgastarta
+    replace: smörgåstårta
+    propagate_case: true
+    word: true
+
+  - trigger: soigne
+    replace: soigné
+    propagate_case: true
+    word: true
+
+  - trigger: soiree
+    replace: soirée
+    propagate_case: true
+    word: true
+
+  - trigger: souffle
+    replace: soufflé
+    propagate_case: true
+    word: true
+
+  - trigger: soupcon
+    replace: soupçon
+    propagate_case: true
+    word: true
+
+  - trigger: surstromming
+    replace: surströmming
+    propagate_case: true
+    word: true
+
+  - trigger: tete-a-tete
+    replace: tête-à-tête
+    propagate_case: true
+    word: true
+
+  - trigger: touche
+    replace: touché
+    propagate_case: true
+    word: true
+
+  - trigger: tourtiere
+    replace: tourtière
+    propagate_case: true
+    word: true
+
+  - trigger: uber'
+    replace: über
+    propagate_case: true
+    word: true
+
+  - trigger: Ubermensch
+    replace: Übermensch
+    propagate_case: true
+    word: true
+
+  - trigger: ventre a terre
+    replace: ventre à terre
+    propagate_case: true
+    word: true
+
+  - trigger: vicuna
+    replace: vicuña
+    propagate_case: true
+    word: true
+
+  - trigger: vin rose
+    replace: vin rosé
+    propagate_case: true
+    word: true
+
+  - trigger: vis a vis
+    replace: vis à vis
+    propagate_case: true
+    word: true
+
+  - trigger: voila
+    replace: voilà
+    propagate_case: true
+    word: true
+
+  - trigger: vardogr
+    replace: vardøgr
+    propagate_case: true
+    word: true
+
+  - trigger: Zaire
+    replace: Zaïre
+    propagate_case: true
+    word: true
+
+  - trigger: zoology
+    replace: zoölogy
+    propagate_case: true
+    word: true

--- a/packages/autocomplete-en/0.2.0/README.md
+++ b/packages/autocomplete-en/0.2.0/README.md
@@ -1,0 +1,8 @@
+# autocomplete-en
+Package for espanso application which autocompletes words using tab
+
+### To use it write at least three letters from the word you want to autocomplete and then hit the Tab key.
+ - \t is tab
+<li>aba\t  -> abandon </li>
+<li>aban\t  -> abandon </li>
+

--- a/packages/autocomplete-en/0.2.0/_manifest.yml
+++ b/packages/autocomplete-en/0.2.0/_manifest.yml
@@ -1,0 +1,7 @@
+author: Metwally Mohamed, rearranged by smeech
+description: A package to autocomplete in espanso.
+name: autocomplete-en
+title: autocomplete-en
+version: 0.2.0
+homepage: "https://github.com/8-momo-8/autocomplete-en"
+tags: ["autocomplete", "autocomplete-en", "autocomplete-espanso"]

--- a/packages/autocomplete-en/0.2.0/package.yml
+++ b/packages/autocomplete-en/0.2.0/package.yml
@@ -1,0 +1,5589 @@
+# Modified by smeech from original by Metwally Mohamed to demonstrate
+# multiple triggers and removing unnecessary quote marks, reducing file-size by
+# about 50%, and the number of lines by 70%.
+# It might be possible to do it even more concisely with Regex triggers
+# but heed the warning at:
+# https://espanso.org/docs/matches/regex-triggers/#when-not-to-use-regex-triggers
+
+matches:
+
+  - triggers: ["AID\t"]
+    replace: AIDS
+  - triggers: ["Afr\t", "Afri\t", "Afric\t", "Africa\t"]
+    replace: African
+  - triggers: ["Afr\t", "Afri\t", "Afric\t", "Africa\t", "African\t", "African-\t", "African-A\t", "African-Am\t", "African-Ame\t", "African-Amer\t", "African-Ameri\t", "African-Americ\t", "African-America\t"]
+    replace: African-American
+  - triggers: ["Ame\t", "Amer\t", "Ameri\t", "Americ\t", "America\t"]
+    replace: American
+  - triggers: ["Ara\t"]
+    replace: Arab
+  - triggers: ["Asi\t", "Asia\t"]
+    replace: Asian
+  - triggers: ["Bib\t", "Bibl\t"]
+    replace: Bible
+  - triggers: ["Bri\t", "Brit\t", "Briti\t", "Britis\t"]
+    replace: British
+  - triggers: ["Can\t", "Cana\t", "Canad\t", "Canadi\t", "Canadia\t"]
+    replace: Canadian
+  - triggers: ["Cat\t", "Cath\t", "Catho\t", "Cathol\t", "Catholi\t"]
+    replace: Catholic
+  - triggers: ["Chi\t", "Chin\t", "Chine\t", "Chines\t"]
+    replace: Chinese
+  - triggers: ["Chr\t", "Chri\t", "Chris\t", "Christ\t", "Christi\t", "Christia\t"]
+    replace: Christian
+  - triggers: ["Chr\t", "Chri\t", "Chris\t", "Christ\t", "Christm\t", "Christma\t"]
+    replace: Christmas
+  - triggers: ["Con\t", "Cong\t", "Congr\t", "Congre\t", "Congres\t"]
+    replace: Congress
+  - triggers: ["Dem\t", "Demo\t", "Democ\t", "Democr\t", "Democra\t"]
+    replace: Democrat
+  - triggers: ["Eng\t", "Engl\t", "Engli\t", "Englis\t"]
+    replace: English
+  - triggers: ["Eur\t", "Euro\t", "Europ\t", "Europe\t", "Europea\t"]
+    replace: European
+  - triggers: ["FAL\t", "FALS\t"]
+    replace: FALSE
+  - triggers: ["Fre\t", "Fren\t", "Frenc\t"]
+    replace: French
+  - triggers: ["Ger\t", "Germ\t", "Germa\t"]
+    replace: German
+  - triggers: ["Ind\t", "Indi\t", "India\t"]
+    replace: Indian
+  - triggers: ["Int\t", "Inte\t", "Inter\t", "Intern\t", "Interne\t"]
+    replace: Internet
+  - triggers: ["Ira\t", "Iraq\t"]
+    replace: Iraqi
+  - triggers: ["Iri\t", "Iris\t"]
+    replace: Irish
+  - triggers: ["Isl\t", "Isla\t", "Islam\t", "Islami\t"]
+    replace: Islamic
+  - triggers: ["Isr\t", "Isra\t", "Israe\t", "Israel\t"]
+    replace: Israeli
+  - triggers: ["Ita\t", "Ital\t", "Itali\t", "Italia\t"]
+    replace: Italian
+  - triggers: ["Jap\t", "Japa\t", "Japan\t", "Japane\t", "Japanes\t"]
+    replace: Japanese
+  - triggers: ["Jew\t", "Jewi\t", "Jewis\t"]
+    replace: Jewish
+  - triggers: ["Lat\t", "Lati\t"]
+    replace: Latin
+  - triggers: ["Mex\t", "Mexi\t", "Mexic\t", "Mexica\t"]
+    replace: Mexican
+  - triggers: ["Mus\t", "Musl\t", "Musli\t"]
+    replace: Muslim
+  - triggers: ["Oly\t", "Olym\t", "Olymp\t", "Olympi\t"]
+    replace: Olympic
+  - triggers: ["Pal\t", "Pale\t", "Pales\t", "Palest\t", "Palesti\t", "Palestin\t", "Palestini\t", "Palestinia\t"]
+    replace: Palestinian
+  - triggers: ["Rep\t", "Repu\t", "Repub\t", "Republ\t", "Republi\t", "Republic\t", "Republica\t"]
+    replace: Republican
+  - triggers: ["Rus\t", "Russ\t", "Russi\t", "Russia\t"]
+    replace: Russian
+  - triggers: ["Sen\t", "Sena\t", "Senat\t"]
+    replace: Senate
+  - triggers: ["Sov\t", "Sovi\t", "Sovie\t"]
+    replace: Soviet
+  - triggers: ["Spa\t", "Span\t", "Spani\t", "Spanis\t"]
+    replace: Spanish
+  - triggers: ["Sup\t", "Supr\t", "Supre\t", "Suprem\t"]
+    replace: Supreme
+  - triggers: ["TRU\t"]
+    replace: TRUE
+  - triggers: ["Uni\t", "Unit\t", "Unite\t"]
+    replace: United
+  - triggers: ["aba\t", "aban\t", "aband\t", "abando\t"]
+    replace: abandon
+  - triggers: ["abi\t", "abil\t", "abili\t", "abilit\t"]
+    replace: ability
+  - triggers: ["abl\t"]
+    replace: able
+  - triggers: ["abo\t", "abor\t", "abort\t", "aborti\t", "abortio\t"]
+    replace: abortion
+  - triggers: ["abo\t", "abou\t"]
+    replace: about
+  - triggers: ["abo\t", "abov\t"]
+    replace: above
+  - triggers: ["abr\t", "abro\t", "abroa\t"]
+    replace: abroad
+  - triggers: ["abs\t", "abse\t", "absen\t", "absenc\t"]
+    replace: absence
+  - triggers: ["abs\t", "abso\t", "absol\t", "absolu\t", "absolut\t"]
+    replace: absolute
+  - triggers: ["abs\t", "abso\t", "absol\t", "absolu\t", "absolut\t", "absolute\t", "absolutel\t"]
+    replace: absolutely
+  - triggers: ["abs\t", "abso\t", "absor\t"]
+    replace: absorb
+  - triggers: ["abu\t", "abus\t"]
+    replace: abuse
+  - triggers: ["aca\t", "acad\t", "acade\t", "academ\t", "academi\t"]
+    replace: academic
+  - triggers: ["acc\t", "acce\t", "accep\t"]
+    replace: accept
+  - triggers: ["acc\t", "acce\t", "acces\t"]
+    replace: access
+  - triggers: ["acc\t", "acci\t", "accid\t", "accide\t", "acciden\t"]
+    replace: accident
+  - triggers: ["acc\t", "acco\t", "accom\t", "accomp\t", "accompa\t", "accompan\t"]
+    replace: accompany
+  - triggers: ["acc\t", "acco\t", "accom\t", "accomp\t", "accompl\t", "accompli\t", "accomplis\t"]
+    replace: accomplish
+  - triggers: ["acc\t", "acco\t", "accor\t", "accord\t", "accordi\t", "accordin\t"]
+    replace: according
+  - triggers: ["acc\t", "acco\t", "accou\t", "accoun\t"]
+    replace: account
+  - triggers: ["acc\t", "accu\t", "accur\t", "accura\t", "accurat\t"]
+    replace: accurate
+  - triggers: ["acc\t", "accu\t", "accus\t"]
+    replace: accuse
+  - triggers: ["ach\t", "achi\t", "achie\t", "achiev\t"]
+    replace: achieve
+  - triggers: ["ach\t", "achi\t", "achie\t", "achiev\t", "achieve\t", "achievem\t", "achieveme\t", "achievemen\t"]
+    replace: achievement
+  - triggers: ["aci\t"]
+    replace: acid
+  - triggers: ["ack\t", "ackn\t", "ackno\t", "acknow\t", "acknowl\t", "acknowle\t", "acknowled\t", "acknowledg\t"]
+    replace: acknowledge
+  - triggers: ["acq\t", "acqu\t", "acqui\t", "acquir\t"]
+    replace: acquire
+  - triggers: ["acr\t", "acro\t", "acros\t"]
+    replace: across
+  - triggers: ["act\t", "acti\t", "actio\t"]
+    replace: action
+  - triggers: ["act\t", "acti\t", "activ\t"]
+    replace: active
+  - triggers: ["act\t", "acti\t", "activ\t", "activi\t", "activis\t"]
+    replace: activist
+  - triggers: ["act\t", "acti\t", "activ\t", "activi\t", "activit\t"]
+    replace: activity
+  - triggers: ["act\t", "acto\t"]
+    replace: actor
+  - triggers: ["act\t", "actr\t", "actre\t", "actres\t"]
+    replace: actress
+  - triggers: ["act\t", "actu\t", "actua\t"]
+    replace: actual
+  - triggers: ["act\t", "actu\t", "actua\t", "actual\t", "actuall\t"]
+    replace: actually
+  - triggers: ["ada\t", "adap\t"]
+    replace: adapt
+  - triggers: ["add\t", "addi\t", "addit\t", "additi\t", "additio\t"]
+    replace: addition
+  - triggers: ["add\t", "addi\t", "addit\t", "additi\t", "additio\t", "addition\t", "additiona\t"]
+    replace: additional
+  - triggers: ["add\t", "addr\t", "addre\t", "addres\t"]
+    replace: address
+  - triggers: ["ade\t", "adeq\t", "adequ\t", "adequa\t", "adequat\t"]
+    replace: adequate
+  - triggers: ["adj\t", "adju\t", "adjus\t"]
+    replace: adjust
+  - triggers: ["adj\t", "adju\t", "adjus\t", "adjust\t", "adjustm\t", "adjustme\t", "adjustmen\t"]
+    replace: adjustment
+  - triggers: ["adm\t", "admi\t", "admin\t", "admini\t", "adminis\t", "administ\t", "administr\t", "administra\t", "administrat\t", "administrati\t", "administratio\t"]
+    replace: administration
+  - triggers: ["adm\t", "admi\t", "admin\t", "admini\t", "adminis\t", "administ\t", "administr\t", "administra\t", "administrat\t", "administrato\t"]
+    replace: administrator
+  - triggers: ["adm\t", "admi\t", "admir\t"]
+    replace: admire
+  - triggers: ["adm\t", "admi\t", "admis\t", "admiss\t", "admissi\t", "admissio\t"]
+    replace: admission
+  - triggers: ["adm\t", "admi\t"]
+    replace: admit
+  - triggers: ["ado\t", "adol\t", "adole\t", "adoles\t", "adolesc\t", "adolesce\t", "adolescen\t"]
+    replace: adolescent
+  - triggers: ["ado\t", "adop\t"]
+    replace: adopt
+  - triggers: ["adu\t", "adul\t"]
+    replace: adult
+  - triggers: ["adv\t", "adva\t", "advan\t", "advanc\t"]
+    replace: advance
+  - triggers: ["adv\t", "adva\t", "advan\t", "advanc\t", "advance\t"]
+    replace: advanced
+  - triggers: ["adv\t", "adva\t", "advan\t", "advant\t", "advanta\t", "advantag\t"]
+    replace: advantage
+  - triggers: ["adv\t", "adve\t", "adven\t", "advent\t", "adventu\t", "adventur\t"]
+    replace: adventure
+  - triggers: ["adv\t", "adve\t", "adver\t", "advert\t", "adverti\t", "advertis\t", "advertisi\t", "advertisin\t"]
+    replace: advertising
+  - triggers: ["adv\t", "advi\t", "advic\t"]
+    replace: advice
+  - triggers: ["adv\t", "advi\t", "advis\t"]
+    replace: advise
+  - triggers: ["adv\t", "advi\t", "advis\t", "advise\t"]
+    replace: adviser
+  - triggers: ["adv\t", "advo\t", "advoc\t", "advoca\t", "advocat\t"]
+    replace: advocate
+  - triggers: ["aff\t", "affa\t", "affai\t"]
+    replace: affair
+  - triggers: ["aff\t", "affe\t", "affec\t"]
+    replace: affect
+  - triggers: ["aff\t", "affo\t", "affor\t"]
+    replace: afford
+  - triggers: ["afr\t", "afra\t", "afrai\t"]
+    replace: afraid
+  - triggers: ["aft\t", "afte\t"]
+    replace: after
+  - triggers: ["aft\t", "afte\t", "after\t", "aftern\t", "afterno\t", "afternoo\t"]
+    replace: afternoon
+  - triggers: ["aga\t", "agai\t"]
+    replace: again
+  - triggers: ["aga\t", "agai\t", "again\t", "agains\t"]
+    replace: against
+  - triggers: ["age\t", "agen\t", "agenc\t"]
+    replace: agency
+  - triggers: ["age\t", "agen\t", "agend\t"]
+    replace: agenda
+  - triggers: ["age\t", "agen\t"]
+    replace: agent
+  - triggers: ["agg\t", "aggr\t", "aggre\t", "aggres\t", "aggress\t", "aggressi\t", "aggressiv\t"]
+    replace: aggressive
+  - triggers: ["agr\t", "agre\t"]
+    replace: agree
+  - triggers: ["agr\t", "agre\t", "agree\t", "agreem\t", "agreeme\t", "agreemen\t"]
+    replace: agreement
+  - triggers: ["agr\t", "agri\t", "agric\t", "agricu\t", "agricul\t", "agricult\t", "agricultu\t", "agricultur\t", "agricultura\t"]
+    replace: agricultural
+  - triggers: ["ahe\t", "ahea\t"]
+    replace: ahead
+  - triggers: ["aid\t"]
+    replace: aide
+  - triggers: ["air\t", "airc\t", "aircr\t", "aircra\t", "aircraf\t"]
+    replace: aircraft
+  - triggers: ["air\t", "airl\t", "airli\t", "airlin\t"]
+    replace: airline
+  - triggers: ["air\t", "airp\t", "airpo\t", "airpor\t"]
+    replace: airport
+  - triggers: ["alb\t", "albu\t"]
+    replace: album
+  - triggers: ["alc\t", "alco\t", "alcoh\t", "alcoho\t"]
+    replace: alcohol
+  - triggers: ["ali\t", "aliv\t"]
+    replace: alive
+  - triggers: ["all\t", "alli\t", "allia\t", "allian\t", "allianc\t"]
+    replace: alliance
+  - triggers: ["all\t", "allo\t"]
+    replace: allow
+  - triggers: ["all\t"]
+    replace: ally
+  - triggers: ["alm\t", "almo\t", "almos\t"]
+    replace: almost
+  - triggers: ["alo\t", "alon\t"]
+    replace: alone
+  - triggers: ["alo\t", "alon\t"]
+    replace: along
+  - triggers: ["alr\t", "alre\t", "alrea\t", "alread\t"]
+    replace: already
+  - triggers: ["als\t"]
+    replace: also
+  - triggers: ["alt\t", "alte\t"]
+    replace: alter
+  - triggers: ["alt\t", "alte\t", "alter\t", "altern\t", "alterna\t", "alternat\t", "alternati\t", "alternativ\t"]
+    replace: alternative
+  - triggers: ["alt\t", "alth\t", "altho\t", "althou\t", "althoug\t"]
+    replace: although
+  - triggers: ["alw\t", "alwa\t", "alway\t"]
+    replace: always
+  - triggers: ["ama\t", "amaz\t", "amazi\t", "amazin\t"]
+    replace: amazing
+  - triggers: ["amo\t", "amon\t"]
+    replace: among
+  - triggers: ["amo\t", "amou\t", "amoun\t"]
+    replace: amount
+  - triggers: ["ana\t", "anal\t", "analy\t", "analys\t", "analysi\t"]
+    replace: analysis
+  - triggers: ["ana\t", "anal\t", "analy\t", "analys\t"]
+    replace: analyst
+  - triggers: ["ana\t", "anal\t", "analy\t", "analyz\t"]
+    replace: analyze
+  - triggers: ["anc\t", "anci\t", "ancie\t", "ancien\t"]
+    replace: ancient
+  - triggers: ["ang\t", "ange\t"]
+    replace: anger
+  - triggers: ["ang\t", "angl\t"]
+    replace: angle
+  - triggers: ["ang\t", "angr\t"]
+    replace: angry
+  - triggers: ["ani\t", "anim\t", "anima\t"]
+    replace: animal
+  - triggers: ["ann\t", "anni\t", "anniv\t", "annive\t", "anniver\t", "annivers\t", "anniversa\t", "anniversar\t"]
+    replace: anniversary
+  - triggers: ["ann\t", "anno\t", "annou\t", "announ\t", "announc\t"]
+    replace: announce
+  - triggers: ["ann\t", "annu\t", "annua\t"]
+    replace: annual
+  - triggers: ["ano\t", "anot\t", "anoth\t", "anothe\t"]
+    replace: another
+  - triggers: ["ans\t", "answ\t", "answe\t"]
+    replace: answer
+  - triggers: ["ant\t", "anti\t", "antic\t", "antici\t", "anticip\t", "anticipa\t", "anticipat\t"]
+    replace: anticipate
+  - triggers: ["anx\t", "anxi\t", "anxie\t", "anxiet\t"]
+    replace: anxiety
+  - triggers: ["any\t", "anyb\t", "anybo\t", "anybod\t"]
+    replace: anybody
+  - triggers: ["any\t", "anym\t", "anymo\t", "anymor\t"]
+    replace: anymore
+  - triggers: ["any\t", "anyo\t", "anyon\t"]
+    replace: anyone
+  - triggers: ["any\t", "anyt\t", "anyth\t", "anythi\t", "anythin\t"]
+    replace: anything
+  - triggers: ["any\t", "anyw\t", "anywa\t"]
+    replace: anyway
+  - triggers: ["any\t", "anyw\t", "anywh\t", "anywhe\t", "anywher\t"]
+    replace: anywhere
+  - triggers: ["apa\t", "apar\t"]
+    replace: apart
+  - triggers: ["apa\t", "apar\t", "apart\t", "apartm\t", "apartme\t", "apartmen\t"]
+    replace: apartment
+  - triggers: ["app\t", "appa\t", "appar\t", "appare\t", "apparen\t"]
+    replace: apparent
+  - triggers: ["app\t", "appa\t", "appar\t", "appare\t", "apparen\t", "apparent\t", "apparentl\t"]
+    replace: apparently
+  - triggers: ["app\t", "appe\t", "appea\t"]
+    replace: appeal
+  - triggers: ["app\t", "appe\t", "appea\t"]
+    replace: appear
+  - triggers: ["app\t", "appe\t", "appea\t", "appear\t", "appeara\t", "appearan\t", "appearanc\t"]
+    replace: appearance
+  - triggers: ["app\t", "appl\t"]
+    replace: apple
+  - triggers: ["app\t", "appl\t", "appli\t", "applic\t", "applica\t", "applicat\t", "applicati\t", "applicatio\t"]
+    replace: application
+  - triggers: ["app\t", "appl\t"]
+    replace: apply
+  - triggers: ["app\t", "appo\t", "appoi\t", "appoin\t"]
+    replace: appoint
+  - triggers: ["app\t", "appo\t", "appoi\t", "appoin\t", "appoint\t", "appointm\t", "appointme\t", "appointmen\t"]
+    replace: appointment
+  - triggers: ["app\t", "appr\t", "appre\t", "apprec\t", "appreci\t", "apprecia\t", "appreciat\t"]
+    replace: appreciate
+  - triggers: ["app\t", "appr\t", "appro\t", "approa\t", "approac\t"]
+    replace: approach
+  - triggers: ["app\t", "appr\t", "appro\t", "approp\t", "appropr\t", "appropri\t", "appropria\t", "appropriat\t"]
+    replace: appropriate
+  - triggers: ["app\t", "appr\t", "appro\t", "approv\t", "approva\t"]
+    replace: approval
+  - triggers: ["app\t", "appr\t", "appro\t", "approv\t"]
+    replace: approve
+  - triggers: ["app\t", "appr\t", "appro\t", "approx\t", "approxi\t", "approxim\t", "approxima\t", "approximat\t", "approximate\t", "approximatel\t"]
+    replace: approximately
+  - triggers: ["arc\t", "arch\t", "archi\t", "archit\t", "archite\t", "architec\t"]
+    replace: architect
+  - triggers: ["are\t"]
+    replace: area
+  - triggers: ["arg\t", "argu\t"]
+    replace: argue
+  - triggers: ["arg\t", "argu\t", "argum\t", "argume\t", "argumen\t"]
+    replace: argument
+  - triggers: ["ari\t", "aris\t"]
+    replace: arise
+  - triggers: ["arm\t", "arme\t"]
+    replace: armed
+  - triggers: ["arm\t"]
+    replace: army
+  - triggers: ["aro\t", "arou\t", "aroun\t"]
+    replace: around
+  - triggers: ["arr\t", "arra\t", "arran\t", "arrang\t"]
+    replace: arrange
+  - triggers: ["arr\t", "arra\t", "arran\t", "arrang\t", "arrange\t", "arrangem\t", "arrangeme\t", "arrangemen\t"]
+    replace: arrangement
+  - triggers: ["arr\t", "arre\t", "arres\t"]
+    replace: arrest
+  - triggers: ["arr\t", "arri\t", "arriv\t", "arriva\t"]
+    replace: arrival
+  - triggers: ["arr\t", "arri\t", "arriv\t"]
+    replace: arrive
+  - triggers: ["art\t", "arti\t", "artic\t", "articl\t"]
+    replace: article
+  - triggers: ["art\t", "arti\t", "artis\t"]
+    replace: artist
+  - triggers: ["art\t", "arti\t", "artis\t", "artist\t", "artisti\t"]
+    replace: artistic
+  - triggers: ["asi\t", "asid\t"]
+    replace: aside
+  - triggers: ["asl\t", "asle\t", "aslee\t"]
+    replace: asleep
+  - triggers: ["asp\t", "aspe\t", "aspec\t"]
+    replace: aspect
+  - triggers: ["ass\t", "assa\t", "assau\t", "assaul\t"]
+    replace: assault
+  - triggers: ["ass\t", "asse\t", "asser\t"]
+    replace: assert
+  - triggers: ["ass\t", "asse\t", "asses\t"]
+    replace: assess
+  - triggers: ["ass\t", "asse\t", "asses\t", "assess\t", "assessm\t", "assessme\t", "assessmen\t"]
+    replace: assessment
+  - triggers: ["ass\t", "asse\t"]
+    replace: asset
+  - triggers: ["ass\t", "assi\t", "assig\t"]
+    replace: assign
+  - triggers: ["ass\t", "assi\t", "assig\t", "assign\t", "assignm\t", "assignme\t", "assignmen\t"]
+    replace: assignment
+  - triggers: ["ass\t", "assi\t", "assis\t"]
+    replace: assist
+  - triggers: ["ass\t", "assi\t", "assis\t", "assist\t", "assista\t", "assistan\t", "assistanc\t"]
+    replace: assistance
+  - triggers: ["ass\t", "assi\t", "assis\t", "assist\t", "assista\t", "assistan\t"]
+    replace: assistant
+  - triggers: ["ass\t", "asso\t", "assoc\t", "associ\t", "associa\t", "associat\t"]
+    replace: associate
+  - triggers: ["ass\t", "asso\t", "assoc\t", "associ\t", "associa\t", "associat\t", "associati\t", "associatio\t"]
+    replace: association
+  - triggers: ["ass\t", "assu\t", "assum\t"]
+    replace: assume
+  - triggers: ["ass\t", "assu\t", "assum\t", "assump\t", "assumpt\t", "assumpti\t", "assumptio\t"]
+    replace: assumption
+  - triggers: ["ass\t", "assu\t", "assur\t"]
+    replace: assure
+  - triggers: ["ath\t", "athl\t", "athle\t", "athlet\t"]
+    replace: athlete
+  - triggers: ["ath\t", "athl\t", "athle\t", "athlet\t", "athleti\t"]
+    replace: athletic
+  - triggers: ["atm\t", "atmo\t", "atmos\t", "atmosp\t", "atmosph\t", "atmosphe\t", "atmospher\t"]
+    replace: atmosphere
+  - triggers: ["att\t", "atta\t", "attac\t"]
+    replace: attach
+  - triggers: ["att\t", "atta\t", "attac\t"]
+    replace: attack
+  - triggers: ["att\t", "atte\t", "attem\t", "attemp\t"]
+    replace: attempt
+  - triggers: ["att\t", "atte\t", "atten\t"]
+    replace: attend
+  - triggers: ["att\t", "atte\t", "atten\t", "attent\t", "attenti\t", "attentio\t"]
+    replace: attention
+  - triggers: ["att\t", "atti\t", "attit\t", "attitu\t", "attitud\t"]
+    replace: attitude
+  - triggers: ["att\t", "atto\t", "attor\t", "attorn\t", "attorne\t"]
+    replace: attorney
+  - triggers: ["att\t", "attr\t", "attra\t", "attrac\t"]
+    replace: attract
+  - triggers: ["att\t", "attr\t", "attra\t", "attrac\t", "attract\t", "attracti\t", "attractiv\t"]
+    replace: attractive
+  - triggers: ["att\t", "attr\t", "attri\t", "attrib\t", "attribu\t", "attribut\t"]
+    replace: attribute
+  - triggers: ["aud\t", "audi\t", "audie\t", "audien\t", "audienc\t"]
+    replace: audience
+  - triggers: ["aut\t", "auth\t", "autho\t"]
+    replace: author
+  - triggers: ["aut\t", "auth\t", "autho\t", "author\t", "authori\t", "authorit\t"]
+    replace: authority
+  - triggers: ["aut\t"]
+    replace: auto
+  - triggers: ["ava\t", "avai\t", "avail\t", "availa\t", "availab\t", "availabl\t"]
+    replace: available
+  - triggers: ["ave\t", "aver\t", "avera\t", "averag\t"]
+    replace: average
+  - triggers: ["avo\t", "avoi\t"]
+    replace: avoid
+  - triggers: ["awa\t", "awar\t"]
+    replace: award
+  - triggers: ["awa\t", "awar\t"]
+    replace: aware
+  - triggers: ["awa\t", "awar\t", "aware\t", "awaren\t", "awarene\t", "awarenes\t"]
+    replace: awareness
+  - triggers: ["awa\t"]
+    replace: away
+  - triggers: ["awf\t", "awfu\t"]
+    replace: awful
+  - triggers: ["bab\t"]
+    replace: baby
+  - triggers: ["bac\t"]
+    replace: back
+  - triggers: ["bac\t", "back\t", "backg\t", "backgr\t", "backgro\t", "backgrou\t", "backgroun\t"]
+    replace: background
+  - triggers: ["bad\t", "badl\t"]
+    replace: badly
+  - triggers: ["bak\t"]
+    replace: bake
+  - triggers: ["bal\t", "bala\t", "balan\t", "balanc\t"]
+    replace: balance
+  - triggers: ["bal\t"]
+    replace: ball
+  - triggers: ["ban\t"]
+    replace: band
+  - triggers: ["ban\t"]
+    replace: bank
+  - triggers: ["bar\t", "bare\t", "barel\t"]
+    replace: barely
+  - triggers: ["bar\t", "barr\t", "barre\t"]
+    replace: barrel
+  - triggers: ["bar\t", "barr\t", "barri\t", "barrie\t"]
+    replace: barrier
+  - triggers: ["bas\t"]
+    replace: base
+  - triggers: ["bas\t", "base\t", "baseb\t", "baseba\t", "basebal\t"]
+    replace: baseball
+  - triggers: ["bas\t", "basi\t"]
+    replace: basic
+  - triggers: ["bas\t", "basi\t", "basic\t", "basica\t", "basical\t", "basicall\t"]
+    replace: basically
+  - triggers: ["bas\t", "basi\t"]
+    replace: basis
+  - triggers: ["bas\t", "bask\t", "baske\t"]
+    replace: basket
+  - triggers: ["bas\t", "bask\t", "baske\t", "basket\t", "basketb\t", "basketba\t", "basketbal\t"]
+    replace: basketball
+  - triggers: ["bat\t", "bath\t", "bathr\t", "bathro\t", "bathroo\t"]
+    replace: bathroom
+  - triggers: ["bat\t", "batt\t", "batte\t", "batter\t"]
+    replace: battery
+  - triggers: ["bat\t", "batt\t", "battl\t"]
+    replace: battle
+  - triggers: ["bea\t", "beac\t"]
+    replace: beach
+  - triggers: ["bea\t"]
+    replace: bean
+  - triggers: ["bea\t"]
+    replace: bear
+  - triggers: ["bea\t"]
+    replace: beat
+  - triggers: ["bea\t", "beau\t", "beaut\t", "beauti\t", "beautif\t", "beautifu\t"]
+    replace: beautiful
+  - triggers: ["bea\t", "beau\t", "beaut\t"]
+    replace: beauty
+  - triggers: ["bec\t", "beca\t", "becau\t", "becaus\t"]
+    replace: because
+  - triggers: ["bec\t", "beco\t", "becom\t"]
+    replace: become
+  - triggers: ["bed\t", "bedr\t", "bedro\t", "bedroo\t"]
+    replace: bedroom
+  - triggers: ["bee\t"]
+    replace: beer
+  - triggers: ["bef\t", "befo\t", "befor\t"]
+    replace: before
+  - triggers: ["beg\t", "begi\t"]
+    replace: begin
+  - triggers: ["beg\t", "begi\t", "begin\t", "beginn\t", "beginni\t", "beginnin\t"]
+    replace: beginning
+  - triggers: ["beh\t", "beha\t", "behav\t", "behavi\t", "behavio\t"]
+    replace: behavior
+  - triggers: ["beh\t", "behi\t", "behin\t"]
+    replace: behind
+  - triggers: ["bei\t", "bein\t"]
+    replace: being
+  - triggers: ["bel\t", "beli\t", "belie\t"]
+    replace: belief
+  - triggers: ["bel\t", "beli\t", "belie\t", "believ\t"]
+    replace: believe
+  - triggers: ["bel\t"]
+    replace: bell
+  - triggers: ["bel\t", "belo\t", "belon\t"]
+    replace: belong
+  - triggers: ["bel\t", "belo\t"]
+    replace: below
+  - triggers: ["bel\t"]
+    replace: belt
+  - triggers: ["ben\t", "benc\t"]
+    replace: bench
+  - triggers: ["ben\t"]
+    replace: bend
+  - triggers: ["ben\t", "bene\t", "benea\t", "beneat\t"]
+    replace: beneath
+  - triggers: ["ben\t", "bene\t", "benef\t", "benefi\t"]
+    replace: benefit
+  - triggers: ["bes\t", "besi\t", "besid\t"]
+    replace: beside
+  - triggers: ["bes\t", "besi\t", "besid\t", "beside\t"]
+    replace: besides
+  - triggers: ["bes\t"]
+    replace: best
+  - triggers: ["bet\t", "bett\t", "bette\t"]
+    replace: better
+  - triggers: ["bet\t", "betw\t", "betwe\t", "betwee\t"]
+    replace: between
+  - triggers: ["bey\t", "beyo\t", "beyon\t"]
+    replace: beyond
+  - triggers: ["bik\t"]
+    replace: bike
+  - triggers: ["bil\t"]
+    replace: bill
+  - triggers: ["bil\t", "bill\t", "billi\t", "billio\t"]
+    replace: billion
+  - triggers: ["bin\t"]
+    replace: bind
+  - triggers: ["bio\t", "biol\t", "biolo\t", "biolog\t", "biologi\t", "biologic\t", "biologica\t"]
+    replace: biological
+  - triggers: ["bir\t"]
+    replace: bird
+  - triggers: ["bir\t", "birt\t"]
+    replace: birth
+  - triggers: ["bir\t", "birt\t", "birth\t", "birthd\t", "birthda\t"]
+    replace: birthday
+  - triggers: ["bit\t"]
+    replace: bite
+  - triggers: ["bla\t", "blac\t"]
+    replace: black
+  - triggers: ["bla\t", "blad\t"]
+    replace: blade
+  - triggers: ["bla\t", "blam\t"]
+    replace: blame
+  - triggers: ["bla\t", "blan\t", "blank\t", "blanke\t"]
+    replace: blanket
+  - triggers: ["bli\t", "blin\t"]
+    replace: blind
+  - triggers: ["blo\t", "bloc\t"]
+    replace: block
+  - triggers: ["blo\t", "bloo\t"]
+    replace: blood
+  - triggers: ["blo\t"]
+    replace: blow
+  - triggers: ["blu\t"]
+    replace: blue
+  - triggers: ["boa\t", "boar\t"]
+    replace: board
+  - triggers: ["boa\t"]
+    replace: boat
+  - triggers: ["bod\t"]
+    replace: body
+  - triggers: ["bom\t"]
+    replace: bomb
+  - triggers: ["bom\t", "bomb\t", "bombi\t", "bombin\t"]
+    replace: bombing
+  - triggers: ["bon\t"]
+    replace: bond
+  - triggers: ["bon\t"]
+    replace: bone
+  - triggers: ["boo\t"]
+    replace: book
+  - triggers: ["boo\t"]
+    replace: boom
+  - triggers: ["boo\t"]
+    replace: boot
+  - triggers: ["bor\t", "bord\t", "borde\t"]
+    replace: border
+  - triggers: ["bor\t"]
+    replace: born
+  - triggers: ["bor\t", "borr\t", "borro\t"]
+    replace: borrow
+  - triggers: ["bos\t"]
+    replace: boss
+  - triggers: ["bot\t"]
+    replace: both
+  - triggers: ["bot\t", "both\t", "bothe\t"]
+    replace: bother
+  - triggers: ["bot\t", "bott\t", "bottl\t"]
+    replace: bottle
+  - triggers: ["bot\t", "bott\t", "botto\t"]
+    replace: bottom
+  - triggers: ["bou\t", "boun\t", "bound\t", "bounda\t", "boundar\t"]
+    replace: boundary
+  - triggers: ["bow\t"]
+    replace: bowl
+  - triggers: ["boy\t", "boyf\t", "boyfr\t", "boyfri\t", "boyfrie\t", "boyfrien\t"]
+    replace: boyfriend
+  - triggers: ["bra\t", "brai\t"]
+    replace: brain
+  - triggers: ["bra\t", "bran\t", "branc\t"]
+    replace: branch
+  - triggers: ["bra\t", "bran\t"]
+    replace: brand
+  - triggers: ["bre\t", "brea\t"]
+    replace: bread
+  - triggers: ["bre\t", "brea\t"]
+    replace: break
+  - triggers: ["bre\t", "brea\t", "break\t", "breakf\t", "breakfa\t", "breakfas\t"]
+    replace: breakfast
+  - triggers: ["bre\t", "brea\t", "breas\t"]
+    replace: breast
+  - triggers: ["bre\t", "brea\t", "breat\t"]
+    replace: breath
+  - triggers: ["bre\t", "brea\t", "breat\t", "breath\t"]
+    replace: breathe
+  - triggers: ["bri\t", "bric\t"]
+    replace: brick
+  - triggers: ["bri\t", "brid\t", "bridg\t"]
+    replace: bridge
+  - triggers: ["bri\t", "brie\t"]
+    replace: brief
+  - triggers: ["bri\t", "brie\t", "brief\t", "briefl\t"]
+    replace: briefly
+  - triggers: ["bri\t", "brig\t", "brigh\t"]
+    replace: bright
+  - triggers: ["bri\t", "bril\t", "brill\t", "brilli\t", "brillia\t", "brillian\t"]
+    replace: brilliant
+  - triggers: ["bri\t", "brin\t"]
+    replace: bring
+  - triggers: ["bro\t", "broa\t"]
+    replace: broad
+  - triggers: ["bro\t", "brok\t", "broke\t"]
+    replace: broken
+  - triggers: ["bro\t", "brot\t", "broth\t", "brothe\t"]
+    replace: brother
+  - triggers: ["bro\t", "brow\t"]
+    replace: brown
+  - triggers: ["bru\t", "brus\t"]
+    replace: brush
+  - triggers: ["buc\t"]
+    replace: buck
+  - triggers: ["bud\t", "budg\t", "budge\t"]
+    replace: budget
+  - triggers: ["bui\t", "buil\t"]
+    replace: build
+  - triggers: ["bui\t", "buil\t", "build\t", "buildi\t", "buildin\t"]
+    replace: building
+  - triggers: ["bul\t", "bull\t", "bulle\t"]
+    replace: bullet
+  - triggers: ["bun\t", "bunc\t"]
+    replace: bunch
+  - triggers: ["bur\t", "burd\t", "burde\t"]
+    replace: burden
+  - triggers: ["bur\t"]
+    replace: burn
+  - triggers: ["bur\t"]
+    replace: bury
+  - triggers: ["bus\t", "busi\t", "busin\t", "busine\t", "busines\t"]
+    replace: business
+  - triggers: ["bus\t"]
+    replace: busy
+  - triggers: ["but\t", "butt\t", "butte\t"]
+    replace: butter
+  - triggers: ["but\t", "butt\t", "butto\t"]
+    replace: button
+  - triggers: ["buy\t", "buye\t"]
+    replace: buyer
+  - triggers: ["cab\t", "cabi\t"]
+    replace: cabin
+  - triggers: ["cab\t", "cabi\t", "cabin\t", "cabine\t"]
+    replace: cabinet
+  - triggers: ["cab\t", "cabl\t"]
+    replace: cable
+  - triggers: ["cak\t"]
+    replace: cake
+  - triggers: ["cal\t", "calc\t", "calcu\t", "calcul\t", "calcula\t", "calculat\t"]
+    replace: calculate
+  - triggers: ["cal\t"]
+    replace: call
+  - triggers: ["cam\t", "came\t", "camer\t"]
+    replace: camera
+  - triggers: ["cam\t"]
+    replace: camp
+  - triggers: ["cam\t", "camp\t", "campa\t", "campai\t", "campaig\t"]
+    replace: campaign
+  - triggers: ["cam\t", "camp\t", "campu\t"]
+    replace: campus
+  - triggers: ["can\t", "canc\t", "cance\t"]
+    replace: cancer
+  - triggers: ["can\t", "cand\t", "candi\t", "candid\t", "candida\t", "candidat\t"]
+    replace: candidate
+  - triggers: ["cap\t", "capa\t", "capab\t", "capabi\t", "capabil\t", "capabili\t", "capabilit\t"]
+    replace: capability
+  - triggers: ["cap\t", "capa\t", "capab\t", "capabl\t"]
+    replace: capable
+  - triggers: ["cap\t", "capa\t", "capac\t", "capaci\t", "capacit\t"]
+    replace: capacity
+  - triggers: ["cap\t", "capi\t", "capit\t", "capita\t"]
+    replace: capital
+  - triggers: ["cap\t", "capt\t", "capta\t", "captai\t"]
+    replace: captain
+  - triggers: ["cap\t", "capt\t", "captu\t", "captur\t"]
+    replace: capture
+  - triggers: ["car\t", "carb\t", "carbo\t"]
+    replace: carbon
+  - triggers: ["car\t"]
+    replace: card
+  - triggers: ["car\t"]
+    replace: care
+  - triggers: ["car\t", "care\t", "caree\t"]
+    replace: career
+  - triggers: ["car\t", "care\t", "caref\t", "carefu\t"]
+    replace: careful
+  - triggers: ["car\t", "care\t", "caref\t", "carefu\t", "careful\t", "carefull\t"]
+    replace: carefully
+  - triggers: ["car\t", "carr\t", "carri\t", "carrie\t"]
+    replace: carrier
+  - triggers: ["car\t", "carr\t"]
+    replace: carry
+  - triggers: ["cas\t"]
+    replace: case
+  - triggers: ["cas\t"]
+    replace: cash
+  - triggers: ["cas\t"]
+    replace: cast
+  - triggers: ["cat\t", "catc\t"]
+    replace: catch
+  - triggers: ["cat\t", "cate\t", "categ\t", "catego\t", "categor\t"]
+    replace: category
+  - triggers: ["cau\t", "caus\t"]
+    replace: cause
+  - triggers: ["cei\t", "ceil\t", "ceili\t", "ceilin\t"]
+    replace: ceiling
+  - triggers: ["cel\t", "cele\t", "celeb\t", "celebr\t", "celebra\t", "celebrat\t"]
+    replace: celebrate
+  - triggers: ["cel\t", "cele\t", "celeb\t", "celebr\t", "celebra\t", "celebrat\t", "celebrati\t", "celebratio\t"]
+    replace: celebration
+  - triggers: ["cel\t", "cele\t", "celeb\t", "celebr\t", "celebri\t", "celebrit\t"]
+    replace: celebrity
+  - triggers: ["cel\t"]
+    replace: cell
+  - triggers: ["cen\t", "cent\t", "cente\t"]
+    replace: center
+  - triggers: ["cen\t", "cent\t", "centr\t", "centra\t"]
+    replace: central
+  - triggers: ["cen\t", "cent\t", "centu\t", "centur\t"]
+    replace: century
+  - triggers: ["cer\t", "cere\t", "cerem\t", "ceremo\t", "ceremon\t"]
+    replace: ceremony
+  - triggers: ["cer\t", "cert\t", "certa\t", "certai\t"]
+    replace: certain
+  - triggers: ["cer\t", "cert\t", "certa\t", "certai\t", "certain\t", "certainl\t"]
+    replace: certainly
+  - triggers: ["cha\t", "chai\t"]
+    replace: chain
+  - triggers: ["cha\t", "chai\t"]
+    replace: chair
+  - triggers: ["cha\t", "chai\t", "chair\t", "chairm\t", "chairma\t"]
+    replace: chairman
+  - triggers: ["cha\t", "chal\t", "chall\t", "challe\t", "challen\t", "challeng\t"]
+    replace: challenge
+  - triggers: ["cha\t", "cham\t", "chamb\t", "chambe\t"]
+    replace: chamber
+  - triggers: ["cha\t", "cham\t", "champ\t", "champi\t", "champio\t"]
+    replace: champion
+  - triggers: ["cha\t", "cham\t", "champ\t", "champi\t", "champio\t", "champion\t", "champions\t", "championsh\t", "championshi\t"]
+    replace: championship
+  - triggers: ["cha\t", "chan\t", "chanc\t"]
+    replace: chance
+  - triggers: ["cha\t", "chan\t", "chang\t"]
+    replace: change
+  - triggers: ["cha\t", "chan\t", "chang\t", "changi\t", "changin\t"]
+    replace: changing
+  - triggers: ["cha\t", "chan\t", "chann\t", "channe\t"]
+    replace: channel
+  - triggers: ["cha\t", "chap\t", "chapt\t", "chapte\t"]
+    replace: chapter
+  - triggers: ["cha\t", "char\t", "chara\t", "charac\t", "charact\t", "characte\t"]
+    replace: character
+  - triggers: ["cha\t", "char\t", "chara\t", "charac\t", "charact\t", "characte\t", "character\t", "characteri\t", "characteris\t", "characterist\t", "characteristi\t"]
+    replace: characteristic
+  - triggers: ["cha\t", "char\t", "chara\t", "charac\t", "charact\t", "characte\t", "character\t", "characteri\t", "characteriz\t"]
+    replace: characterize
+  - triggers: ["cha\t", "char\t", "charg\t"]
+    replace: charge
+  - triggers: ["cha\t", "char\t", "chari\t", "charit\t"]
+    replace: charity
+  - triggers: ["cha\t", "char\t"]
+    replace: chart
+  - triggers: ["cha\t", "chas\t"]
+    replace: chase
+  - triggers: ["che\t", "chea\t"]
+    replace: cheap
+  - triggers: ["che\t", "chec\t"]
+    replace: check
+  - triggers: ["che\t", "chee\t"]
+    replace: cheek
+  - triggers: ["che\t", "chee\t", "chees\t"]
+    replace: cheese
+  - triggers: ["che\t"]
+    replace: chef
+  - triggers: ["che\t", "chem\t", "chemi\t", "chemic\t", "chemica\t"]
+    replace: chemical
+  - triggers: ["che\t", "ches\t"]
+    replace: chest
+  - triggers: ["chi\t", "chic\t", "chick\t", "chicke\t"]
+    replace: chicken
+  - triggers: ["chi\t", "chie\t"]
+    replace: chief
+  - triggers: ["chi\t", "chil\t"]
+    replace: child
+  - triggers: ["chi\t", "chil\t", "child\t", "childh\t", "childho\t", "childhoo\t"]
+    replace: childhood
+  - triggers: ["chi\t"]
+    replace: chip
+  - triggers: ["cho\t", "choc\t", "choco\t", "chocol\t", "chocola\t", "chocolat\t"]
+    replace: chocolate
+  - triggers: ["cho\t", "choi\t", "choic\t"]
+    replace: choice
+  - triggers: ["cho\t", "chol\t", "chole\t", "choles\t", "cholest\t", "choleste\t", "cholester\t", "cholestero\t"]
+    replace: cholesterol
+  - triggers: ["cho\t", "choo\t", "choos\t"]
+    replace: choose
+  - triggers: ["chu\t", "chur\t", "churc\t"]
+    replace: church
+  - triggers: ["cig\t", "ciga\t", "cigar\t", "cigare\t", "cigaret\t", "cigarett\t"]
+    replace: cigarette
+  - triggers: ["cir\t", "circ\t", "circl\t"]
+    replace: circle
+  - triggers: ["cir\t", "circ\t", "circu\t", "circum\t", "circums\t", "circumst\t", "circumsta\t", "circumstan\t", "circumstanc\t"]
+    replace: circumstance
+  - triggers: ["cit\t"]
+    replace: cite
+  - triggers: ["cit\t", "citi\t", "citiz\t", "citize\t"]
+    replace: citizen
+  - triggers: ["cit\t"]
+    replace: city
+  - triggers: ["civ\t", "civi\t"]
+    replace: civil
+  - triggers: ["civ\t", "civi\t", "civil\t", "civili\t", "civilia\t"]
+    replace: civilian
+  - triggers: ["cla\t", "clai\t"]
+    replace: claim
+  - triggers: ["cla\t", "clas\t"]
+    replace: class
+  - triggers: ["cla\t", "clas\t", "class\t", "classi\t"]
+    replace: classic
+  - triggers: ["cla\t", "clas\t", "class\t", "classr\t", "classro\t", "classroo\t"]
+    replace: classroom
+  - triggers: ["cle\t", "clea\t"]
+    replace: clean
+  - triggers: ["cle\t", "clea\t"]
+    replace: clear
+  - triggers: ["cle\t", "clea\t", "clear\t", "clearl\t"]
+    replace: clearly
+  - triggers: ["cli\t", "clie\t", "clien\t"]
+    replace: client
+  - triggers: ["cli\t", "clim\t", "clima\t", "climat\t"]
+    replace: climate
+  - triggers: ["cli\t", "clim\t"]
+    replace: climb
+  - triggers: ["cli\t", "clin\t", "clini\t"]
+    replace: clinic
+  - triggers: ["cli\t", "clin\t", "clini\t", "clinic\t", "clinica\t"]
+    replace: clinical
+  - triggers: ["clo\t", "cloc\t"]
+    replace: clock
+  - triggers: ["clo\t", "clos\t"]
+    replace: close
+  - triggers: ["clo\t", "clos\t", "close\t", "closel\t"]
+    replace: closely
+  - triggers: ["clo\t", "clos\t", "close\t"]
+    replace: closer
+  - triggers: ["clo\t", "clot\t", "cloth\t", "clothe\t"]
+    replace: clothes
+  - triggers: ["clo\t", "clot\t", "cloth\t", "clothi\t", "clothin\t"]
+    replace: clothing
+  - triggers: ["clo\t", "clou\t"]
+    replace: cloud
+  - triggers: ["clu\t"]
+    replace: club
+  - triggers: ["clu\t"]
+    replace: clue
+  - triggers: ["clu\t", "clus\t", "clust\t", "cluste\t"]
+    replace: cluster
+  - triggers: ["coa\t", "coac\t"]
+    replace: coach
+  - triggers: ["coa\t"]
+    replace: coal
+  - triggers: ["coa\t", "coal\t", "coali\t", "coalit\t", "coaliti\t", "coalitio\t"]
+    replace: coalition
+  - triggers: ["coa\t", "coas\t"]
+    replace: coast
+  - triggers: ["coa\t"]
+    replace: coat
+  - triggers: ["cod\t"]
+    replace: code
+  - triggers: ["cof\t", "coff\t", "coffe\t"]
+    replace: coffee
+  - triggers: ["cog\t", "cogn\t", "cogni\t", "cognit\t", "cogniti\t", "cognitiv\t"]
+    replace: cognitive
+  - triggers: ["col\t"]
+    replace: cold
+  - triggers: ["col\t", "coll\t", "colla\t", "collap\t", "collaps\t"]
+    replace: collapse
+  - triggers: ["col\t", "coll\t", "colle\t", "collea\t", "colleag\t", "colleagu\t"]
+    replace: colleague
+  - triggers: ["col\t", "coll\t", "colle\t", "collec\t"]
+    replace: collect
+  - triggers: ["col\t", "coll\t", "colle\t", "collec\t", "collect\t", "collecti\t", "collectio\t"]
+    replace: collection
+  - triggers: ["col\t", "coll\t", "colle\t", "collec\t", "collect\t", "collecti\t", "collectiv\t"]
+    replace: collective
+  - triggers: ["col\t", "coll\t", "colle\t", "colleg\t"]
+    replace: college
+  - triggers: ["col\t", "colo\t", "colon\t", "coloni\t", "colonia\t"]
+    replace: colonial
+  - triggers: ["col\t", "colo\t"]
+    replace: color
+  - triggers: ["col\t", "colu\t", "colum\t"]
+    replace: column
+  - triggers: ["com\t", "comb\t", "combi\t", "combin\t", "combina\t", "combinat\t", "combinati\t", "combinatio\t"]
+    replace: combination
+  - triggers: ["com\t", "comb\t", "combi\t", "combin\t"]
+    replace: combine
+  - triggers: ["com\t"]
+    replace: come
+  - triggers: ["com\t", "come\t", "comed\t"]
+    replace: comedy
+  - triggers: ["com\t", "comf\t", "comfo\t", "comfor\t"]
+    replace: comfort
+  - triggers: ["com\t", "comf\t", "comfo\t", "comfor\t", "comfort\t", "comforta\t", "comfortab\t", "comfortabl\t"]
+    replace: comfortable
+  - triggers: ["com\t", "comm\t", "comma\t", "comman\t"]
+    replace: command
+  - triggers: ["com\t", "comm\t", "comma\t", "comman\t", "command\t", "commande\t"]
+    replace: commander
+  - triggers: ["com\t", "comm\t", "comme\t", "commen\t"]
+    replace: comment
+  - triggers: ["com\t", "comm\t", "comme\t", "commer\t", "commerc\t", "commerci\t", "commercia\t"]
+    replace: commercial
+  - triggers: ["com\t", "comm\t", "commi\t", "commis\t", "commiss\t", "commissi\t", "commissio\t"]
+    replace: commission
+  - triggers: ["com\t", "comm\t", "commi\t"]
+    replace: commit
+  - triggers: ["com\t", "comm\t", "commi\t", "commit\t", "commitm\t", "commitme\t", "commitmen\t"]
+    replace: commitment
+  - triggers: ["com\t", "comm\t", "commi\t", "commit\t", "committ\t", "committe\t"]
+    replace: committee
+  - triggers: ["com\t", "comm\t", "commo\t"]
+    replace: common
+  - triggers: ["com\t", "comm\t", "commu\t", "commun\t", "communi\t", "communic\t", "communica\t", "communicat\t"]
+    replace: communicate
+  - triggers: ["com\t", "comm\t", "commu\t", "commun\t", "communi\t", "communic\t", "communica\t", "communicat\t", "communicati\t", "communicatio\t"]
+    replace: communication
+  - triggers: ["com\t", "comm\t", "commu\t", "commun\t", "communi\t", "communit\t"]
+    replace: community
+  - triggers: ["com\t", "comp\t", "compa\t", "compan\t"]
+    replace: company
+  - triggers: ["com\t", "comp\t", "compa\t", "compar\t"]
+    replace: compare
+  - triggers: ["com\t", "comp\t", "compa\t", "compar\t", "compari\t", "comparis\t", "compariso\t"]
+    replace: comparison
+  - triggers: ["com\t", "comp\t", "compe\t", "compet\t"]
+    replace: compete
+  - triggers: ["com\t", "comp\t", "compe\t", "compet\t", "competi\t", "competit\t", "competiti\t", "competitio\t"]
+    replace: competition
+  - triggers: ["com\t", "comp\t", "compe\t", "compet\t", "competi\t", "competit\t", "competiti\t", "competitiv\t"]
+    replace: competitive
+  - triggers: ["com\t", "comp\t", "compe\t", "compet\t", "competi\t", "competit\t", "competito\t"]
+    replace: competitor
+  - triggers: ["com\t", "comp\t", "compl\t", "compla\t", "complai\t"]
+    replace: complain
+  - triggers: ["com\t", "comp\t", "compl\t", "compla\t", "complai\t", "complain\t"]
+    replace: complaint
+  - triggers: ["com\t", "comp\t", "compl\t", "comple\t", "complet\t"]
+    replace: complete
+  - triggers: ["com\t", "comp\t", "compl\t", "comple\t", "complet\t", "complete\t", "completel\t"]
+    replace: completely
+  - triggers: ["com\t", "comp\t", "compl\t", "comple\t"]
+    replace: complex
+  - triggers: ["com\t", "comp\t", "compl\t", "compli\t", "complic\t", "complica\t", "complicat\t", "complicate\t"]
+    replace: complicated
+  - triggers: ["com\t", "comp\t", "compo\t", "compon\t", "compone\t", "componen\t"]
+    replace: component
+  - triggers: ["com\t", "comp\t", "compo\t", "compos\t"]
+    replace: compose
+  - triggers: ["com\t", "comp\t", "compo\t", "compos\t", "composi\t", "composit\t", "compositi\t", "compositio\t"]
+    replace: composition
+  - triggers: ["com\t", "comp\t", "compr\t", "compre\t", "compreh\t", "comprehe\t", "comprehen\t", "comprehens\t", "comprehensi\t", "comprehensiv\t"]
+    replace: comprehensive
+  - triggers: ["com\t", "comp\t", "compu\t", "comput\t", "compute\t"]
+    replace: computer
+  - triggers: ["con\t", "conc\t", "conce\t", "concen\t", "concent\t", "concentr\t", "concentra\t", "concentrat\t"]
+    replace: concentrate
+  - triggers: ["con\t", "conc\t", "conce\t", "concen\t", "concent\t", "concentr\t", "concentra\t", "concentrat\t", "concentrati\t", "concentratio\t"]
+    replace: concentration
+  - triggers: ["con\t", "conc\t", "conce\t", "concep\t"]
+    replace: concept
+  - triggers: ["con\t", "conc\t", "conce\t", "concer\t"]
+    replace: concern
+  - triggers: ["con\t", "conc\t", "conce\t", "concer\t", "concern\t", "concerne\t"]
+    replace: concerned
+  - triggers: ["con\t", "conc\t", "conce\t", "concer\t"]
+    replace: concert
+  - triggers: ["con\t", "conc\t", "concl\t", "conclu\t", "conclud\t"]
+    replace: conclude
+  - triggers: ["con\t", "conc\t", "concl\t", "conclu\t", "conclus\t", "conclusi\t", "conclusio\t"]
+    replace: conclusion
+  - triggers: ["con\t", "conc\t", "concr\t", "concre\t", "concret\t"]
+    replace: concrete
+  - triggers: ["con\t", "cond\t", "condi\t", "condit\t", "conditi\t", "conditio\t"]
+    replace: condition
+  - triggers: ["con\t", "cond\t", "condu\t", "conduc\t"]
+    replace: conduct
+  - triggers: ["con\t", "conf\t", "confe\t", "confer\t", "confere\t", "conferen\t", "conferenc\t"]
+    replace: conference
+  - triggers: ["con\t", "conf\t", "confi\t", "confid\t", "confide\t", "confiden\t", "confidenc\t"]
+    replace: confidence
+  - triggers: ["con\t", "conf\t", "confi\t", "confid\t", "confide\t", "confiden\t"]
+    replace: confident
+  - triggers: ["con\t", "conf\t", "confi\t", "confir\t"]
+    replace: confirm
+  - triggers: ["con\t", "conf\t", "confl\t", "confli\t", "conflic\t"]
+    replace: conflict
+  - triggers: ["con\t", "conf\t", "confr\t", "confro\t", "confron\t"]
+    replace: confront
+  - triggers: ["con\t", "conf\t", "confu\t", "confus\t", "confusi\t", "confusio\t"]
+    replace: confusion
+  - triggers: ["con\t", "cong\t", "congr\t", "congre\t", "congres\t", "congress\t", "congressi\t", "congressio\t", "congression\t", "congressiona\t"]
+    replace: congressional
+  - triggers: ["con\t", "conn\t", "conne\t", "connec\t"]
+    replace: connect
+  - triggers: ["con\t", "conn\t", "conne\t", "connec\t", "connect\t", "connecti\t", "connectio\t"]
+    replace: connection
+  - triggers: ["con\t", "cons\t", "consc\t", "consci\t", "conscio\t", "consciou\t", "conscious\t", "consciousn\t", "consciousne\t", "consciousnes\t"]
+    replace: consciousness
+  - triggers: ["con\t", "cons\t", "conse\t", "consen\t", "consens\t", "consensu\t"]
+    replace: consensus
+  - triggers: ["con\t", "cons\t", "conse\t", "conseq\t", "consequ\t", "conseque\t", "consequen\t", "consequenc\t"]
+    replace: consequence
+  - triggers: ["con\t", "cons\t", "conse\t", "conser\t", "conserv\t", "conserva\t", "conservat\t", "conservati\t", "conservativ\t"]
+    replace: conservative
+  - triggers: ["con\t", "cons\t", "consi\t", "consid\t", "conside\t"]
+    replace: consider
+  - triggers: ["con\t", "cons\t", "consi\t", "consid\t", "conside\t", "consider\t", "considera\t", "considerab\t", "considerabl\t"]
+    replace: considerable
+  - triggers: ["con\t", "cons\t", "consi\t", "consid\t", "conside\t", "consider\t", "considera\t", "considerat\t", "considerati\t", "consideratio\t"]
+    replace: consideration
+  - triggers: ["con\t", "cons\t", "consi\t", "consis\t"]
+    replace: consist
+  - triggers: ["con\t", "cons\t", "consi\t", "consis\t", "consist\t", "consiste\t", "consisten\t"]
+    replace: consistent
+  - triggers: ["con\t", "cons\t", "const\t", "consta\t", "constan\t"]
+    replace: constant
+  - triggers: ["con\t", "cons\t", "const\t", "consta\t", "constan\t", "constant\t", "constantl\t"]
+    replace: constantly
+  - triggers: ["con\t", "cons\t", "const\t", "consti\t", "constit\t", "constitu\t", "constitut\t"]
+    replace: constitute
+  - triggers: ["con\t", "cons\t", "const\t", "consti\t", "constit\t", "constitu\t", "constitut\t", "constituti\t", "constitutio\t", "constitution\t", "constitutiona\t"]
+    replace: constitutional
+  - triggers: ["con\t", "cons\t", "const\t", "constr\t", "constru\t", "construc\t"]
+    replace: construct
+  - triggers: ["con\t", "cons\t", "const\t", "constr\t", "constru\t", "construc\t", "construct\t", "constructi\t", "constructio\t"]
+    replace: construction
+  - triggers: ["con\t", "cons\t", "consu\t", "consul\t", "consult\t", "consulta\t", "consultan\t"]
+    replace: consultant
+  - triggers: ["con\t", "cons\t", "consu\t", "consum\t"]
+    replace: consume
+  - triggers: ["con\t", "cons\t", "consu\t", "consum\t", "consume\t"]
+    replace: consumer
+  - triggers: ["con\t", "cons\t", "consu\t", "consum\t", "consump\t", "consumpt\t", "consumpti\t", "consumptio\t"]
+    replace: consumption
+  - triggers: ["con\t", "cont\t", "conta\t", "contac\t"]
+    replace: contact
+  - triggers: ["con\t", "cont\t", "conta\t", "contai\t"]
+    replace: contain
+  - triggers: ["con\t", "cont\t", "conta\t", "contai\t", "contain\t", "containe\t"]
+    replace: container
+  - triggers: ["con\t", "cont\t", "conte\t", "contem\t", "contemp\t", "contempo\t", "contempor\t", "contempora\t", "contemporar\t"]
+    replace: contemporary
+  - triggers: ["con\t", "cont\t", "conte\t", "conten\t"]
+    replace: content
+  - triggers: ["con\t", "cont\t", "conte\t", "contes\t"]
+    replace: contest
+  - triggers: ["con\t", "cont\t", "conte\t", "contex\t"]
+    replace: context
+  - triggers: ["con\t", "cont\t", "conti\t", "contin\t", "continu\t"]
+    replace: continue
+  - triggers: ["con\t", "cont\t", "conti\t", "contin\t", "continu\t", "continue\t"]
+    replace: continued
+  - triggers: ["con\t", "cont\t", "contr\t", "contra\t", "contrac\t"]
+    replace: contract
+  - triggers: ["con\t", "cont\t", "contr\t", "contra\t", "contras\t"]
+    replace: contrast
+  - triggers: ["con\t", "cont\t", "contr\t", "contri\t", "contrib\t", "contribu\t", "contribut\t"]
+    replace: contribute
+  - triggers: ["con\t", "cont\t", "contr\t", "contri\t", "contrib\t", "contribu\t", "contribut\t", "contributi\t", "contributio\t"]
+    replace: contribution
+  - triggers: ["con\t", "cont\t", "contr\t", "contro\t"]
+    replace: control
+  - triggers: ["con\t", "cont\t", "contr\t", "contro\t", "controv\t", "controve\t", "controver\t", "controvers\t", "controversi\t", "controversia\t"]
+    replace: controversial
+  - triggers: ["con\t", "cont\t", "contr\t", "contro\t", "controv\t", "controve\t", "controver\t", "controvers\t"]
+    replace: controversy
+  - triggers: ["con\t", "conv\t", "conve\t", "conven\t", "convent\t", "conventi\t", "conventio\t"]
+    replace: convention
+  - triggers: ["con\t", "conv\t", "conve\t", "conven\t", "convent\t", "conventi\t", "conventio\t", "convention\t", "conventiona\t"]
+    replace: conventional
+  - triggers: ["con\t", "conv\t", "conve\t", "conver\t", "convers\t", "conversa\t", "conversat\t", "conversati\t", "conversatio\t"]
+    replace: conversation
+  - triggers: ["con\t", "conv\t", "conve\t", "conver\t"]
+    replace: convert
+  - triggers: ["con\t", "conv\t", "convi\t", "convic\t", "convict\t", "convicti\t", "convictio\t"]
+    replace: conviction
+  - triggers: ["con\t", "conv\t", "convi\t", "convin\t", "convinc\t"]
+    replace: convince
+  - triggers: ["coo\t"]
+    replace: cook
+  - triggers: ["coo\t", "cook\t", "cooki\t"]
+    replace: cookie
+  - triggers: ["coo\t", "cook\t", "cooki\t", "cookin\t"]
+    replace: cooking
+  - triggers: ["coo\t"]
+    replace: cool
+  - triggers: ["coo\t", "coop\t", "coope\t", "cooper\t", "coopera\t", "cooperat\t", "cooperati\t", "cooperatio\t"]
+    replace: cooperation
+  - triggers: ["cop\t"]
+    replace: cope
+  - triggers: ["cop\t"]
+    replace: copy
+  - triggers: ["cor\t"]
+    replace: core
+  - triggers: ["cor\t"]
+    replace: corn
+  - triggers: ["cor\t", "corn\t", "corne\t"]
+    replace: corner
+  - triggers: ["cor\t", "corp\t", "corpo\t", "corpor\t", "corpora\t", "corporat\t"]
+    replace: corporate
+  - triggers: ["cor\t", "corp\t", "corpo\t", "corpor\t", "corpora\t", "corporat\t", "corporati\t", "corporatio\t"]
+    replace: corporation
+  - triggers: ["cor\t", "corr\t", "corre\t", "correc\t"]
+    replace: correct
+  - triggers: ["cor\t", "corr\t", "corre\t", "corres\t", "corresp\t", "correspo\t", "correspon\t", "correspond\t", "corresponde\t", "corresponden\t"]
+    replace: correspondent
+  - triggers: ["cos\t"]
+    replace: cost
+  - triggers: ["cot\t", "cott\t", "cotto\t"]
+    replace: cotton
+  - triggers: ["cou\t", "couc\t"]
+    replace: couch
+  - triggers: ["cou\t", "coul\t"]
+    replace: could
+  - triggers: ["cou\t", "coun\t", "counc\t", "counci\t"]
+    replace: council
+  - triggers: ["cou\t", "coun\t", "couns\t", "counse\t", "counsel\t", "counselo\t"]
+    replace: counselor
+  - triggers: ["cou\t", "coun\t"]
+    replace: count
+  - triggers: ["cou\t", "coun\t", "count\t", "counte\t"]
+    replace: counter
+  - triggers: ["cou\t", "coun\t", "count\t", "countr\t"]
+    replace: country
+  - triggers: ["cou\t", "coun\t", "count\t"]
+    replace: county
+  - triggers: ["cou\t", "coup\t", "coupl\t"]
+    replace: couple
+  - triggers: ["cou\t", "cour\t", "coura\t", "courag\t"]
+    replace: courage
+  - triggers: ["cou\t", "cour\t", "cours\t"]
+    replace: course
+  - triggers: ["cou\t", "cour\t"]
+    replace: court
+  - triggers: ["cou\t", "cous\t", "cousi\t"]
+    replace: cousin
+  - triggers: ["cov\t", "cove\t"]
+    replace: cover
+  - triggers: ["cov\t", "cove\t", "cover\t", "covera\t", "coverag\t"]
+    replace: coverage
+  - triggers: ["cra\t", "crac\t"]
+    replace: crack
+  - triggers: ["cra\t", "craf\t"]
+    replace: craft
+  - triggers: ["cra\t", "cras\t"]
+    replace: crash
+  - triggers: ["cra\t", "craz\t"]
+    replace: crazy
+  - triggers: ["cre\t", "crea\t"]
+    replace: cream
+  - triggers: ["cre\t", "crea\t", "creat\t"]
+    replace: create
+  - triggers: ["cre\t", "crea\t", "creat\t", "creati\t", "creatio\t"]
+    replace: creation
+  - triggers: ["cre\t", "crea\t", "creat\t", "creati\t", "creativ\t"]
+    replace: creative
+  - triggers: ["cre\t", "crea\t", "creat\t", "creatu\t", "creatur\t"]
+    replace: creature
+  - triggers: ["cre\t", "cred\t", "credi\t"]
+    replace: credit
+  - triggers: ["cre\t"]
+    replace: crew
+  - triggers: ["cri\t", "crim\t"]
+    replace: crime
+  - triggers: ["cri\t", "crim\t", "crimi\t", "crimin\t", "crimina\t"]
+    replace: criminal
+  - triggers: ["cri\t", "cris\t", "crisi\t"]
+    replace: crisis
+  - triggers: ["cri\t", "crit\t", "crite\t", "criter\t", "criteri\t"]
+    replace: criteria
+  - triggers: ["cri\t", "crit\t", "criti\t"]
+    replace: critic
+  - triggers: ["cri\t", "crit\t", "criti\t", "critic\t", "critica\t"]
+    replace: critical
+  - triggers: ["cri\t", "crit\t", "criti\t", "critic\t", "critici\t", "criticis\t"]
+    replace: criticism
+  - triggers: ["cri\t", "crit\t", "criti\t", "critic\t", "critici\t", "criticiz\t"]
+    replace: criticize
+  - triggers: ["cro\t"]
+    replace: crop
+  - triggers: ["cro\t", "cros\t"]
+    replace: cross
+  - triggers: ["cro\t", "crow\t"]
+    replace: crowd
+  - triggers: ["cru\t", "cruc\t", "cruci\t", "crucia\t"]
+    replace: crucial
+  - triggers: ["cul\t", "cult\t", "cultu\t", "cultur\t", "cultura\t"]
+    replace: cultural
+  - triggers: ["cul\t", "cult\t", "cultu\t", "cultur\t"]
+    replace: culture
+  - triggers: ["cur\t", "curi\t", "curio\t", "curiou\t"]
+    replace: curious
+  - triggers: ["cur\t", "curr\t", "curre\t", "curren\t"]
+    replace: current
+  - triggers: ["cur\t", "curr\t", "curre\t", "curren\t", "current\t", "currentl\t"]
+    replace: currently
+  - triggers: ["cur\t", "curr\t", "curri\t", "curric\t", "curricu\t", "curricul\t", "curriculu\t"]
+    replace: curriculum
+  - triggers: ["cus\t", "cust\t", "custo\t"]
+    replace: custom
+  - triggers: ["cus\t", "cust\t", "custo\t", "custom\t", "custome\t"]
+    replace: customer
+  - triggers: ["cyc\t", "cycl\t"]
+    replace: cycle
+  - triggers: ["dai\t", "dail\t"]
+    replace: daily
+  - triggers: ["dam\t", "dama\t", "damag\t"]
+    replace: damage
+  - triggers: ["dan\t", "danc\t"]
+    replace: dance
+  - triggers: ["dan\t", "dang\t", "dange\t"]
+    replace: danger
+  - triggers: ["dan\t", "dang\t", "dange\t", "danger\t", "dangero\t", "dangerou\t"]
+    replace: dangerous
+  - triggers: ["dar\t"]
+    replace: dare
+  - triggers: ["dar\t"]
+    replace: dark
+  - triggers: ["dar\t", "dark\t", "darkn\t", "darkne\t", "darknes\t"]
+    replace: darkness
+  - triggers: ["dat\t"]
+    replace: data
+  - triggers: ["dat\t"]
+    replace: date
+  - triggers: ["dau\t", "daug\t", "daugh\t", "daught\t", "daughte\t"]
+    replace: daughter
+  - triggers: ["dea\t"]
+    replace: dead
+  - triggers: ["dea\t"]
+    replace: deal
+  - triggers: ["dea\t", "deal\t", "deale\t"]
+    replace: dealer
+  - triggers: ["dea\t"]
+    replace: dear
+  - triggers: ["dea\t", "deat\t"]
+    replace: death
+  - triggers: ["deb\t", "deba\t", "debat\t"]
+    replace: debate
+  - triggers: ["deb\t"]
+    replace: debt
+  - triggers: ["dec\t", "deca\t", "decad\t"]
+    replace: decade
+  - triggers: ["dec\t", "deci\t", "decid\t"]
+    replace: decide
+  - triggers: ["dec\t", "deci\t", "decis\t", "decisi\t", "decisio\t"]
+    replace: decision
+  - triggers: ["dec\t"]
+    replace: deck
+  - triggers: ["dec\t", "decl\t", "decla\t", "declar\t"]
+    replace: declare
+  - triggers: ["dec\t", "decl\t", "decli\t", "declin\t"]
+    replace: decline
+  - triggers: ["dec\t", "decr\t", "decre\t", "decrea\t", "decreas\t"]
+    replace: decrease
+  - triggers: ["dee\t"]
+    replace: deep
+  - triggers: ["dee\t", "deep\t", "deepl\t"]
+    replace: deeply
+  - triggers: ["dee\t"]
+    replace: deer
+  - triggers: ["def\t", "defe\t", "defea\t"]
+    replace: defeat
+  - triggers: ["def\t", "defe\t", "defen\t"]
+    replace: defend
+  - triggers: ["def\t", "defe\t", "defen\t", "defend\t", "defenda\t", "defendan\t"]
+    replace: defendant
+  - triggers: ["def\t", "defe\t", "defen\t", "defens\t"]
+    replace: defense
+  - triggers: ["def\t", "defe\t", "defen\t", "defens\t", "defensi\t", "defensiv\t"]
+    replace: defensive
+  - triggers: ["def\t", "defi\t", "defic\t", "defici\t"]
+    replace: deficit
+  - triggers: ["def\t", "defi\t", "defin\t"]
+    replace: define
+  - triggers: ["def\t", "defi\t", "defin\t", "defini\t", "definit\t", "definite\t", "definitel\t"]
+    replace: definitely
+  - triggers: ["def\t", "defi\t", "defin\t", "defini\t", "definit\t", "definiti\t", "definitio\t"]
+    replace: definition
+  - triggers: ["deg\t", "degr\t", "degre\t"]
+    replace: degree
+  - triggers: ["del\t", "dela\t"]
+    replace: delay
+  - triggers: ["del\t", "deli\t", "deliv\t", "delive\t"]
+    replace: deliver
+  - triggers: ["del\t", "deli\t", "deliv\t", "delive\t", "deliver\t"]
+    replace: delivery
+  - triggers: ["dem\t", "dema\t", "deman\t"]
+    replace: demand
+  - triggers: ["dem\t", "demo\t", "democ\t", "democr\t", "democra\t", "democrac\t"]
+    replace: democracy
+  - triggers: ["dem\t", "demo\t", "democ\t", "democr\t", "democra\t", "democrat\t", "democrati\t"]
+    replace: democratic
+  - triggers: ["dem\t", "demo\t", "demon\t", "demons\t", "demonst\t", "demonstr\t", "demonstra\t", "demonstrat\t"]
+    replace: demonstrate
+  - triggers: ["dem\t", "demo\t", "demon\t", "demons\t", "demonst\t", "demonstr\t", "demonstra\t", "demonstrat\t", "demonstrati\t", "demonstratio\t"]
+    replace: demonstration
+  - triggers: ["den\t"]
+    replace: deny
+  - triggers: ["dep\t", "depa\t", "depar\t", "depart\t", "departm\t", "departme\t", "departmen\t"]
+    replace: department
+  - triggers: ["dep\t", "depe\t", "depen\t"]
+    replace: depend
+  - triggers: ["dep\t", "depe\t", "depen\t", "depend\t", "depende\t", "dependen\t"]
+    replace: dependent
+  - triggers: ["dep\t", "depe\t", "depen\t", "depend\t", "dependi\t", "dependin\t"]
+    replace: depending
+  - triggers: ["dep\t", "depi\t", "depic\t"]
+    replace: depict
+  - triggers: ["dep\t", "depr\t", "depre\t", "depres\t", "depress\t", "depressi\t", "depressio\t"]
+    replace: depression
+  - triggers: ["dep\t", "dept\t"]
+    replace: depth
+  - triggers: ["dep\t", "depu\t", "deput\t"]
+    replace: deputy
+  - triggers: ["der\t", "deri\t", "deriv\t"]
+    replace: derive
+  - triggers: ["des\t", "desc\t", "descr\t", "descri\t", "describ\t"]
+    replace: describe
+  - triggers: ["des\t", "desc\t", "descr\t", "descri\t", "descrip\t", "descript\t", "descripti\t", "descriptio\t"]
+    replace: description
+  - triggers: ["des\t", "dese\t", "deser\t"]
+    replace: desert
+  - triggers: ["des\t", "dese\t", "deser\t", "deserv\t"]
+    replace: deserve
+  - triggers: ["des\t", "desi\t", "desig\t"]
+    replace: design
+  - triggers: ["des\t", "desi\t", "desig\t", "design\t", "designe\t"]
+    replace: designer
+  - triggers: ["des\t", "desi\t", "desir\t"]
+    replace: desire
+  - triggers: ["des\t"]
+    replace: desk
+  - triggers: ["des\t", "desp\t", "despe\t", "desper\t", "despera\t", "desperat\t"]
+    replace: desperate
+  - triggers: ["des\t", "desp\t", "despi\t", "despit\t"]
+    replace: despite
+  - triggers: ["des\t", "dest\t", "destr\t", "destro\t"]
+    replace: destroy
+  - triggers: ["des\t", "dest\t", "destr\t", "destru\t", "destruc\t", "destruct\t", "destructi\t", "destructio\t"]
+    replace: destruction
+  - triggers: ["det\t", "deta\t", "detai\t"]
+    replace: detail
+  - triggers: ["det\t", "deta\t", "detai\t", "detail\t", "detaile\t"]
+    replace: detailed
+  - triggers: ["det\t", "dete\t", "detec\t"]
+    replace: detect
+  - triggers: ["det\t", "dete\t", "deter\t", "determ\t", "determi\t", "determin\t"]
+    replace: determine
+  - triggers: ["dev\t", "deve\t", "devel\t", "develo\t"]
+    replace: develop
+  - triggers: ["dev\t", "deve\t", "devel\t", "develo\t", "develop\t", "developi\t", "developin\t"]
+    replace: developing
+  - triggers: ["dev\t", "deve\t", "devel\t", "develo\t", "develop\t", "developm\t", "developme\t", "developmen\t"]
+    replace: development
+  - triggers: ["dev\t", "devi\t", "devic\t"]
+    replace: device
+  - triggers: ["dev\t", "devo\t", "devot\t"]
+    replace: devote
+  - triggers: ["dia\t", "dial\t", "dialo\t", "dialog\t", "dialogu\t"]
+    replace: dialogue
+  - triggers: ["die\t"]
+    replace: diet
+  - triggers: ["dif\t", "diff\t", "diffe\t"]
+    replace: differ
+  - triggers: ["dif\t", "diff\t", "diffe\t", "differ\t", "differe\t", "differen\t", "differenc\t"]
+    replace: difference
+  - triggers: ["dif\t", "diff\t", "diffe\t", "differ\t", "differe\t", "differen\t"]
+    replace: different
+  - triggers: ["dif\t", "diff\t", "diffe\t", "differ\t", "differe\t", "differen\t", "different\t", "differentl\t"]
+    replace: differently
+  - triggers: ["dif\t", "diff\t", "diffi\t", "diffic\t", "difficu\t", "difficul\t"]
+    replace: difficult
+  - triggers: ["dif\t", "diff\t", "diffi\t", "diffic\t", "difficu\t", "difficul\t", "difficult\t"]
+    replace: difficulty
+  - triggers: ["dig\t", "digi\t", "digit\t", "digita\t"]
+    replace: digital
+  - triggers: ["dim\t", "dime\t", "dimen\t", "dimens\t", "dimensi\t", "dimensio\t"]
+    replace: dimension
+  - triggers: ["din\t", "dini\t", "dinin\t"]
+    replace: dining
+  - triggers: ["din\t", "dinn\t", "dinne\t"]
+    replace: dinner
+  - triggers: ["dir\t", "dire\t", "direc\t"]
+    replace: direct
+  - triggers: ["dir\t", "dire\t", "direc\t", "direct\t", "directi\t", "directio\t"]
+    replace: direction
+  - triggers: ["dir\t", "dire\t", "direc\t", "direct\t", "directl\t"]
+    replace: directly
+  - triggers: ["dir\t", "dire\t", "direc\t", "direct\t", "directo\t"]
+    replace: director
+  - triggers: ["dir\t"]
+    replace: dirt
+  - triggers: ["dir\t", "dirt\t"]
+    replace: dirty
+  - triggers: ["dis\t", "disa\t", "disab\t", "disabi\t", "disabil\t", "disabili\t", "disabilit\t"]
+    replace: disability
+  - triggers: ["dis\t", "disa\t", "disag\t", "disagr\t", "disagre\t"]
+    replace: disagree
+  - triggers: ["dis\t", "disa\t", "disap\t", "disapp\t", "disappe\t", "disappea\t"]
+    replace: disappear
+  - triggers: ["dis\t", "disa\t", "disas\t", "disast\t", "disaste\t"]
+    replace: disaster
+  - triggers: ["dis\t", "disc\t", "disci\t", "discip\t", "discipl\t", "discipli\t", "disciplin\t"]
+    replace: discipline
+  - triggers: ["dis\t", "disc\t", "disco\t", "discou\t", "discour\t", "discours\t"]
+    replace: discourse
+  - triggers: ["dis\t", "disc\t", "disco\t", "discov\t", "discove\t"]
+    replace: discover
+  - triggers: ["dis\t", "disc\t", "disco\t", "discov\t", "discove\t", "discover\t"]
+    replace: discovery
+  - triggers: ["dis\t", "disc\t", "discr\t", "discri\t", "discrim\t", "discrimi\t", "discrimin\t", "discrimina\t", "discriminat\t", "discriminati\t", "discriminatio\t"]
+    replace: discrimination
+  - triggers: ["dis\t", "disc\t", "discu\t", "discus\t"]
+    replace: discuss
+  - triggers: ["dis\t", "disc\t", "discu\t", "discus\t", "discuss\t", "discussi\t", "discussio\t"]
+    replace: discussion
+  - triggers: ["dis\t", "dise\t", "disea\t", "diseas\t"]
+    replace: disease
+  - triggers: ["dis\t"]
+    replace: dish
+  - triggers: ["dis\t", "dism\t", "dismi\t", "dismis\t"]
+    replace: dismiss
+  - triggers: ["dis\t", "diso\t", "disor\t", "disord\t", "disorde\t"]
+    replace: disorder
+  - triggers: ["dis\t", "disp\t", "displ\t", "displa\t"]
+    replace: display
+  - triggers: ["dis\t", "disp\t", "dispu\t", "disput\t"]
+    replace: dispute
+  - triggers: ["dis\t", "dist\t", "dista\t", "distan\t", "distanc\t"]
+    replace: distance
+  - triggers: ["dis\t", "dist\t", "dista\t", "distan\t"]
+    replace: distant
+  - triggers: ["dis\t", "dist\t", "disti\t", "distin\t", "distinc\t"]
+    replace: distinct
+  - triggers: ["dis\t", "dist\t", "disti\t", "distin\t", "distinc\t", "distinct\t", "distincti\t", "distinctio\t"]
+    replace: distinction
+  - triggers: ["dis\t", "dist\t", "disti\t", "distin\t", "disting\t", "distingu\t", "distingui\t", "distinguis\t"]
+    replace: distinguish
+  - triggers: ["dis\t", "dist\t", "distr\t", "distri\t", "distrib\t", "distribu\t", "distribut\t"]
+    replace: distribute
+  - triggers: ["dis\t", "dist\t", "distr\t", "distri\t", "distrib\t", "distribu\t", "distribut\t", "distributi\t", "distributio\t"]
+    replace: distribution
+  - triggers: ["dis\t", "dist\t", "distr\t", "distri\t", "distric\t"]
+    replace: district
+  - triggers: ["div\t", "dive\t", "diver\t", "divers\t"]
+    replace: diverse
+  - triggers: ["div\t", "dive\t", "diver\t", "divers\t", "diversi\t", "diversit\t"]
+    replace: diversity
+  - triggers: ["div\t", "divi\t", "divid\t"]
+    replace: divide
+  - triggers: ["div\t", "divi\t", "divis\t", "divisi\t", "divisio\t"]
+    replace: division
+  - triggers: ["div\t", "divo\t", "divor\t", "divorc\t"]
+    replace: divorce
+  - triggers: ["doc\t", "doct\t", "docto\t"]
+    replace: doctor
+  - triggers: ["doc\t", "docu\t", "docum\t", "docume\t", "documen\t"]
+    replace: document
+  - triggers: ["dom\t", "dome\t", "domes\t", "domest\t", "domesti\t"]
+    replace: domestic
+  - triggers: ["dom\t", "domi\t", "domin\t", "domina\t", "dominan\t"]
+    replace: dominant
+  - triggers: ["dom\t", "domi\t", "domin\t", "domina\t", "dominat\t"]
+    replace: dominate
+  - triggers: ["doo\t"]
+    replace: door
+  - triggers: ["dou\t", "doub\t", "doubl\t"]
+    replace: double
+  - triggers: ["dou\t", "doub\t"]
+    replace: doubt
+  - triggers: ["dow\t"]
+    replace: down
+  - triggers: ["dow\t", "down\t", "downt\t", "downto\t", "downtow\t"]
+    replace: downtown
+  - triggers: ["doz\t", "doze\t"]
+    replace: dozen
+  - triggers: ["dra\t", "draf\t"]
+    replace: draft
+  - triggers: ["dra\t"]
+    replace: drag
+  - triggers: ["dra\t", "dram\t"]
+    replace: drama
+  - triggers: ["dra\t", "dram\t", "drama\t", "dramat\t", "dramati\t"]
+    replace: dramatic
+  - triggers: ["dra\t", "dram\t", "drama\t", "dramat\t", "dramati\t", "dramatic\t", "dramatica\t", "dramatical\t", "dramaticall\t"]
+    replace: dramatically
+  - triggers: ["dra\t"]
+    replace: draw
+  - triggers: ["dra\t", "draw\t", "drawi\t", "drawin\t"]
+    replace: drawing
+  - triggers: ["dre\t", "drea\t"]
+    replace: dream
+  - triggers: ["dre\t", "dres\t"]
+    replace: dress
+  - triggers: ["dri\t", "drin\t"]
+    replace: drink
+  - triggers: ["dri\t", "driv\t"]
+    replace: drive
+  - triggers: ["dri\t", "driv\t", "drive\t"]
+    replace: driver
+  - triggers: ["dro\t"]
+    replace: drop
+  - triggers: ["dru\t"]
+    replace: drug
+  - triggers: ["dur\t", "duri\t", "durin\t"]
+    replace: during
+  - triggers: ["dus\t"]
+    replace: dust
+  - triggers: ["dut\t"]
+    replace: duty
+  - triggers: ["e-m\t", "e-ma\t", "e-mai\t"]
+    replace: e-mail
+  - triggers: ["eac\t"]
+    replace: each
+  - triggers: ["eag\t", "eage\t"]
+    replace: eager
+  - triggers: ["ear\t", "earl\t"]
+    replace: early
+  - triggers: ["ear\t"]
+    replace: earn
+  - triggers: ["ear\t", "earn\t", "earni\t", "earnin\t", "earning\t"]
+    replace: earnings
+  - triggers: ["ear\t", "eart\t"]
+    replace: earth
+  - triggers: ["eas\t"]
+    replace: ease
+  - triggers: ["eas\t", "easi\t", "easil\t"]
+    replace: easily
+  - triggers: ["eas\t"]
+    replace: east
+  - triggers: ["eas\t", "east\t", "easte\t", "easter\t"]
+    replace: eastern
+  - triggers: ["eas\t"]
+    replace: easy
+  - triggers: ["eco\t", "econ\t", "econo\t", "econom\t", "economi\t"]
+    replace: economic
+  - triggers: ["eco\t", "econ\t", "econo\t", "econom\t", "economi\t", "economic\t"]
+    replace: economics
+  - triggers: ["eco\t", "econ\t", "econo\t", "econom\t", "economi\t", "economis\t"]
+    replace: economist
+  - triggers: ["eco\t", "econ\t", "econo\t", "econom\t"]
+    replace: economy
+  - triggers: ["edg\t"]
+    replace: edge
+  - triggers: ["edi\t", "edit\t", "editi\t", "editio\t"]
+    replace: edition
+  - triggers: ["edi\t", "edit\t", "edito\t"]
+    replace: editor
+  - triggers: ["edu\t", "educ\t", "educa\t", "educat\t"]
+    replace: educate
+  - triggers: ["edu\t", "educ\t", "educa\t", "educat\t", "educati\t", "educatio\t"]
+    replace: education
+  - triggers: ["edu\t", "educ\t", "educa\t", "educat\t", "educati\t", "educatio\t", "education\t", "educationa\t"]
+    replace: educational
+  - triggers: ["edu\t", "educ\t", "educa\t", "educat\t", "educato\t"]
+    replace: educator
+  - triggers: ["eff\t", "effe\t", "effec\t"]
+    replace: effect
+  - triggers: ["eff\t", "effe\t", "effec\t", "effect\t", "effecti\t", "effectiv\t"]
+    replace: effective
+  - triggers: ["eff\t", "effe\t", "effec\t", "effect\t", "effecti\t", "effectiv\t", "effective\t", "effectivel\t"]
+    replace: effectively
+  - triggers: ["eff\t", "effi\t", "effic\t", "effici\t", "efficie\t", "efficien\t", "efficienc\t"]
+    replace: efficiency
+  - triggers: ["eff\t", "effi\t", "effic\t", "effici\t", "efficie\t", "efficien\t"]
+    replace: efficient
+  - triggers: ["eff\t", "effo\t", "effor\t"]
+    replace: effort
+  - triggers: ["eig\t", "eigh\t"]
+    replace: eight
+  - triggers: ["eit\t", "eith\t", "eithe\t"]
+    replace: either
+  - triggers: ["eld\t", "elde\t", "elder\t", "elderl\t"]
+    replace: elderly
+  - triggers: ["ele\t", "elec\t"]
+    replace: elect
+  - triggers: ["ele\t", "elec\t", "elect\t", "electi\t", "electio\t"]
+    replace: election
+  - triggers: ["ele\t", "elec\t", "elect\t", "electr\t", "electri\t"]
+    replace: electric
+  - triggers: ["ele\t", "elec\t", "elect\t", "electr\t", "electri\t", "electric\t", "electrici\t", "electricit\t"]
+    replace: electricity
+  - triggers: ["ele\t", "elec\t", "elect\t", "electr\t", "electro\t", "electron\t", "electroni\t"]
+    replace: electronic
+  - triggers: ["ele\t", "elem\t", "eleme\t", "elemen\t"]
+    replace: element
+  - triggers: ["ele\t", "elem\t", "eleme\t", "elemen\t", "element\t", "elementa\t", "elementar\t"]
+    replace: elementary
+  - triggers: ["eli\t", "elim\t", "elimi\t", "elimin\t", "elimina\t", "eliminat\t"]
+    replace: eliminate
+  - triggers: ["eli\t", "elit\t"]
+    replace: elite
+  - triggers: ["els\t"]
+    replace: else
+  - triggers: ["els\t", "else\t", "elsew\t", "elsewh\t", "elsewhe\t", "elsewher\t"]
+    replace: elsewhere
+  - triggers: ["emb\t", "embr\t", "embra\t", "embrac\t"]
+    replace: embrace
+  - triggers: ["eme\t", "emer\t", "emerg\t"]
+    replace: emerge
+  - triggers: ["eme\t", "emer\t", "emerg\t", "emerge\t", "emergen\t", "emergenc\t"]
+    replace: emergency
+  - triggers: ["emi\t", "emis\t", "emiss\t", "emissi\t", "emissio\t"]
+    replace: emission
+  - triggers: ["emo\t", "emot\t", "emoti\t", "emotio\t"]
+    replace: emotion
+  - triggers: ["emo\t", "emot\t", "emoti\t", "emotio\t", "emotion\t", "emotiona\t"]
+    replace: emotional
+  - triggers: ["emp\t", "emph\t", "empha\t", "emphas\t", "emphasi\t"]
+    replace: emphasis
+  - triggers: ["emp\t", "emph\t", "empha\t", "emphas\t", "emphasi\t", "emphasiz\t"]
+    replace: emphasize
+  - triggers: ["emp\t", "empl\t", "emplo\t"]
+    replace: employ
+  - triggers: ["emp\t", "empl\t", "emplo\t", "employ\t", "employe\t"]
+    replace: employee
+  - triggers: ["emp\t", "empl\t", "emplo\t", "employ\t", "employe\t"]
+    replace: employer
+  - triggers: ["emp\t", "empl\t", "emplo\t", "employ\t", "employm\t", "employme\t", "employmen\t"]
+    replace: employment
+  - triggers: ["emp\t", "empt\t"]
+    replace: empty
+  - triggers: ["ena\t", "enab\t", "enabl\t"]
+    replace: enable
+  - triggers: ["enc\t", "enco\t", "encou\t", "encoun\t", "encount\t", "encounte\t"]
+    replace: encounter
+  - triggers: ["enc\t", "enco\t", "encou\t", "encour\t", "encoura\t", "encourag\t"]
+    replace: encourage
+  - triggers: ["ene\t", "enem\t"]
+    replace: enemy
+  - triggers: ["ene\t", "ener\t", "energ\t"]
+    replace: energy
+  - triggers: ["enf\t", "enfo\t", "enfor\t", "enforc\t", "enforce\t", "enforcem\t", "enforceme\t", "enforcemen\t"]
+    replace: enforcement
+  - triggers: ["eng\t", "enga\t", "engag\t"]
+    replace: engage
+  - triggers: ["eng\t", "engi\t", "engin\t"]
+    replace: engine
+  - triggers: ["eng\t", "engi\t", "engin\t", "engine\t", "enginee\t"]
+    replace: engineer
+  - triggers: ["eng\t", "engi\t", "engin\t", "engine\t", "enginee\t", "engineer\t", "engineeri\t", "engineerin\t"]
+    replace: engineering
+  - triggers: ["enh\t", "enha\t", "enhan\t", "enhanc\t"]
+    replace: enhance
+  - triggers: ["enj\t", "enjo\t"]
+    replace: enjoy
+  - triggers: ["eno\t", "enor\t", "enorm\t", "enormo\t", "enormou\t"]
+    replace: enormous
+  - triggers: ["eno\t", "enou\t", "enoug\t"]
+    replace: enough
+  - triggers: ["ens\t", "ensu\t", "ensur\t"]
+    replace: ensure
+  - triggers: ["ent\t", "ente\t"]
+    replace: enter
+  - triggers: ["ent\t", "ente\t", "enter\t", "enterp\t", "enterpr\t", "enterpri\t", "enterpris\t"]
+    replace: enterprise
+  - triggers: ["ent\t", "ente\t", "enter\t", "entert\t", "enterta\t", "entertai\t", "entertain\t", "entertainm\t", "entertainme\t", "entertainmen\t"]
+    replace: entertainment
+  - triggers: ["ent\t", "enti\t", "entir\t"]
+    replace: entire
+  - triggers: ["ent\t", "enti\t", "entir\t", "entire\t", "entirel\t"]
+    replace: entirely
+  - triggers: ["ent\t", "entr\t", "entra\t", "entran\t", "entranc\t"]
+    replace: entrance
+  - triggers: ["ent\t", "entr\t"]
+    replace: entry
+  - triggers: ["env\t", "envi\t", "envir\t", "enviro\t", "environ\t", "environm\t", "environme\t", "environmen\t"]
+    replace: environment
+  - triggers: ["env\t", "envi\t", "envir\t", "enviro\t", "environ\t", "environm\t", "environme\t", "environmen\t", "environment\t", "environmenta\t"]
+    replace: environmental
+  - triggers: ["epi\t", "epis\t", "episo\t", "episod\t"]
+    replace: episode
+  - triggers: ["equ\t", "equa\t"]
+    replace: equal
+  - triggers: ["equ\t", "equa\t", "equal\t", "equall\t"]
+    replace: equally
+  - triggers: ["equ\t", "equi\t", "equip\t", "equipm\t", "equipme\t", "equipmen\t"]
+    replace: equipment
+  - triggers: ["err\t", "erro\t"]
+    replace: error
+  - triggers: ["esc\t", "esca\t", "escap\t"]
+    replace: escape
+  - triggers: ["esp\t", "espe\t", "espec\t", "especi\t", "especia\t", "especial\t", "especiall\t"]
+    replace: especially
+  - triggers: ["ess\t", "essa\t"]
+    replace: essay
+  - triggers: ["ess\t", "esse\t", "essen\t", "essent\t", "essenti\t", "essentia\t"]
+    replace: essential
+  - triggers: ["ess\t", "esse\t", "essen\t", "essent\t", "essenti\t", "essentia\t", "essential\t", "essentiall\t"]
+    replace: essentially
+  - triggers: ["est\t", "esta\t", "estab\t", "establ\t", "establi\t", "establis\t"]
+    replace: establish
+  - triggers: ["est\t", "esta\t", "estab\t", "establ\t", "establi\t", "establis\t", "establish\t", "establishm\t", "establishme\t", "establishmen\t"]
+    replace: establishment
+  - triggers: ["est\t", "esta\t", "estat\t"]
+    replace: estate
+  - triggers: ["est\t", "esti\t", "estim\t", "estima\t", "estimat\t"]
+    replace: estimate
+  - triggers: ["eth\t", "ethi\t", "ethic\t"]
+    replace: ethics
+  - triggers: ["eth\t", "ethn\t", "ethni\t"]
+    replace: ethnic
+  - triggers: ["eva\t", "eval\t", "evalu\t", "evalua\t", "evaluat\t"]
+    replace: evaluate
+  - triggers: ["eva\t", "eval\t", "evalu\t", "evalua\t", "evaluat\t", "evaluati\t", "evaluatio\t"]
+    replace: evaluation
+  - triggers: ["eve\t"]
+    replace: even
+  - triggers: ["eve\t", "even\t", "eveni\t", "evenin\t"]
+    replace: evening
+  - triggers: ["eve\t", "even\t"]
+    replace: event
+  - triggers: ["eve\t", "even\t", "event\t", "eventu\t", "eventua\t", "eventual\t", "eventuall\t"]
+    replace: eventually
+  - triggers: ["eve\t"]
+    replace: ever
+  - triggers: ["eve\t", "ever\t"]
+    replace: every
+  - triggers: ["eve\t", "ever\t", "every\t", "everyb\t", "everybo\t", "everybod\t"]
+    replace: everybody
+  - triggers: ["eve\t", "ever\t", "every\t", "everyd\t", "everyda\t"]
+    replace: everyday
+  - triggers: ["eve\t", "ever\t", "every\t", "everyo\t", "everyon\t"]
+    replace: everyone
+  - triggers: ["eve\t", "ever\t", "every\t", "everyt\t", "everyth\t", "everythi\t", "everythin\t"]
+    replace: everything
+  - triggers: ["eve\t", "ever\t", "every\t", "everyw\t", "everywh\t", "everywhe\t", "everywher\t"]
+    replace: everywhere
+  - triggers: ["evi\t", "evid\t", "evide\t", "eviden\t", "evidenc\t"]
+    replace: evidence
+  - triggers: ["evo\t", "evol\t", "evolu\t", "evolut\t", "evoluti\t", "evolutio\t"]
+    replace: evolution
+  - triggers: ["evo\t", "evol\t", "evolv\t"]
+    replace: evolve
+  - triggers: ["exa\t", "exac\t"]
+    replace: exact
+  - triggers: ["exa\t", "exac\t", "exact\t", "exactl\t"]
+    replace: exactly
+  - triggers: ["exa\t", "exam\t", "exami\t", "examin\t", "examina\t", "examinat\t", "examinati\t", "examinatio\t"]
+    replace: examination
+  - triggers: ["exa\t", "exam\t", "exami\t", "examin\t"]
+    replace: examine
+  - triggers: ["exa\t", "exam\t", "examp\t", "exampl\t"]
+    replace: example
+  - triggers: ["exc\t", "exce\t", "excee\t"]
+    replace: exceed
+  - triggers: ["exc\t", "exce\t", "excel\t", "excell\t", "excelle\t", "excellen\t"]
+    replace: excellent
+  - triggers: ["exc\t", "exce\t", "excep\t"]
+    replace: except
+  - triggers: ["exc\t", "exce\t", "excep\t", "except\t", "excepti\t", "exceptio\t"]
+    replace: exception
+  - triggers: ["exc\t", "exch\t", "excha\t", "exchan\t", "exchang\t"]
+    replace: exchange
+  - triggers: ["exc\t", "exci\t", "excit\t", "exciti\t", "excitin\t"]
+    replace: exciting
+  - triggers: ["exe\t", "exec\t", "execu\t", "execut\t", "executi\t", "executiv\t"]
+    replace: executive
+  - triggers: ["exe\t", "exer\t", "exerc\t", "exerci\t", "exercis\t"]
+    replace: exercise
+  - triggers: ["exh\t", "exhi\t", "exhib\t", "exhibi\t"]
+    replace: exhibit
+  - triggers: ["exh\t", "exhi\t", "exhib\t", "exhibi\t", "exhibit\t", "exhibiti\t", "exhibitio\t"]
+    replace: exhibition
+  - triggers: ["exi\t", "exis\t"]
+    replace: exist
+  - triggers: ["exi\t", "exis\t", "exist\t", "existe\t", "existen\t", "existenc\t"]
+    replace: existence
+  - triggers: ["exi\t", "exis\t", "exist\t", "existi\t", "existin\t"]
+    replace: existing
+  - triggers: ["exp\t", "expa\t", "expan\t"]
+    replace: expand
+  - triggers: ["exp\t", "expa\t", "expan\t", "expans\t", "expansi\t", "expansio\t"]
+    replace: expansion
+  - triggers: ["exp\t", "expe\t", "expec\t"]
+    replace: expect
+  - triggers: ["exp\t", "expe\t", "expec\t", "expect\t", "expecta\t", "expectat\t", "expectati\t", "expectatio\t"]
+    replace: expectation
+  - triggers: ["exp\t", "expe\t", "expen\t", "expens\t"]
+    replace: expense
+  - triggers: ["exp\t", "expe\t", "expen\t", "expens\t", "expensi\t", "expensiv\t"]
+    replace: expensive
+  - triggers: ["exp\t", "expe\t", "exper\t", "experi\t", "experie\t", "experien\t", "experienc\t"]
+    replace: experience
+  - triggers: ["exp\t", "expe\t", "exper\t", "experi\t", "experim\t", "experime\t", "experimen\t"]
+    replace: experiment
+  - triggers: ["exp\t", "expe\t", "exper\t"]
+    replace: expert
+  - triggers: ["exp\t", "expl\t", "expla\t", "explai\t"]
+    replace: explain
+  - triggers: ["exp\t", "expl\t", "expla\t", "explan\t", "explana\t", "explanat\t", "explanati\t", "explanatio\t"]
+    replace: explanation
+  - triggers: ["exp\t", "expl\t", "explo\t", "explod\t"]
+    replace: explode
+  - triggers: ["exp\t", "expl\t", "explo\t", "explor\t"]
+    replace: explore
+  - triggers: ["exp\t", "expl\t", "explo\t", "explos\t", "explosi\t", "explosio\t"]
+    replace: explosion
+  - triggers: ["exp\t", "expo\t", "expos\t"]
+    replace: expose
+  - triggers: ["exp\t", "expo\t", "expos\t", "exposu\t", "exposur\t"]
+    replace: exposure
+  - triggers: ["exp\t", "expr\t", "expre\t", "expres\t"]
+    replace: express
+  - triggers: ["exp\t", "expr\t", "expre\t", "expres\t", "express\t", "expressi\t", "expressio\t"]
+    replace: expression
+  - triggers: ["ext\t", "exte\t", "exten\t"]
+    replace: extend
+  - triggers: ["ext\t", "exte\t", "exten\t", "extens\t", "extensi\t", "extensio\t"]
+    replace: extension
+  - triggers: ["ext\t", "exte\t", "exten\t", "extens\t", "extensi\t", "extensiv\t"]
+    replace: extensive
+  - triggers: ["ext\t", "exte\t", "exten\t"]
+    replace: extent
+  - triggers: ["ext\t", "exte\t", "exter\t", "extern\t", "externa\t"]
+    replace: external
+  - triggers: ["ext\t", "extr\t"]
+    replace: extra
+  - triggers: ["ext\t", "extr\t", "extra\t", "extrao\t", "extraor\t", "extraord\t", "extraordi\t", "extraordin\t", "extraordina\t", "extraordinar\t"]
+    replace: extraordinary
+  - triggers: ["ext\t", "extr\t", "extre\t", "extrem\t"]
+    replace: extreme
+  - triggers: ["ext\t", "extr\t", "extre\t", "extrem\t", "extreme\t", "extremel\t"]
+    replace: extremely
+  - triggers: ["fab\t", "fabr\t", "fabri\t"]
+    replace: fabric
+  - triggers: ["fac\t"]
+    replace: face
+  - triggers: ["fac\t", "faci\t", "facil\t", "facili\t", "facilit\t"]
+    replace: facility
+  - triggers: ["fac\t"]
+    replace: fact
+  - triggers: ["fac\t", "fact\t", "facto\t"]
+    replace: factor
+  - triggers: ["fac\t", "fact\t", "facto\t", "factor\t"]
+    replace: factory
+  - triggers: ["fac\t", "facu\t", "facul\t", "facult\t"]
+    replace: faculty
+  - triggers: ["fad\t"]
+    replace: fade
+  - triggers: ["fai\t"]
+    replace: fail
+  - triggers: ["fai\t", "fail\t", "failu\t", "failur\t"]
+    replace: failure
+  - triggers: ["fai\t"]
+    replace: fair
+  - triggers: ["fai\t", "fair\t", "fairl\t"]
+    replace: fairly
+  - triggers: ["fai\t", "fait\t"]
+    replace: faith
+  - triggers: ["fal\t"]
+    replace: fall
+  - triggers: ["fam\t", "fami\t", "famil\t", "famili\t", "familia\t"]
+    replace: familiar
+  - triggers: ["fam\t", "fami\t", "famil\t"]
+    replace: family
+  - triggers: ["fam\t", "famo\t", "famou\t"]
+    replace: famous
+  - triggers: ["fan\t", "fant\t", "fanta\t", "fantas\t"]
+    replace: fantasy
+  - triggers: ["far\t"]
+    replace: farm
+  - triggers: ["far\t", "farm\t", "farme\t"]
+    replace: farmer
+  - triggers: ["fas\t", "fash\t", "fashi\t", "fashio\t"]
+    replace: fashion
+  - triggers: ["fas\t"]
+    replace: fast
+  - triggers: ["fat\t"]
+    replace: fate
+  - triggers: ["fat\t", "fath\t", "fathe\t"]
+    replace: father
+  - triggers: ["fau\t", "faul\t"]
+    replace: fault
+  - triggers: ["fav\t", "favo\t"]
+    replace: favor
+  - triggers: ["fav\t", "favo\t", "favor\t", "favori\t", "favorit\t"]
+    replace: favorite
+  - triggers: ["fea\t"]
+    replace: fear
+  - triggers: ["fea\t", "feat\t", "featu\t", "featur\t"]
+    replace: feature
+  - triggers: ["fed\t", "fede\t", "feder\t", "federa\t"]
+    replace: federal
+  - triggers: ["fee\t"]
+    replace: feed
+  - triggers: ["fee\t"]
+    replace: feel
+  - triggers: ["fee\t", "feel\t", "feeli\t", "feelin\t"]
+    replace: feeling
+  - triggers: ["fel\t", "fell\t", "fello\t"]
+    replace: fellow
+  - triggers: ["fem\t", "fema\t", "femal\t"]
+    replace: female
+  - triggers: ["fen\t", "fenc\t"]
+    replace: fence
+  - triggers: ["few\t", "fewe\t"]
+    replace: fewer
+  - triggers: ["fib\t", "fibe\t"]
+    replace: fiber
+  - triggers: ["fic\t", "fict\t", "ficti\t", "fictio\t"]
+    replace: fiction
+  - triggers: ["fie\t", "fiel\t"]
+    replace: field
+  - triggers: ["fif\t", "fift\t", "fifte\t", "fiftee\t"]
+    replace: fifteen
+  - triggers: ["fif\t", "fift\t"]
+    replace: fifth
+  - triggers: ["fif\t", "fift\t"]
+    replace: fifty
+  - triggers: ["fig\t", "figh\t"]
+    replace: fight
+  - triggers: ["fig\t", "figh\t", "fight\t", "fighte\t"]
+    replace: fighter
+  - triggers: ["fig\t", "figh\t", "fight\t", "fighti\t", "fightin\t"]
+    replace: fighting
+  - triggers: ["fig\t", "figu\t", "figur\t"]
+    replace: figure
+  - triggers: ["fil\t"]
+    replace: file
+  - triggers: ["fil\t"]
+    replace: fill
+  - triggers: ["fil\t"]
+    replace: film
+  - triggers: ["fin\t", "fina\t"]
+    replace: final
+  - triggers: ["fin\t", "fina\t", "final\t", "finall\t"]
+    replace: finally
+  - triggers: ["fin\t", "fina\t", "finan\t", "financ\t"]
+    replace: finance
+  - triggers: ["fin\t", "fina\t", "finan\t", "financ\t", "financi\t", "financia\t"]
+    replace: financial
+  - triggers: ["fin\t"]
+    replace: find
+  - triggers: ["fin\t", "find\t", "findi\t", "findin\t"]
+    replace: finding
+  - triggers: ["fin\t"]
+    replace: fine
+  - triggers: ["fin\t", "fing\t", "finge\t"]
+    replace: finger
+  - triggers: ["fin\t", "fini\t", "finis\t"]
+    replace: finish
+  - triggers: ["fir\t"]
+    replace: fire
+  - triggers: ["fir\t"]
+    replace: firm
+  - triggers: ["fir\t", "firs\t"]
+    replace: first
+  - triggers: ["fis\t"]
+    replace: fish
+  - triggers: ["fis\t", "fish\t", "fishi\t", "fishin\t"]
+    replace: fishing
+  - triggers: ["fit\t", "fitn\t", "fitne\t", "fitnes\t"]
+    replace: fitness
+  - triggers: ["fiv\t"]
+    replace: five
+  - triggers: ["fla\t"]
+    replace: flag
+  - triggers: ["fla\t", "flam\t"]
+    replace: flame
+  - triggers: ["fla\t"]
+    replace: flat
+  - triggers: ["fla\t", "flav\t", "flavo\t"]
+    replace: flavor
+  - triggers: ["fle\t"]
+    replace: flee
+  - triggers: ["fle\t", "fles\t"]
+    replace: flesh
+  - triggers: ["fli\t", "flig\t", "fligh\t"]
+    replace: flight
+  - triggers: ["flo\t", "floa\t"]
+    replace: float
+  - triggers: ["flo\t", "floo\t"]
+    replace: floor
+  - triggers: ["flo\t"]
+    replace: flow
+  - triggers: ["flo\t", "flow\t", "flowe\t"]
+    replace: flower
+  - triggers: ["foc\t", "focu\t"]
+    replace: focus
+  - triggers: ["fol\t"]
+    replace: folk
+  - triggers: ["fol\t", "foll\t", "follo\t"]
+    replace: follow
+  - triggers: ["fol\t", "foll\t", "follo\t", "follow\t", "followi\t", "followin\t"]
+    replace: following
+  - triggers: ["foo\t"]
+    replace: food
+  - triggers: ["foo\t"]
+    replace: foot
+  - triggers: ["foo\t", "foot\t", "footb\t", "footba\t", "footbal\t"]
+    replace: football
+  - triggers: ["for\t", "forc\t"]
+    replace: force
+  - triggers: ["for\t", "fore\t", "forei\t", "foreig\t"]
+    replace: foreign
+  - triggers: ["for\t", "fore\t", "fores\t"]
+    replace: forest
+  - triggers: ["for\t", "fore\t", "forev\t", "foreve\t"]
+    replace: forever
+  - triggers: ["for\t", "forg\t", "forge\t"]
+    replace: forget
+  - triggers: ["for\t"]
+    replace: form
+  - triggers: ["for\t", "form\t", "forma\t"]
+    replace: formal
+  - triggers: ["for\t", "form\t", "forma\t", "format\t", "formati\t", "formatio\t"]
+    replace: formation
+  - triggers: ["for\t", "form\t", "forme\t"]
+    replace: former
+  - triggers: ["for\t", "form\t", "formu\t", "formul\t"]
+    replace: formula
+  - triggers: ["for\t", "fort\t"]
+    replace: forth
+  - triggers: ["for\t", "fort\t", "fortu\t", "fortun\t"]
+    replace: fortune
+  - triggers: ["for\t", "forw\t", "forwa\t", "forwar\t"]
+    replace: forward
+  - triggers: ["fou\t", "foun\t"]
+    replace: found
+  - triggers: ["fou\t", "foun\t", "found\t", "founda\t", "foundat\t", "foundati\t", "foundatio\t"]
+    replace: foundation
+  - triggers: ["fou\t", "foun\t", "found\t", "founde\t"]
+    replace: founder
+  - triggers: ["fou\t"]
+    replace: four
+  - triggers: ["fou\t", "four\t", "fourt\t"]
+    replace: fourth
+  - triggers: ["fra\t", "fram\t"]
+    replace: frame
+  - triggers: ["fra\t", "fram\t", "frame\t", "framew\t", "framewo\t", "framewor\t"]
+    replace: framework
+  - triggers: ["fre\t"]
+    replace: free
+  - triggers: ["fre\t", "free\t", "freed\t", "freedo\t"]
+    replace: freedom
+  - triggers: ["fre\t", "free\t", "freez\t"]
+    replace: freeze
+  - triggers: ["fre\t", "freq\t", "frequ\t", "freque\t", "frequen\t", "frequenc\t"]
+    replace: frequency
+  - triggers: ["fre\t", "freq\t", "frequ\t", "freque\t", "frequen\t"]
+    replace: frequent
+  - triggers: ["fre\t", "freq\t", "frequ\t", "freque\t", "frequen\t", "frequent\t", "frequentl\t"]
+    replace: frequently
+  - triggers: ["fre\t", "fres\t"]
+    replace: fresh
+  - triggers: ["fri\t", "frie\t", "frien\t"]
+    replace: friend
+  - triggers: ["fri\t", "frie\t", "frien\t", "friend\t", "friendl\t"]
+    replace: friendly
+  - triggers: ["fri\t", "frie\t", "frien\t", "friend\t", "friends\t", "friendsh\t", "friendshi\t"]
+    replace: friendship
+  - triggers: ["fro\t"]
+    replace: from
+  - triggers: ["fro\t", "fron\t"]
+    replace: front
+  - triggers: ["fru\t", "frui\t"]
+    replace: fruit
+  - triggers: ["fru\t", "frus\t", "frust\t", "frustr\t", "frustra\t", "frustrat\t", "frustrati\t", "frustratio\t"]
+    replace: frustration
+  - triggers: ["fue\t"]
+    replace: fuel
+  - triggers: ["ful\t"]
+    replace: full
+  - triggers: ["ful\t", "full\t"]
+    replace: fully
+  - triggers: ["fun\t", "func\t", "funct\t", "functi\t", "functio\t"]
+    replace: function
+  - triggers: ["fun\t"]
+    replace: fund
+  - triggers: ["fun\t", "fund\t", "funda\t", "fundam\t", "fundame\t", "fundamen\t", "fundament\t", "fundamenta\t"]
+    replace: fundamental
+  - triggers: ["fun\t", "fund\t", "fundi\t", "fundin\t"]
+    replace: funding
+  - triggers: ["fun\t", "fune\t", "funer\t", "funera\t"]
+    replace: funeral
+  - triggers: ["fun\t", "funn\t"]
+    replace: funny
+  - triggers: ["fur\t", "furn\t", "furni\t", "furnit\t", "furnitu\t", "furnitur\t"]
+    replace: furniture
+  - triggers: ["fur\t", "furt\t", "furth\t", "furthe\t", "further\t", "furtherm\t", "furthermo\t", "furthermor\t"]
+    replace: furthermore
+  - triggers: ["fut\t", "futu\t", "futur\t"]
+    replace: future
+  - triggers: ["gai\t"]
+    replace: gain
+  - triggers: ["gal\t", "gala\t", "galax\t"]
+    replace: galaxy
+  - triggers: ["gal\t", "gall\t", "galle\t", "galler\t"]
+    replace: gallery
+  - triggers: ["gam\t"]
+    replace: game
+  - triggers: ["gan\t"]
+    replace: gang
+  - triggers: ["gar\t", "gara\t", "garag\t"]
+    replace: garage
+  - triggers: ["gar\t", "gard\t", "garde\t"]
+    replace: garden
+  - triggers: ["gar\t", "garl\t", "garli\t"]
+    replace: garlic
+  - triggers: ["gat\t"]
+    replace: gate
+  - triggers: ["gat\t", "gath\t", "gathe\t"]
+    replace: gather
+  - triggers: ["gaz\t"]
+    replace: gaze
+  - triggers: ["gea\t"]
+    replace: gear
+  - triggers: ["gen\t", "gend\t", "gende\t"]
+    replace: gender
+  - triggers: ["gen\t"]
+    replace: gene
+  - triggers: ["gen\t", "gene\t", "gener\t", "genera\t"]
+    replace: general
+  - triggers: ["gen\t", "gene\t", "gener\t", "genera\t", "general\t", "generall\t"]
+    replace: generally
+  - triggers: ["gen\t", "gene\t", "gener\t", "genera\t", "generat\t"]
+    replace: generate
+  - triggers: ["gen\t", "gene\t", "gener\t", "genera\t", "generat\t", "generati\t", "generatio\t"]
+    replace: generation
+  - triggers: ["gen\t", "gene\t", "genet\t", "geneti\t"]
+    replace: genetic
+  - triggers: ["gen\t", "gent\t", "gentl\t", "gentle\t", "gentlem\t", "gentlema\t"]
+    replace: gentleman
+  - triggers: ["gen\t", "gent\t", "gentl\t"]
+    replace: gently
+  - triggers: ["ges\t", "gest\t", "gestu\t", "gestur\t"]
+    replace: gesture
+  - triggers: ["gho\t", "ghos\t"]
+    replace: ghost
+  - triggers: ["gia\t", "gian\t"]
+    replace: giant
+  - triggers: ["gif\t"]
+    replace: gift
+  - triggers: ["gif\t", "gift\t", "gifte\t"]
+    replace: gifted
+  - triggers: ["gir\t"]
+    replace: girl
+  - triggers: ["gir\t", "girl\t", "girlf\t", "girlfr\t", "girlfri\t", "girlfrie\t", "girlfrien\t"]
+    replace: girlfriend
+  - triggers: ["giv\t"]
+    replace: give
+  - triggers: ["giv\t", "give\t"]
+    replace: given
+  - triggers: ["gla\t"]
+    replace: glad
+  - triggers: ["gla\t", "glan\t", "glanc\t"]
+    replace: glance
+  - triggers: ["gla\t", "glas\t"]
+    replace: glass
+  - triggers: ["glo\t", "glob\t", "globa\t"]
+    replace: global
+  - triggers: ["glo\t", "glov\t"]
+    replace: glove
+  - triggers: ["goa\t"]
+    replace: goal
+  - triggers: ["gol\t"]
+    replace: gold
+  - triggers: ["gol\t", "gold\t", "golde\t"]
+    replace: golden
+  - triggers: ["gol\t"]
+    replace: golf
+  - triggers: ["goo\t"]
+    replace: good
+  - triggers: ["gov\t", "gove\t", "gover\t", "govern\t", "governm\t", "governme\t", "governmen\t"]
+    replace: government
+  - triggers: ["gov\t", "gove\t", "gover\t", "govern\t", "governo\t"]
+    replace: governor
+  - triggers: ["gra\t"]
+    replace: grab
+  - triggers: ["gra\t", "grad\t"]
+    replace: grade
+  - triggers: ["gra\t", "grad\t", "gradu\t", "gradua\t", "gradual\t", "graduall\t"]
+    replace: gradually
+  - triggers: ["gra\t", "grad\t", "gradu\t", "gradua\t", "graduat\t"]
+    replace: graduate
+  - triggers: ["gra\t", "grai\t"]
+    replace: grain
+  - triggers: ["gra\t", "gran\t"]
+    replace: grand
+  - triggers: ["gra\t", "gran\t", "grand\t", "grandf\t", "grandfa\t", "grandfat\t", "grandfath\t", "grandfathe\t"]
+    replace: grandfather
+  - triggers: ["gra\t", "gran\t", "grand\t", "grandm\t", "grandmo\t", "grandmot\t", "grandmoth\t", "grandmothe\t"]
+    replace: grandmother
+  - triggers: ["gra\t", "gran\t"]
+    replace: grant
+  - triggers: ["gra\t", "gras\t"]
+    replace: grass
+  - triggers: ["gra\t", "grav\t"]
+    replace: grave
+  - triggers: ["gra\t"]
+    replace: gray
+  - triggers: ["gre\t", "grea\t"]
+    replace: great
+  - triggers: ["gre\t", "grea\t", "great\t", "greate\t", "greates\t"]
+    replace: greatest
+  - triggers: ["gre\t", "gree\t"]
+    replace: green
+  - triggers: ["gro\t", "groc\t", "groce\t", "grocer\t"]
+    replace: grocery
+  - triggers: ["gro\t", "grou\t", "groun\t"]
+    replace: ground
+  - triggers: ["gro\t", "grou\t"]
+    replace: group
+  - triggers: ["gro\t"]
+    replace: grow
+  - triggers: ["gro\t", "grow\t", "growi\t", "growin\t"]
+    replace: growing
+  - triggers: ["gro\t", "grow\t", "growt\t"]
+    replace: growth
+  - triggers: ["gua\t", "guar\t", "guara\t", "guaran\t", "guarant\t", "guarante\t"]
+    replace: guarantee
+  - triggers: ["gua\t", "guar\t"]
+    replace: guard
+  - triggers: ["gue\t", "gues\t"]
+    replace: guess
+  - triggers: ["gue\t", "gues\t"]
+    replace: guest
+  - triggers: ["gui\t", "guid\t"]
+    replace: guide
+  - triggers: ["gui\t", "guid\t", "guide\t", "guidel\t", "guideli\t", "guidelin\t"]
+    replace: guideline
+  - triggers: ["gui\t", "guil\t", "guilt\t"]
+    replace: guilty
+  - triggers: ["hab\t", "habi\t"]
+    replace: habit
+  - triggers: ["hab\t", "habi\t", "habit\t", "habita\t"]
+    replace: habitat
+  - triggers: ["hai\t"]
+    replace: hair
+  - triggers: ["hal\t"]
+    replace: half
+  - triggers: ["hal\t"]
+    replace: hall
+  - triggers: ["han\t"]
+    replace: hand
+  - triggers: ["han\t", "hand\t", "handf\t", "handfu\t"]
+    replace: handful
+  - triggers: ["han\t", "hand\t", "handl\t"]
+    replace: handle
+  - triggers: ["han\t"]
+    replace: hang
+  - triggers: ["hap\t", "happ\t", "happe\t"]
+    replace: happen
+  - triggers: ["hap\t", "happ\t"]
+    replace: happy
+  - triggers: ["har\t"]
+    replace: hard
+  - triggers: ["har\t", "hard\t", "hardl\t"]
+    replace: hardly
+  - triggers: ["hat\t"]
+    replace: hate
+  - triggers: ["hav\t"]
+    replace: have
+  - triggers: ["hea\t"]
+    replace: head
+  - triggers: ["hea\t", "head\t", "headl\t", "headli\t", "headlin\t"]
+    replace: headline
+  - triggers: ["hea\t", "head\t", "headq\t", "headqu\t", "headqua\t", "headquar\t", "headquart\t", "headquarte\t", "headquarter\t"]
+    replace: headquarters
+  - triggers: ["hea\t", "heal\t", "healt\t"]
+    replace: health
+  - triggers: ["hea\t", "heal\t", "healt\t", "health\t"]
+    replace: healthy
+  - triggers: ["hea\t"]
+    replace: hear
+  - triggers: ["hea\t", "hear\t", "heari\t", "hearin\t"]
+    replace: hearing
+  - triggers: ["hea\t", "hear\t"]
+    replace: heart
+  - triggers: ["hea\t"]
+    replace: heat
+  - triggers: ["hea\t", "heav\t", "heave\t"]
+    replace: heaven
+  - triggers: ["hea\t", "heav\t", "heavi\t", "heavil\t"]
+    replace: heavily
+  - triggers: ["hea\t", "heav\t"]
+    replace: heavy
+  - triggers: ["hee\t"]
+    replace: heel
+  - triggers: ["hei\t", "heig\t", "heigh\t"]
+    replace: height
+  - triggers: ["hel\t", "heli\t", "helic\t", "helico\t", "helicop\t", "helicopt\t", "helicopte\t"]
+    replace: helicopter
+  - triggers: ["hel\t"]
+    replace: hell
+  - triggers: ["hel\t", "hell\t"]
+    replace: hello
+  - triggers: ["hel\t"]
+    replace: help
+  - triggers: ["hel\t", "help\t", "helpf\t", "helpfu\t"]
+    replace: helpful
+  - triggers: ["her\t"]
+    replace: here
+  - triggers: ["her\t", "heri\t", "herit\t", "herita\t", "heritag\t"]
+    replace: heritage
+  - triggers: ["her\t"]
+    replace: hero
+  - triggers: ["her\t", "hers\t", "herse\t", "hersel\t"]
+    replace: herself
+  - triggers: ["hid\t"]
+    replace: hide
+  - triggers: ["hig\t"]
+    replace: high
+  - triggers: ["hig\t", "high\t", "highl\t", "highli\t", "highlig\t", "highligh\t"]
+    replace: highlight
+  - triggers: ["hig\t", "high\t", "highl\t"]
+    replace: highly
+  - triggers: ["hig\t", "high\t", "highw\t", "highwa\t"]
+    replace: highway
+  - triggers: ["hil\t"]
+    replace: hill
+  - triggers: ["him\t", "hims\t", "himse\t", "himsel\t"]
+    replace: himself
+  - triggers: ["hir\t"]
+    replace: hire
+  - triggers: ["his\t", "hist\t", "histo\t", "histor\t", "histori\t", "historia\t"]
+    replace: historian
+  - triggers: ["his\t", "hist\t", "histo\t", "histor\t", "histori\t"]
+    replace: historic
+  - triggers: ["his\t", "hist\t", "histo\t", "histor\t", "histori\t", "historic\t", "historica\t"]
+    replace: historical
+  - triggers: ["his\t", "hist\t", "histo\t", "histor\t"]
+    replace: history
+  - triggers: ["hol\t"]
+    replace: hold
+  - triggers: ["hol\t"]
+    replace: hole
+  - triggers: ["hol\t", "holi\t", "holid\t", "holida\t"]
+    replace: holiday
+  - triggers: ["hol\t"]
+    replace: holy
+  - triggers: ["hom\t"]
+    replace: home
+  - triggers: ["hom\t", "home\t", "homel\t", "homele\t", "homeles\t"]
+    replace: homeless
+  - triggers: ["hon\t", "hone\t", "hones\t"]
+    replace: honest
+  - triggers: ["hon\t", "hone\t"]
+    replace: honey
+  - triggers: ["hon\t", "hono\t"]
+    replace: honor
+  - triggers: ["hop\t"]
+    replace: hope
+  - triggers: ["hor\t", "hori\t", "horiz\t", "horizo\t"]
+    replace: horizon
+  - triggers: ["hor\t", "horr\t", "horro\t"]
+    replace: horror
+  - triggers: ["hor\t", "hors\t"]
+    replace: horse
+  - triggers: ["hos\t", "hosp\t", "hospi\t", "hospit\t", "hospita\t"]
+    replace: hospital
+  - triggers: ["hos\t"]
+    replace: host
+  - triggers: ["hot\t", "hote\t"]
+    replace: hotel
+  - triggers: ["hou\t"]
+    replace: hour
+  - triggers: ["hou\t", "hous\t"]
+    replace: house
+  - triggers: ["hou\t", "hous\t", "house\t", "househ\t", "househo\t", "househol\t"]
+    replace: household
+  - triggers: ["hou\t", "hous\t", "housi\t", "housin\t"]
+    replace: housing
+  - triggers: ["how\t", "howe\t", "howev\t", "howeve\t"]
+    replace: however
+  - triggers: ["hug\t"]
+    replace: huge
+  - triggers: ["hum\t", "huma\t"]
+    replace: human
+  - triggers: ["hum\t", "humo\t"]
+    replace: humor
+  - triggers: ["hun\t", "hund\t", "hundr\t", "hundre\t"]
+    replace: hundred
+  - triggers: ["hun\t", "hung\t", "hungr\t"]
+    replace: hungry
+  - triggers: ["hun\t", "hunt\t", "hunte\t"]
+    replace: hunter
+  - triggers: ["hun\t", "hunt\t", "hunti\t", "huntin\t"]
+    replace: hunting
+  - triggers: ["hur\t"]
+    replace: hurt
+  - triggers: ["hus\t", "husb\t", "husba\t", "husban\t"]
+    replace: husband
+  - triggers: ["hyp\t", "hypo\t", "hypot\t", "hypoth\t", "hypothe\t", "hypothes\t", "hypothesi\t"]
+    replace: hypothesis
+  - triggers: ["ide\t"]
+    replace: idea
+  - triggers: ["ide\t", "idea\t"]
+    replace: ideal
+  - triggers: ["ide\t", "iden\t", "ident\t", "identi\t", "identif\t", "identifi\t", "identific\t", "identifica\t", "identificat\t", "identificati\t", "identificatio\t"]
+    replace: identification
+  - triggers: ["ide\t", "iden\t", "ident\t", "identi\t", "identif\t"]
+    replace: identify
+  - triggers: ["ide\t", "iden\t", "ident\t", "identi\t", "identit\t"]
+    replace: identity
+  - triggers: ["ign\t", "igno\t", "ignor\t"]
+    replace: ignore
+  - triggers: ["ill\t", "ille\t", "illeg\t", "illega\t"]
+    replace: illegal
+  - triggers: ["ill\t", "illn\t", "illne\t", "illnes\t"]
+    replace: illness
+  - triggers: ["ill\t", "illu\t", "illus\t", "illust\t", "illustr\t", "illustra\t", "illustrat\t"]
+    replace: illustrate
+  - triggers: ["ima\t", "imag\t"]
+    replace: image
+  - triggers: ["ima\t", "imag\t", "imagi\t", "imagin\t", "imagina\t", "imaginat\t", "imaginati\t", "imaginatio\t"]
+    replace: imagination
+  - triggers: ["ima\t", "imag\t", "imagi\t", "imagin\t"]
+    replace: imagine
+  - triggers: ["imm\t", "imme\t", "immed\t", "immedi\t", "immedia\t", "immediat\t"]
+    replace: immediate
+  - triggers: ["imm\t", "imme\t", "immed\t", "immedi\t", "immedia\t", "immediat\t", "immediate\t", "immediatel\t"]
+    replace: immediately
+  - triggers: ["imm\t", "immi\t", "immig\t", "immigr\t", "immigra\t", "immigran\t"]
+    replace: immigrant
+  - triggers: ["imm\t", "immi\t", "immig\t", "immigr\t", "immigra\t", "immigrat\t", "immigrati\t", "immigratio\t"]
+    replace: immigration
+  - triggers: ["imp\t", "impa\t", "impac\t"]
+    replace: impact
+  - triggers: ["imp\t", "impl\t", "imple\t", "implem\t", "impleme\t", "implemen\t"]
+    replace: implement
+  - triggers: ["imp\t", "impl\t", "impli\t", "implic\t", "implica\t", "implicat\t", "implicati\t", "implicatio\t"]
+    replace: implication
+  - triggers: ["imp\t", "impl\t"]
+    replace: imply
+  - triggers: ["imp\t", "impo\t", "impor\t", "import\t", "importa\t", "importan\t", "importanc\t"]
+    replace: importance
+  - triggers: ["imp\t", "impo\t", "impor\t", "import\t", "importa\t", "importan\t"]
+    replace: important
+  - triggers: ["imp\t", "impo\t", "impos\t"]
+    replace: impose
+  - triggers: ["imp\t", "impo\t", "impos\t", "imposs\t", "impossi\t", "impossib\t", "impossibl\t"]
+    replace: impossible
+  - triggers: ["imp\t", "impr\t", "impre\t", "impres\t"]
+    replace: impress
+  - triggers: ["imp\t", "impr\t", "impre\t", "impres\t", "impress\t", "impressi\t", "impressio\t"]
+    replace: impression
+  - triggers: ["imp\t", "impr\t", "impre\t", "impres\t", "impress\t", "impressi\t", "impressiv\t"]
+    replace: impressive
+  - triggers: ["imp\t", "impr\t", "impro\t", "improv\t"]
+    replace: improve
+  - triggers: ["imp\t", "impr\t", "impro\t", "improv\t", "improve\t", "improvem\t", "improveme\t", "improvemen\t"]
+    replace: improvement
+  - triggers: ["inc\t", "ince\t", "incen\t", "incent\t", "incenti\t", "incentiv\t"]
+    replace: incentive
+  - triggers: ["inc\t", "inci\t", "incid\t", "incide\t", "inciden\t"]
+    replace: incident
+  - triggers: ["inc\t", "incl\t", "inclu\t", "includ\t"]
+    replace: include
+  - triggers: ["inc\t", "incl\t", "inclu\t", "includ\t", "includi\t", "includin\t"]
+    replace: including
+  - triggers: ["inc\t", "inco\t", "incom\t"]
+    replace: income
+  - triggers: ["inc\t", "inco\t", "incor\t", "incorp\t", "incorpo\t", "incorpor\t", "incorpora\t", "incorporat\t"]
+    replace: incorporate
+  - triggers: ["inc\t", "incr\t", "incre\t", "increa\t", "increas\t"]
+    replace: increase
+  - triggers: ["inc\t", "incr\t", "incre\t", "increa\t", "increas\t", "increase\t"]
+    replace: increased
+  - triggers: ["inc\t", "incr\t", "incre\t", "increa\t", "increas\t", "increasi\t", "increasin\t"]
+    replace: increasing
+  - triggers: ["inc\t", "incr\t", "incre\t", "increa\t", "increas\t", "increasi\t", "increasin\t", "increasing\t", "increasingl\t"]
+    replace: increasingly
+  - triggers: ["inc\t", "incr\t", "incre\t", "incred\t", "incredi\t", "incredib\t", "incredibl\t"]
+    replace: incredible
+  - triggers: ["ind\t", "inde\t", "indee\t"]
+    replace: indeed
+  - triggers: ["ind\t", "inde\t", "indep\t", "indepe\t", "indepen\t", "independ\t", "independe\t", "independen\t", "independenc\t"]
+    replace: independence
+  - triggers: ["ind\t", "inde\t", "indep\t", "indepe\t", "indepen\t", "independ\t", "independe\t", "independen\t"]
+    replace: independent
+  - triggers: ["ind\t", "inde\t"]
+    replace: index
+  - triggers: ["ind\t", "indi\t", "indic\t", "indica\t", "indicat\t"]
+    replace: indicate
+  - triggers: ["ind\t", "indi\t", "indic\t", "indica\t", "indicat\t", "indicati\t", "indicatio\t"]
+    replace: indication
+  - triggers: ["ind\t", "indi\t", "indiv\t", "indivi\t", "individ\t", "individu\t", "individua\t"]
+    replace: individual
+  - triggers: ["ind\t", "indu\t", "indus\t", "indust\t", "industr\t", "industri\t", "industria\t"]
+    replace: industrial
+  - triggers: ["ind\t", "indu\t", "indus\t", "indust\t", "industr\t"]
+    replace: industry
+  - triggers: ["inf\t", "infa\t", "infan\t"]
+    replace: infant
+  - triggers: ["inf\t", "infe\t", "infec\t", "infect\t", "infecti\t", "infectio\t"]
+    replace: infection
+  - triggers: ["inf\t", "infl\t", "infla\t", "inflat\t", "inflati\t", "inflatio\t"]
+    replace: inflation
+  - triggers: ["inf\t", "infl\t", "influ\t", "influe\t", "influen\t", "influenc\t"]
+    replace: influence
+  - triggers: ["inf\t", "info\t", "infor\t"]
+    replace: inform
+  - triggers: ["inf\t", "info\t", "infor\t", "inform\t", "informa\t", "informat\t", "informati\t", "informatio\t"]
+    replace: information
+  - triggers: ["ing\t", "ingr\t", "ingre\t", "ingred\t", "ingredi\t", "ingredie\t", "ingredien\t"]
+    replace: ingredient
+  - triggers: ["ini\t", "init\t", "initi\t", "initia\t"]
+    replace: initial
+  - triggers: ["ini\t", "init\t", "initi\t", "initia\t", "initial\t", "initiall\t"]
+    replace: initially
+  - triggers: ["ini\t", "init\t", "initi\t", "initia\t", "initiat\t", "initiati\t", "initiativ\t"]
+    replace: initiative
+  - triggers: ["inj\t", "inju\t", "injur\t"]
+    replace: injury
+  - triggers: ["inn\t", "inne\t"]
+    replace: inner
+  - triggers: ["inn\t", "inno\t", "innoc\t", "innoce\t", "innocen\t"]
+    replace: innocent
+  - triggers: ["inq\t", "inqu\t", "inqui\t", "inquir\t"]
+    replace: inquiry
+  - triggers: ["ins\t", "insi\t", "insid\t"]
+    replace: inside
+  - triggers: ["ins\t", "insi\t", "insig\t", "insigh\t"]
+    replace: insight
+  - triggers: ["ins\t", "insi\t", "insis\t"]
+    replace: insist
+  - triggers: ["ins\t", "insp\t", "inspi\t", "inspir\t"]
+    replace: inspire
+  - triggers: ["ins\t", "inst\t", "insta\t", "instal\t"]
+    replace: install
+  - triggers: ["ins\t", "inst\t", "insta\t", "instan\t", "instanc\t"]
+    replace: instance
+  - triggers: ["ins\t", "inst\t", "inste\t", "instea\t"]
+    replace: instead
+  - triggers: ["ins\t", "inst\t", "insti\t", "instit\t", "institu\t", "institut\t", "instituti\t", "institutio\t"]
+    replace: institution
+  - triggers: ["ins\t", "inst\t", "insti\t", "instit\t", "institu\t", "institut\t", "instituti\t", "institutio\t", "institution\t", "institutiona\t"]
+    replace: institutional
+  - triggers: ["ins\t", "inst\t", "instr\t", "instru\t", "instruc\t", "instruct\t", "instructi\t", "instructio\t"]
+    replace: instruction
+  - triggers: ["ins\t", "inst\t", "instr\t", "instru\t", "instruc\t", "instruct\t", "instructo\t"]
+    replace: instructor
+  - triggers: ["ins\t", "inst\t", "instr\t", "instru\t", "instrum\t", "instrume\t", "instrumen\t"]
+    replace: instrument
+  - triggers: ["ins\t", "insu\t", "insur\t", "insura\t", "insuran\t", "insuranc\t"]
+    replace: insurance
+  - triggers: ["int\t", "inte\t", "intel\t", "intell\t", "intelle\t", "intellec\t", "intellect\t", "intellectu\t", "intellectua\t"]
+    replace: intellectual
+  - triggers: ["int\t", "inte\t", "intel\t", "intell\t", "intelli\t", "intellig\t", "intellige\t", "intelligen\t", "intelligenc\t"]
+    replace: intelligence
+  - triggers: ["int\t", "inte\t", "inten\t"]
+    replace: intend
+  - triggers: ["int\t", "inte\t", "inten\t", "intens\t"]
+    replace: intense
+  - triggers: ["int\t", "inte\t", "inten\t", "intens\t", "intensi\t", "intensit\t"]
+    replace: intensity
+  - triggers: ["int\t", "inte\t", "inten\t", "intent\t", "intenti\t", "intentio\t"]
+    replace: intention
+  - triggers: ["int\t", "inte\t", "inter\t", "intera\t", "interac\t", "interact\t", "interacti\t", "interactio\t"]
+    replace: interaction
+  - triggers: ["int\t", "inte\t", "inter\t", "intere\t", "interes\t"]
+    replace: interest
+  - triggers: ["int\t", "inte\t", "inter\t", "intere\t", "interes\t", "interest\t", "intereste\t"]
+    replace: interested
+  - triggers: ["int\t", "inte\t", "inter\t", "intere\t", "interes\t", "interest\t", "interesti\t", "interestin\t"]
+    replace: interesting
+  - triggers: ["int\t", "inte\t", "inter\t", "intern\t", "interna\t"]
+    replace: internal
+  - triggers: ["int\t", "inte\t", "inter\t", "intern\t", "interna\t", "internat\t", "internati\t", "internatio\t", "internation\t", "internationa\t"]
+    replace: international
+  - triggers: ["int\t", "inte\t", "inter\t", "interp\t", "interpr\t", "interpre\t"]
+    replace: interpret
+  - triggers: ["int\t", "inte\t", "inter\t", "interp\t", "interpr\t", "interpre\t", "interpret\t", "interpreta\t", "interpretat\t", "interpretati\t", "interpretatio\t"]
+    replace: interpretation
+  - triggers: ["int\t", "inte\t", "inter\t", "interv\t", "interve\t", "interven\t", "intervent\t", "interventi\t", "interventio\t"]
+    replace: intervention
+  - triggers: ["int\t", "inte\t", "inter\t", "interv\t", "intervi\t", "intervie\t"]
+    replace: interview
+  - triggers: ["int\t"]
+    replace: into
+  - triggers: ["int\t", "intr\t", "intro\t", "introd\t", "introdu\t", "introduc\t"]
+    replace: introduce
+  - triggers: ["int\t", "intr\t", "intro\t", "introd\t", "introdu\t", "introduc\t", "introduct\t", "introducti\t", "introductio\t"]
+    replace: introduction
+  - triggers: ["inv\t", "inva\t", "invas\t", "invasi\t", "invasio\t"]
+    replace: invasion
+  - triggers: ["inv\t", "inve\t", "inves\t"]
+    replace: invest
+  - triggers: ["inv\t", "inve\t", "inves\t", "invest\t", "investi\t", "investig\t", "investiga\t", "investigat\t"]
+    replace: investigate
+  - triggers: ["inv\t", "inve\t", "inves\t", "invest\t", "investi\t", "investig\t", "investiga\t", "investigat\t", "investigati\t", "investigatio\t"]
+    replace: investigation
+  - triggers: ["inv\t", "inve\t", "inves\t", "invest\t", "investi\t", "investig\t", "investiga\t", "investigat\t", "investigato\t"]
+    replace: investigator
+  - triggers: ["inv\t", "inve\t", "inves\t", "invest\t", "investm\t", "investme\t", "investmen\t"]
+    replace: investment
+  - triggers: ["inv\t", "inve\t", "inves\t", "invest\t", "investo\t"]
+    replace: investor
+  - triggers: ["inv\t", "invi\t", "invit\t"]
+    replace: invite
+  - triggers: ["inv\t", "invo\t", "invol\t", "involv\t"]
+    replace: involve
+  - triggers: ["inv\t", "invo\t", "invol\t", "involv\t", "involve\t"]
+    replace: involved
+  - triggers: ["inv\t", "invo\t", "invol\t", "involv\t", "involve\t", "involvem\t", "involveme\t", "involvemen\t"]
+    replace: involvement
+  - triggers: ["iro\t"]
+    replace: iron
+  - triggers: ["isl\t", "isla\t", "islan\t"]
+    replace: island
+  - triggers: ["iss\t", "issu\t"]
+    replace: issue
+  - triggers: ["ite\t"]
+    replace: item
+  - triggers: ["its\t", "itse\t", "itsel\t"]
+    replace: itself
+  - triggers: ["jac\t", "jack\t", "jacke\t"]
+    replace: jacket
+  - triggers: ["jai\t"]
+    replace: jail
+  - triggers: ["joi\t"]
+    replace: join
+  - triggers: ["joi\t", "join\t"]
+    replace: joint
+  - triggers: ["jok\t"]
+    replace: joke
+  - triggers: ["jou\t", "jour\t", "journ\t", "journa\t"]
+    replace: journal
+  - triggers: ["jou\t", "jour\t", "journ\t", "journa\t", "journal\t", "journali\t", "journalis\t"]
+    replace: journalist
+  - triggers: ["jou\t", "jour\t", "journ\t", "journe\t"]
+    replace: journey
+  - triggers: ["jud\t", "judg\t"]
+    replace: judge
+  - triggers: ["jud\t", "judg\t", "judgm\t", "judgme\t", "judgmen\t"]
+    replace: judgment
+  - triggers: ["jui\t", "juic\t"]
+    replace: juice
+  - triggers: ["jum\t"]
+    replace: jump
+  - triggers: ["jun\t", "juni\t", "junio\t"]
+    replace: junior
+  - triggers: ["jur\t"]
+    replace: jury
+  - triggers: ["jus\t"]
+    replace: just
+  - triggers: ["jus\t", "just\t", "justi\t", "justic\t"]
+    replace: justice
+  - triggers: ["jus\t", "just\t", "justi\t", "justif\t"]
+    replace: justify
+  - triggers: ["kee\t"]
+    replace: keep
+  - triggers: ["kic\t"]
+    replace: kick
+  - triggers: ["kil\t"]
+    replace: kill
+  - triggers: ["kil\t", "kill\t", "kille\t"]
+    replace: killer
+  - triggers: ["kil\t", "kill\t", "killi\t", "killin\t"]
+    replace: killing
+  - triggers: ["kin\t"]
+    replace: kind
+  - triggers: ["kin\t"]
+    replace: king
+  - triggers: ["kis\t"]
+    replace: kiss
+  - triggers: ["kit\t", "kitc\t", "kitch\t", "kitche\t"]
+    replace: kitchen
+  - triggers: ["kne\t"]
+    replace: knee
+  - triggers: ["kni\t", "knif\t"]
+    replace: knife
+  - triggers: ["kno\t", "knoc\t"]
+    replace: knock
+  - triggers: ["kno\t"]
+    replace: know
+  - triggers: ["kno\t", "know\t", "knowl\t", "knowle\t", "knowled\t", "knowledg\t"]
+    replace: knowledge
+  - triggers: ["lab\t", "labe\t"]
+    replace: label
+  - triggers: ["lab\t", "labo\t"]
+    replace: labor
+  - triggers: ["lab\t", "labo\t", "labor\t", "labora\t", "laborat\t", "laborato\t", "laborator\t"]
+    replace: laboratory
+  - triggers: ["lac\t"]
+    replace: lack
+  - triggers: ["lad\t"]
+    replace: lady
+  - triggers: ["lak\t"]
+    replace: lake
+  - triggers: ["lan\t"]
+    replace: land
+  - triggers: ["lan\t", "land\t", "lands\t", "landsc\t", "landsca\t", "landscap\t"]
+    replace: landscape
+  - triggers: ["lan\t", "lang\t", "langu\t", "langua\t", "languag\t"]
+    replace: language
+  - triggers: ["lar\t", "larg\t"]
+    replace: large
+  - triggers: ["lar\t", "larg\t", "large\t", "largel\t"]
+    replace: largely
+  - triggers: ["las\t"]
+    replace: last
+  - triggers: ["lat\t"]
+    replace: late
+  - triggers: ["lat\t", "late\t"]
+    replace: later
+  - triggers: ["lat\t", "latt\t", "latte\t"]
+    replace: latter
+  - triggers: ["lau\t", "laug\t"]
+    replace: laugh
+  - triggers: ["lau\t", "laun\t", "launc\t"]
+    replace: launch
+  - triggers: ["law\t"]
+    replace: lawn
+  - triggers: ["law\t", "laws\t", "lawsu\t", "lawsui\t"]
+    replace: lawsuit
+  - triggers: ["law\t", "lawy\t", "lawye\t"]
+    replace: lawyer
+  - triggers: ["lay\t", "laye\t"]
+    replace: layer
+  - triggers: ["lea\t"]
+    replace: lead
+  - triggers: ["lea\t", "lead\t", "leade\t"]
+    replace: leader
+  - triggers: ["lea\t", "lead\t", "leade\t", "leader\t", "leaders\t", "leadersh\t", "leadershi\t"]
+    replace: leadership
+  - triggers: ["lea\t", "lead\t", "leadi\t", "leadin\t"]
+    replace: leading
+  - triggers: ["lea\t"]
+    replace: leaf
+  - triggers: ["lea\t", "leag\t", "leagu\t"]
+    replace: league
+  - triggers: ["lea\t"]
+    replace: lean
+  - triggers: ["lea\t", "lear\t"]
+    replace: learn
+  - triggers: ["lea\t", "lear\t", "learn\t", "learni\t", "learnin\t"]
+    replace: learning
+  - triggers: ["lea\t", "leas\t"]
+    replace: least
+  - triggers: ["lea\t", "leat\t", "leath\t", "leathe\t"]
+    replace: leather
+  - triggers: ["lea\t", "leav\t"]
+    replace: leave
+  - triggers: ["lef\t"]
+    replace: left
+  - triggers: ["leg\t", "lega\t", "legac\t"]
+    replace: legacy
+  - triggers: ["leg\t", "lega\t"]
+    replace: legal
+  - triggers: ["leg\t", "lege\t", "legen\t"]
+    replace: legend
+  - triggers: ["leg\t", "legi\t", "legis\t", "legisl\t", "legisla\t", "legislat\t", "legislati\t", "legislatio\t"]
+    replace: legislation
+  - triggers: ["leg\t", "legi\t", "legit\t", "legiti\t", "legitim\t", "legitima\t", "legitimat\t"]
+    replace: legitimate
+  - triggers: ["lem\t", "lemo\t"]
+    replace: lemon
+  - triggers: ["len\t", "leng\t", "lengt\t"]
+    replace: length
+  - triggers: ["les\t"]
+    replace: less
+  - triggers: ["les\t", "less\t", "lesso\t"]
+    replace: lesson
+  - triggers: ["let\t", "lett\t", "lette\t"]
+    replace: letter
+  - triggers: ["lev\t", "leve\t"]
+    replace: level
+  - triggers: ["lib\t", "libe\t", "liber\t", "libera\t"]
+    replace: liberal
+  - triggers: ["lib\t", "libr\t", "libra\t", "librar\t"]
+    replace: library
+  - triggers: ["lic\t", "lice\t", "licen\t", "licens\t"]
+    replace: license
+  - triggers: ["lif\t"]
+    replace: life
+  - triggers: ["lif\t", "life\t", "lifes\t", "lifest\t", "lifesty\t", "lifestyl\t"]
+    replace: lifestyle
+  - triggers: ["lif\t", "life\t", "lifet\t", "lifeti\t", "lifetim\t"]
+    replace: lifetime
+  - triggers: ["lif\t"]
+    replace: lift
+  - triggers: ["lig\t", "ligh\t"]
+    replace: light
+  - triggers: ["lik\t"]
+    replace: like
+  - triggers: ["lik\t", "like\t", "likel\t"]
+    replace: likely
+  - triggers: ["lim\t", "limi\t"]
+    replace: limit
+  - triggers: ["lim\t", "limi\t", "limit\t", "limita\t", "limitat\t", "limitati\t", "limitatio\t"]
+    replace: limitation
+  - triggers: ["lim\t", "limi\t", "limit\t", "limite\t"]
+    replace: limited
+  - triggers: ["lin\t"]
+    replace: line
+  - triggers: ["lin\t"]
+    replace: link
+  - triggers: ["lis\t"]
+    replace: list
+  - triggers: ["lis\t", "list\t", "liste\t"]
+    replace: listen
+  - triggers: ["lit\t", "lite\t", "liter\t", "litera\t", "literal\t", "literall\t"]
+    replace: literally
+  - triggers: ["lit\t", "lite\t", "liter\t", "litera\t", "literar\t"]
+    replace: literary
+  - triggers: ["lit\t", "lite\t", "liter\t", "litera\t", "literat\t", "literatu\t", "literatur\t"]
+    replace: literature
+  - triggers: ["lit\t", "litt\t", "littl\t"]
+    replace: little
+  - triggers: ["liv\t"]
+    replace: live
+  - triggers: ["liv\t", "livi\t", "livin\t"]
+    replace: living
+  - triggers: ["loa\t"]
+    replace: load
+  - triggers: ["loa\t"]
+    replace: loan
+  - triggers: ["loc\t", "loca\t"]
+    replace: local
+  - triggers: ["loc\t", "loca\t", "locat\t"]
+    replace: locate
+  - triggers: ["loc\t", "loca\t", "locat\t", "locati\t", "locatio\t"]
+    replace: location
+  - triggers: ["loc\t"]
+    replace: lock
+  - triggers: ["lon\t"]
+    replace: long
+  - triggers: ["lon\t", "long\t", "long-\t", "long-t\t", "long-te\t", "long-ter\t"]
+    replace: long-term
+  - triggers: ["loo\t"]
+    replace: look
+  - triggers: ["loo\t", "loos\t"]
+    replace: loose
+  - triggers: ["los\t"]
+    replace: lose
+  - triggers: ["los\t"]
+    replace: loss
+  - triggers: ["los\t"]
+    replace: lost
+  - triggers: ["lot\t"]
+    replace: lots
+  - triggers: ["lou\t"]
+    replace: loud
+  - triggers: ["lov\t"]
+    replace: love
+  - triggers: ["lov\t", "love\t", "lovel\t"]
+    replace: lovely
+  - triggers: ["lov\t", "love\t"]
+    replace: lover
+  - triggers: ["low\t", "lowe\t"]
+    replace: lower
+  - triggers: ["luc\t"]
+    replace: luck
+  - triggers: ["luc\t", "luck\t"]
+    replace: lucky
+  - triggers: ["lun\t", "lunc\t"]
+    replace: lunch
+  - triggers: ["lun\t"]
+    replace: lung
+  - triggers: ["mac\t", "mach\t", "machi\t", "machin\t"]
+    replace: machine
+  - triggers: ["mag\t", "maga\t", "magaz\t", "magazi\t", "magazin\t"]
+    replace: magazine
+  - triggers: ["mai\t"]
+    replace: mail
+  - triggers: ["mai\t"]
+    replace: main
+  - triggers: ["mai\t", "main\t", "mainl\t"]
+    replace: mainly
+  - triggers: ["mai\t", "main\t", "maint\t", "mainta\t", "maintai\t"]
+    replace: maintain
+  - triggers: ["mai\t", "main\t", "maint\t", "mainte\t", "mainten\t", "maintena\t", "maintenan\t", "maintenanc\t"]
+    replace: maintenance
+  - triggers: ["maj\t", "majo\t"]
+    replace: major
+  - triggers: ["maj\t", "majo\t", "major\t", "majori\t", "majorit\t"]
+    replace: majority
+  - triggers: ["mak\t"]
+    replace: make
+  - triggers: ["mak\t", "make\t"]
+    replace: maker
+  - triggers: ["mak\t", "make\t", "makeu\t"]
+    replace: makeup
+  - triggers: ["mal\t"]
+    replace: male
+  - triggers: ["mal\t"]
+    replace: mall
+  - triggers: ["man\t", "mana\t", "manag\t"]
+    replace: manage
+  - triggers: ["man\t", "mana\t", "manag\t", "manage\t", "managem\t", "manageme\t", "managemen\t"]
+    replace: management
+  - triggers: ["man\t", "mana\t", "manag\t", "manage\t"]
+    replace: manager
+  - triggers: ["man\t", "mann\t", "manne\t"]
+    replace: manner
+  - triggers: ["man\t", "manu\t", "manuf\t", "manufa\t", "manufac\t", "manufact\t", "manufactu\t", "manufactur\t", "manufacture\t"]
+    replace: manufacturer
+  - triggers: ["man\t", "manu\t", "manuf\t", "manufa\t", "manufac\t", "manufact\t", "manufactu\t", "manufactur\t", "manufacturi\t", "manufacturin\t"]
+    replace: manufacturing
+  - triggers: ["man\t"]
+    replace: many
+  - triggers: ["mar\t", "marg\t", "margi\t"]
+    replace: margin
+  - triggers: ["mar\t"]
+    replace: mark
+  - triggers: ["mar\t", "mark\t", "marke\t"]
+    replace: market
+  - triggers: ["mar\t", "mark\t", "marke\t", "market\t", "marketi\t", "marketin\t"]
+    replace: marketing
+  - triggers: ["mar\t", "marr\t", "marri\t", "marria\t", "marriag\t"]
+    replace: marriage
+  - triggers: ["mar\t", "marr\t", "marri\t", "marrie\t"]
+    replace: married
+  - triggers: ["mar\t", "marr\t"]
+    replace: marry
+  - triggers: ["mas\t"]
+    replace: mask
+  - triggers: ["mas\t"]
+    replace: mass
+  - triggers: ["mas\t", "mass\t", "massi\t", "massiv\t"]
+    replace: massive
+  - triggers: ["mas\t", "mast\t", "maste\t"]
+    replace: master
+  - triggers: ["mat\t", "matc\t"]
+    replace: match
+  - triggers: ["mat\t", "mate\t", "mater\t", "materi\t", "materia\t"]
+    replace: material
+  - triggers: ["mat\t"]
+    replace: math
+  - triggers: ["mat\t", "matt\t", "matte\t"]
+    replace: matter
+  - triggers: ["may\t", "mayb\t"]
+    replace: maybe
+  - triggers: ["may\t", "mayo\t"]
+    replace: mayor
+  - triggers: ["mea\t"]
+    replace: meal
+  - triggers: ["mea\t"]
+    replace: mean
+  - triggers: ["mea\t", "mean\t", "meani\t", "meanin\t"]
+    replace: meaning
+  - triggers: ["mea\t", "mean\t", "meanw\t", "meanwh\t", "meanwhi\t", "meanwhil\t"]
+    replace: meanwhile
+  - triggers: ["mea\t", "meas\t", "measu\t", "measur\t"]
+    replace: measure
+  - triggers: ["mea\t", "meas\t", "measu\t", "measur\t", "measure\t", "measurem\t", "measureme\t", "measuremen\t"]
+    replace: measurement
+  - triggers: ["mea\t"]
+    replace: meat
+  - triggers: ["mec\t", "mech\t", "mecha\t", "mechan\t", "mechani\t", "mechanis\t"]
+    replace: mechanism
+  - triggers: ["med\t", "medi\t"]
+    replace: media
+  - triggers: ["med\t", "medi\t", "medic\t", "medica\t"]
+    replace: medical
+  - triggers: ["med\t", "medi\t", "medic\t", "medica\t", "medicat\t", "medicati\t", "medicatio\t"]
+    replace: medication
+  - triggers: ["med\t", "medi\t", "medic\t", "medici\t", "medicin\t"]
+    replace: medicine
+  - triggers: ["med\t", "medi\t", "mediu\t"]
+    replace: medium
+  - triggers: ["mee\t"]
+    replace: meet
+  - triggers: ["mee\t", "meet\t", "meeti\t", "meetin\t"]
+    replace: meeting
+  - triggers: ["mem\t", "memb\t", "membe\t"]
+    replace: member
+  - triggers: ["mem\t", "memb\t", "membe\t", "member\t", "members\t", "membersh\t", "membershi\t"]
+    replace: membership
+  - triggers: ["mem\t", "memo\t", "memor\t"]
+    replace: memory
+  - triggers: ["men\t", "ment\t", "menta\t"]
+    replace: mental
+  - triggers: ["men\t", "ment\t", "menti\t", "mentio\t"]
+    replace: mention
+  - triggers: ["men\t"]
+    replace: menu
+  - triggers: ["mer\t"]
+    replace: mere
+  - triggers: ["mer\t", "mere\t", "merel\t"]
+    replace: merely
+  - triggers: ["mes\t"]
+    replace: mess
+  - triggers: ["mes\t", "mess\t", "messa\t", "messag\t"]
+    replace: message
+  - triggers: ["met\t", "meta\t"]
+    replace: metal
+  - triggers: ["met\t", "mete\t"]
+    replace: meter
+  - triggers: ["met\t", "meth\t", "metho\t"]
+    replace: method
+  - triggers: ["mid\t", "midd\t", "middl\t"]
+    replace: middle
+  - triggers: ["mig\t", "migh\t"]
+    replace: might
+  - triggers: ["mil\t", "mili\t", "milit\t", "milita\t", "militar\t"]
+    replace: military
+  - triggers: ["mil\t"]
+    replace: milk
+  - triggers: ["mil\t", "mill\t", "milli\t", "millio\t"]
+    replace: million
+  - triggers: ["min\t"]
+    replace: mind
+  - triggers: ["min\t"]
+    replace: mine
+  - triggers: ["min\t", "mini\t", "minis\t", "minist\t", "ministe\t"]
+    replace: minister
+  - triggers: ["min\t", "mino\t"]
+    replace: minor
+  - triggers: ["min\t", "mino\t", "minor\t", "minori\t", "minorit\t"]
+    replace: minority
+  - triggers: ["min\t", "minu\t", "minut\t"]
+    replace: minute
+  - triggers: ["mir\t", "mira\t", "mirac\t", "miracl\t"]
+    replace: miracle
+  - triggers: ["mir\t", "mirr\t", "mirro\t"]
+    replace: mirror
+  - triggers: ["mis\t"]
+    replace: miss
+  - triggers: ["mis\t", "miss\t", "missi\t", "missil\t"]
+    replace: missile
+  - triggers: ["mis\t", "miss\t", "missi\t", "missio\t"]
+    replace: mission
+  - triggers: ["mis\t", "mist\t", "mista\t", "mistak\t"]
+    replace: mistake
+  - triggers: ["mix\t", "mixt\t", "mixtu\t", "mixtur\t"]
+    replace: mixture
+  - triggers: ["mm-\t", "mm-h\t", "mm-hm\t"]
+    replace: mm-hmm
+  - triggers: ["mod\t"]
+    replace: mode
+  - triggers: ["mod\t", "mode\t"]
+    replace: model
+  - triggers: ["mod\t", "mode\t", "moder\t", "modera\t", "moderat\t"]
+    replace: moderate
+  - triggers: ["mod\t", "mode\t", "moder\t"]
+    replace: modern
+  - triggers: ["mod\t", "mode\t", "modes\t"]
+    replace: modest
+  - triggers: ["mom\t", "mome\t", "momen\t"]
+    replace: moment
+  - triggers: ["mon\t", "mone\t"]
+    replace: money
+  - triggers: ["mon\t", "moni\t", "monit\t", "monito\t"]
+    replace: monitor
+  - triggers: ["mon\t", "mont\t"]
+    replace: month
+  - triggers: ["moo\t"]
+    replace: mood
+  - triggers: ["moo\t"]
+    replace: moon
+  - triggers: ["mor\t", "mora\t"]
+    replace: moral
+  - triggers: ["mor\t"]
+    replace: more
+  - triggers: ["mor\t", "more\t", "moreo\t", "moreov\t", "moreove\t"]
+    replace: moreover
+  - triggers: ["mor\t", "morn\t", "morni\t", "mornin\t"]
+    replace: morning
+  - triggers: ["mor\t", "mort\t", "mortg\t", "mortga\t", "mortgag\t"]
+    replace: mortgage
+  - triggers: ["mos\t"]
+    replace: most
+  - triggers: ["mos\t", "most\t", "mostl\t"]
+    replace: mostly
+  - triggers: ["mot\t", "moth\t", "mothe\t"]
+    replace: mother
+  - triggers: ["mot\t", "moti\t", "motio\t"]
+    replace: motion
+  - triggers: ["mot\t", "moti\t", "motiv\t", "motiva\t", "motivat\t", "motivati\t", "motivatio\t"]
+    replace: motivation
+  - triggers: ["mot\t", "moto\t"]
+    replace: motor
+  - triggers: ["mou\t", "moun\t"]
+    replace: mount
+  - triggers: ["mou\t", "moun\t", "mount\t", "mounta\t", "mountai\t"]
+    replace: mountain
+  - triggers: ["mou\t", "mous\t"]
+    replace: mouse
+  - triggers: ["mou\t", "mout\t"]
+    replace: mouth
+  - triggers: ["mov\t"]
+    replace: move
+  - triggers: ["mov\t", "move\t", "movem\t", "moveme\t", "movemen\t"]
+    replace: movement
+  - triggers: ["mov\t", "movi\t"]
+    replace: movie
+  - triggers: ["muc\t"]
+    replace: much
+  - triggers: ["mul\t", "mult\t", "multi\t", "multip\t", "multipl\t"]
+    replace: multiple
+  - triggers: ["mur\t", "murd\t", "murde\t"]
+    replace: murder
+  - triggers: ["mus\t", "musc\t", "muscl\t"]
+    replace: muscle
+  - triggers: ["mus\t", "muse\t", "museu\t"]
+    replace: museum
+  - triggers: ["mus\t", "musi\t"]
+    replace: music
+  - triggers: ["mus\t", "musi\t", "music\t", "musica\t"]
+    replace: musical
+  - triggers: ["mus\t", "musi\t", "music\t", "musici\t", "musicia\t"]
+    replace: musician
+  - triggers: ["mus\t"]
+    replace: must
+  - triggers: ["mut\t", "mutu\t", "mutua\t"]
+    replace: mutual
+  - triggers: ["mys\t", "myse\t", "mysel\t"]
+    replace: myself
+  - triggers: ["mys\t", "myst\t", "myste\t", "myster\t"]
+    replace: mystery
+  - triggers: ["myt\t"]
+    replace: myth
+  - triggers: ["nak\t", "nake\t"]
+    replace: naked
+  - triggers: ["nam\t"]
+    replace: name
+  - triggers: ["nar\t", "narr\t", "narra\t", "narrat\t", "narrati\t", "narrativ\t"]
+    replace: narrative
+  - triggers: ["nar\t", "narr\t", "narro\t"]
+    replace: narrow
+  - triggers: ["nat\t", "nati\t", "natio\t"]
+    replace: nation
+  - triggers: ["nat\t", "nati\t", "natio\t", "nation\t", "nationa\t"]
+    replace: national
+  - triggers: ["nat\t", "nati\t", "nativ\t"]
+    replace: native
+  - triggers: ["nat\t", "natu\t", "natur\t", "natura\t"]
+    replace: natural
+  - triggers: ["nat\t", "natu\t", "natur\t", "natura\t", "natural\t", "naturall\t"]
+    replace: naturally
+  - triggers: ["nat\t", "natu\t", "natur\t"]
+    replace: nature
+  - triggers: ["nea\t"]
+    replace: near
+  - triggers: ["nea\t", "near\t", "nearb\t"]
+    replace: nearby
+  - triggers: ["nea\t", "near\t", "nearl\t"]
+    replace: nearly
+  - triggers: ["nec\t", "nece\t", "neces\t", "necess\t", "necessa\t", "necessar\t", "necessari\t", "necessaril\t"]
+    replace: necessarily
+  - triggers: ["nec\t", "nece\t", "neces\t", "necess\t", "necessa\t", "necessar\t"]
+    replace: necessary
+  - triggers: ["nec\t"]
+    replace: neck
+  - triggers: ["nee\t"]
+    replace: need
+  - triggers: ["neg\t", "nega\t", "negat\t", "negati\t", "negativ\t"]
+    replace: negative
+  - triggers: ["neg\t", "nego\t", "negot\t", "negoti\t", "negotia\t", "negotiat\t"]
+    replace: negotiate
+  - triggers: ["neg\t", "nego\t", "negot\t", "negoti\t", "negotia\t", "negotiat\t", "negotiati\t", "negotiatio\t"]
+    replace: negotiation
+  - triggers: ["nei\t", "neig\t", "neigh\t", "neighb\t", "neighbo\t"]
+    replace: neighbor
+  - triggers: ["nei\t", "neig\t", "neigh\t", "neighb\t", "neighbo\t", "neighbor\t", "neighborh\t", "neighborho\t", "neighborhoo\t"]
+    replace: neighborhood
+  - triggers: ["nei\t", "neit\t", "neith\t", "neithe\t"]
+    replace: neither
+  - triggers: ["ner\t", "nerv\t"]
+    replace: nerve
+  - triggers: ["ner\t", "nerv\t", "nervo\t", "nervou\t"]
+    replace: nervous
+  - triggers: ["net\t", "netw\t", "netwo\t", "networ\t"]
+    replace: network
+  - triggers: ["nev\t", "neve\t"]
+    replace: never
+  - triggers: ["nev\t", "neve\t", "never\t", "nevert\t", "neverth\t", "neverthe\t", "neverthel\t", "neverthele\t", "nevertheles\t"]
+    replace: nevertheless
+  - triggers: ["new\t", "newl\t"]
+    replace: newly
+  - triggers: ["new\t"]
+    replace: news
+  - triggers: ["new\t", "news\t", "newsp\t", "newspa\t", "newspap\t", "newspape\t"]
+    replace: newspaper
+  - triggers: ["nex\t"]
+    replace: next
+  - triggers: ["nic\t"]
+    replace: nice
+  - triggers: ["nig\t", "nigh\t"]
+    replace: night
+  - triggers: ["nin\t"]
+    replace: nine
+  - triggers: ["nob\t", "nobo\t", "nobod\t"]
+    replace: nobody
+  - triggers: ["noi\t", "nois\t"]
+    replace: noise
+  - triggers: ["nom\t", "nomi\t", "nomin\t", "nomina\t", "nominat\t", "nominati\t", "nominatio\t"]
+    replace: nomination
+  - triggers: ["non\t"]
+    replace: none
+  - triggers: ["non\t", "none\t", "nonet\t", "noneth\t", "nonethe\t", "nonethel\t", "nonethele\t", "nonetheles\t"]
+    replace: nonetheless
+  - triggers: ["nor\t", "norm\t", "norma\t"]
+    replace: normal
+  - triggers: ["nor\t", "norm\t", "norma\t", "normal\t", "normall\t"]
+    replace: normally
+  - triggers: ["nor\t", "nort\t"]
+    replace: north
+  - triggers: ["nor\t", "nort\t", "north\t", "northe\t", "norther\t"]
+    replace: northern
+  - triggers: ["nos\t"]
+    replace: nose
+  - triggers: ["not\t"]
+    replace: note
+  - triggers: ["not\t", "noth\t", "nothi\t", "nothin\t"]
+    replace: nothing
+  - triggers: ["not\t", "noti\t", "notic\t"]
+    replace: notice
+  - triggers: ["not\t", "noti\t", "notio\t"]
+    replace: notion
+  - triggers: ["nov\t", "nove\t"]
+    replace: novel
+  - triggers: ["now\t", "nowh\t", "nowhe\t", "nowher\t"]
+    replace: nowhere
+  - triggers: ["nuc\t", "nucl\t", "nucle\t", "nuclea\t"]
+    replace: nuclear
+  - triggers: ["num\t", "numb\t", "numbe\t"]
+    replace: number
+  - triggers: ["num\t", "nume\t", "numer\t", "numero\t", "numerou\t"]
+    replace: numerous
+  - triggers: ["nur\t", "nurs\t"]
+    replace: nurse
+  - triggers: ["obj\t", "obje\t", "objec\t"]
+    replace: object
+  - triggers: ["obj\t", "obje\t", "objec\t", "object\t", "objecti\t", "objectiv\t"]
+    replace: objective
+  - triggers: ["obl\t", "obli\t", "oblig\t", "obliga\t", "obligat\t", "obligati\t", "obligatio\t"]
+    replace: obligation
+  - triggers: ["obs\t", "obse\t", "obser\t", "observ\t", "observa\t", "observat\t", "observati\t", "observatio\t"]
+    replace: observation
+  - triggers: ["obs\t", "obse\t", "obser\t", "observ\t"]
+    replace: observe
+  - triggers: ["obs\t", "obse\t", "obser\t", "observ\t", "observe\t"]
+    replace: observer
+  - triggers: ["obt\t", "obta\t", "obtai\t"]
+    replace: obtain
+  - triggers: ["obv\t", "obvi\t", "obvio\t", "obviou\t"]
+    replace: obvious
+  - triggers: ["obv\t", "obvi\t", "obvio\t", "obviou\t", "obvious\t", "obviousl\t"]
+    replace: obviously
+  - triggers: ["occ\t", "occa\t", "occas\t", "occasi\t", "occasio\t"]
+    replace: occasion
+  - triggers: ["occ\t", "occa\t", "occas\t", "occasi\t", "occasio\t", "occasion\t", "occasiona\t", "occasional\t", "occasionall\t"]
+    replace: occasionally
+  - triggers: ["occ\t", "occu\t", "occup\t", "occupa\t", "occupat\t", "occupati\t", "occupatio\t"]
+    replace: occupation
+  - triggers: ["occ\t", "occu\t", "occup\t"]
+    replace: occupy
+  - triggers: ["occ\t", "occu\t"]
+    replace: occur
+  - triggers: ["oce\t", "ocea\t"]
+    replace: ocean
+  - triggers: ["odd\t"]
+    replace: odds
+  - triggers: ["off\t", "offe\t", "offen\t", "offens\t"]
+    replace: offense
+  - triggers: ["off\t", "offe\t", "offen\t", "offens\t", "offensi\t", "offensiv\t"]
+    replace: offensive
+  - triggers: ["off\t", "offe\t"]
+    replace: offer
+  - triggers: ["off\t", "offi\t", "offic\t"]
+    replace: office
+  - triggers: ["off\t", "offi\t", "offic\t", "office\t"]
+    replace: officer
+  - triggers: ["off\t", "offi\t", "offic\t", "offici\t", "officia\t"]
+    replace: official
+  - triggers: ["oft\t", "ofte\t"]
+    replace: often
+  - triggers: ["oka\t"]
+    replace: okay
+  - triggers: ["onc\t"]
+    replace: once
+  - triggers: ["ong\t", "ongo\t", "ongoi\t", "ongoin\t"]
+    replace: ongoing
+  - triggers: ["oni\t", "onio\t"]
+    replace: onion
+  - triggers: ["onl\t", "onli\t", "onlin\t"]
+    replace: online
+  - triggers: ["onl\t"]
+    replace: only
+  - triggers: ["ont\t"]
+    replace: onto
+  - triggers: ["ope\t"]
+    replace: open
+  - triggers: ["ope\t", "open\t", "openi\t", "openin\t"]
+    replace: opening
+  - triggers: ["ope\t", "oper\t", "opera\t", "operat\t"]
+    replace: operate
+  - triggers: ["ope\t", "oper\t", "opera\t", "operat\t", "operati\t", "operatin\t"]
+    replace: operating
+  - triggers: ["ope\t", "oper\t", "opera\t", "operat\t", "operati\t", "operatio\t"]
+    replace: operation
+  - triggers: ["ope\t", "oper\t", "opera\t", "operat\t", "operato\t"]
+    replace: operator
+  - triggers: ["opi\t", "opin\t", "opini\t", "opinio\t"]
+    replace: opinion
+  - triggers: ["opp\t", "oppo\t", "oppon\t", "oppone\t", "opponen\t"]
+    replace: opponent
+  - triggers: ["opp\t", "oppo\t", "oppor\t", "opport\t", "opportu\t", "opportun\t", "opportuni\t", "opportunit\t"]
+    replace: opportunity
+  - triggers: ["opp\t", "oppo\t", "oppos\t"]
+    replace: oppose
+  - triggers: ["opp\t", "oppo\t", "oppos\t", "opposi\t", "opposit\t"]
+    replace: opposite
+  - triggers: ["opp\t", "oppo\t", "oppos\t", "opposi\t", "opposit\t", "oppositi\t", "oppositio\t"]
+    replace: opposition
+  - triggers: ["opt\t", "opti\t", "optio\t"]
+    replace: option
+  - triggers: ["ora\t", "oran\t", "orang\t"]
+    replace: orange
+  - triggers: ["ord\t", "orde\t"]
+    replace: order
+  - triggers: ["ord\t", "ordi\t", "ordin\t", "ordina\t", "ordinar\t"]
+    replace: ordinary
+  - triggers: ["org\t", "orga\t", "organ\t", "organi\t"]
+    replace: organic
+  - triggers: ["org\t", "orga\t", "organ\t", "organi\t", "organiz\t", "organiza\t", "organizat\t", "organizati\t", "organizatio\t"]
+    replace: organization
+  - triggers: ["org\t", "orga\t", "organ\t", "organi\t", "organiz\t"]
+    replace: organize
+  - triggers: ["ori\t", "orie\t", "orien\t", "orient\t", "orienta\t", "orientat\t", "orientati\t", "orientatio\t"]
+    replace: orientation
+  - triggers: ["ori\t", "orig\t", "origi\t"]
+    replace: origin
+  - triggers: ["ori\t", "orig\t", "origi\t", "origin\t", "origina\t"]
+    replace: original
+  - triggers: ["ori\t", "orig\t", "origi\t", "origin\t", "origina\t", "original\t", "originall\t"]
+    replace: originally
+  - triggers: ["oth\t", "othe\t"]
+    replace: other
+  - triggers: ["oth\t", "othe\t", "other\t"]
+    replace: others
+  - triggers: ["oth\t", "othe\t", "other\t", "otherw\t", "otherwi\t", "otherwis\t"]
+    replace: otherwise
+  - triggers: ["oug\t", "ough\t"]
+    replace: ought
+  - triggers: ["our\t", "ours\t", "ourse\t", "oursel\t", "ourselv\t", "ourselve\t"]
+    replace: ourselves
+  - triggers: ["out\t", "outc\t", "outco\t", "outcom\t"]
+    replace: outcome
+  - triggers: ["out\t", "outs\t", "outsi\t", "outsid\t"]
+    replace: outside
+  - triggers: ["ove\t"]
+    replace: oven
+  - triggers: ["ove\t"]
+    replace: over
+  - triggers: ["ove\t", "over\t", "overa\t", "overal\t"]
+    replace: overall
+  - triggers: ["ove\t", "over\t", "overc\t", "overco\t", "overcom\t"]
+    replace: overcome
+  - triggers: ["ove\t", "over\t", "overl\t", "overlo\t", "overloo\t"]
+    replace: overlook
+  - triggers: ["own\t", "owne\t"]
+    replace: owner
+  - triggers: ["pac\t"]
+    replace: pace
+  - triggers: ["pac\t"]
+    replace: pack
+  - triggers: ["pac\t", "pack\t", "packa\t", "packag\t"]
+    replace: package
+  - triggers: ["pag\t"]
+    replace: page
+  - triggers: ["pai\t"]
+    replace: pain
+  - triggers: ["pai\t", "pain\t", "painf\t", "painfu\t"]
+    replace: painful
+  - triggers: ["pai\t", "pain\t"]
+    replace: paint
+  - triggers: ["pai\t", "pain\t", "paint\t", "painte\t"]
+    replace: painter
+  - triggers: ["pai\t", "pain\t", "paint\t", "painti\t", "paintin\t"]
+    replace: painting
+  - triggers: ["pai\t"]
+    replace: pair
+  - triggers: ["pal\t"]
+    replace: pale
+  - triggers: ["pal\t"]
+    replace: palm
+  - triggers: ["pan\t", "pane\t"]
+    replace: panel
+  - triggers: ["pan\t"]
+    replace: pant
+  - triggers: ["pap\t", "pape\t"]
+    replace: paper
+  - triggers: ["par\t", "pare\t", "paren\t"]
+    replace: parent
+  - triggers: ["par\t"]
+    replace: park
+  - triggers: ["par\t", "park\t", "parki\t", "parkin\t"]
+    replace: parking
+  - triggers: ["par\t"]
+    replace: part
+  - triggers: ["par\t", "part\t", "parti\t", "partic\t", "partici\t", "particip\t", "participa\t", "participan\t"]
+    replace: participant
+  - triggers: ["par\t", "part\t", "parti\t", "partic\t", "partici\t", "particip\t", "participa\t", "participat\t"]
+    replace: participate
+  - triggers: ["par\t", "part\t", "parti\t", "partic\t", "partici\t", "particip\t", "participa\t", "participat\t", "participati\t", "participatio\t"]
+    replace: participation
+  - triggers: ["par\t", "part\t", "parti\t", "partic\t", "particu\t", "particul\t", "particula\t"]
+    replace: particular
+  - triggers: ["par\t", "part\t", "parti\t", "partic\t", "particu\t", "particul\t", "particula\t", "particular\t", "particularl\t"]
+    replace: particularly
+  - triggers: ["par\t", "part\t", "partl\t"]
+    replace: partly
+  - triggers: ["par\t", "part\t", "partn\t", "partne\t"]
+    replace: partner
+  - triggers: ["par\t", "part\t", "partn\t", "partne\t", "partner\t", "partners\t", "partnersh\t", "partnershi\t"]
+    replace: partnership
+  - triggers: ["par\t", "part\t"]
+    replace: party
+  - triggers: ["pas\t"]
+    replace: pass
+  - triggers: ["pas\t", "pass\t", "passa\t", "passag\t"]
+    replace: passage
+  - triggers: ["pas\t", "pass\t", "passe\t", "passen\t", "passeng\t", "passenge\t"]
+    replace: passenger
+  - triggers: ["pas\t", "pass\t", "passi\t", "passio\t"]
+    replace: passion
+  - triggers: ["pas\t"]
+    replace: past
+  - triggers: ["pat\t", "patc\t"]
+    replace: patch
+  - triggers: ["pat\t"]
+    replace: path
+  - triggers: ["pat\t", "pati\t", "patie\t", "patien\t"]
+    replace: patient
+  - triggers: ["pat\t", "patt\t", "patte\t", "patter\t"]
+    replace: pattern
+  - triggers: ["pau\t", "paus\t"]
+    replace: pause
+  - triggers: ["pay\t", "paym\t", "payme\t", "paymen\t"]
+    replace: payment
+  - triggers: ["pea\t", "peac\t"]
+    replace: peace
+  - triggers: ["pea\t"]
+    replace: peak
+  - triggers: ["pee\t"]
+    replace: peer
+  - triggers: ["pen\t", "pena\t", "penal\t", "penalt\t"]
+    replace: penalty
+  - triggers: ["peo\t", "peop\t", "peopl\t"]
+    replace: people
+  - triggers: ["pep\t", "pepp\t", "peppe\t"]
+    replace: pepper
+  - triggers: ["per\t", "perc\t", "perce\t", "percei\t", "perceiv\t"]
+    replace: perceive
+  - triggers: ["per\t", "perc\t", "perce\t", "percen\t", "percent\t", "percenta\t", "percentag\t"]
+    replace: percentage
+  - triggers: ["per\t", "perc\t", "perce\t", "percep\t", "percept\t", "percepti\t", "perceptio\t"]
+    replace: perception
+  - triggers: ["per\t", "perf\t", "perfe\t", "perfec\t"]
+    replace: perfect
+  - triggers: ["per\t", "perf\t", "perfe\t", "perfec\t", "perfect\t", "perfectl\t"]
+    replace: perfectly
+  - triggers: ["per\t", "perf\t", "perfo\t", "perfor\t"]
+    replace: perform
+  - triggers: ["per\t", "perf\t", "perfo\t", "perfor\t", "perform\t", "performa\t", "performan\t", "performanc\t"]
+    replace: performance
+  - triggers: ["per\t", "perh\t", "perha\t", "perhap\t"]
+    replace: perhaps
+  - triggers: ["per\t", "peri\t", "perio\t"]
+    replace: period
+  - triggers: ["per\t", "perm\t", "perma\t", "perman\t", "permane\t", "permanen\t"]
+    replace: permanent
+  - triggers: ["per\t", "perm\t", "permi\t", "permis\t", "permiss\t", "permissi\t", "permissio\t"]
+    replace: permission
+  - triggers: ["per\t", "perm\t", "permi\t"]
+    replace: permit
+  - triggers: ["per\t", "pers\t", "perso\t"]
+    replace: person
+  - triggers: ["per\t", "pers\t", "perso\t", "person\t", "persona\t"]
+    replace: personal
+  - triggers: ["per\t", "pers\t", "perso\t", "person\t", "persona\t", "personal\t", "personali\t", "personalit\t"]
+    replace: personality
+  - triggers: ["per\t", "pers\t", "perso\t", "person\t", "persona\t", "personal\t", "personall\t"]
+    replace: personally
+  - triggers: ["per\t", "pers\t", "perso\t", "person\t", "personn\t", "personne\t"]
+    replace: personnel
+  - triggers: ["per\t", "pers\t", "persp\t", "perspe\t", "perspec\t", "perspect\t", "perspecti\t", "perspectiv\t"]
+    replace: perspective
+  - triggers: ["per\t", "pers\t", "persu\t", "persua\t", "persuad\t"]
+    replace: persuade
+  - triggers: ["pha\t", "phas\t"]
+    replace: phase
+  - triggers: ["phe\t", "phen\t", "pheno\t", "phenom\t", "phenome\t", "phenomen\t", "phenomeno\t"]
+    replace: phenomenon
+  - triggers: ["phi\t", "phil\t", "philo\t", "philos\t", "philoso\t", "philosop\t", "philosoph\t"]
+    replace: philosophy
+  - triggers: ["pho\t", "phon\t"]
+    replace: phone
+  - triggers: ["pho\t", "phot\t"]
+    replace: photo
+  - triggers: ["pho\t", "phot\t", "photo\t", "photog\t", "photogr\t", "photogra\t", "photograp\t"]
+    replace: photograph
+  - triggers: ["pho\t", "phot\t", "photo\t", "photog\t", "photogr\t", "photogra\t", "photograp\t", "photograph\t", "photographe\t"]
+    replace: photographer
+  - triggers: ["phr\t", "phra\t", "phras\t"]
+    replace: phrase
+  - triggers: ["phy\t", "phys\t", "physi\t", "physic\t", "physica\t"]
+    replace: physical
+  - triggers: ["phy\t", "phys\t", "physi\t", "physic\t", "physica\t", "physical\t", "physicall\t"]
+    replace: physically
+  - triggers: ["phy\t", "phys\t", "physi\t", "physic\t", "physici\t", "physicia\t"]
+    replace: physician
+  - triggers: ["pia\t", "pian\t"]
+    replace: piano
+  - triggers: ["pic\t"]
+    replace: pick
+  - triggers: ["pic\t", "pict\t", "pictu\t", "pictur\t"]
+    replace: picture
+  - triggers: ["pie\t", "piec\t"]
+    replace: piece
+  - triggers: ["pil\t"]
+    replace: pile
+  - triggers: ["pil\t", "pilo\t"]
+    replace: pilot
+  - triggers: ["pin\t"]
+    replace: pine
+  - triggers: ["pin\t"]
+    replace: pink
+  - triggers: ["pip\t"]
+    replace: pipe
+  - triggers: ["pit\t", "pitc\t"]
+    replace: pitch
+  - triggers: ["pla\t", "plac\t"]
+    replace: place
+  - triggers: ["pla\t"]
+    replace: plan
+  - triggers: ["pla\t", "plan\t"]
+    replace: plane
+  - triggers: ["pla\t", "plan\t", "plane\t"]
+    replace: planet
+  - triggers: ["pla\t", "plan\t", "plann\t", "planni\t", "plannin\t"]
+    replace: planning
+  - triggers: ["pla\t", "plan\t"]
+    replace: plant
+  - triggers: ["pla\t", "plas\t", "plast\t", "plasti\t"]
+    replace: plastic
+  - triggers: ["pla\t", "plat\t"]
+    replace: plate
+  - triggers: ["pla\t", "plat\t", "platf\t", "platfo\t", "platfor\t"]
+    replace: platform
+  - triggers: ["pla\t"]
+    replace: play
+  - triggers: ["pla\t", "play\t", "playe\t"]
+    replace: player
+  - triggers: ["ple\t", "plea\t", "pleas\t"]
+    replace: please
+  - triggers: ["ple\t", "plea\t", "pleas\t", "pleasu\t", "pleasur\t"]
+    replace: pleasure
+  - triggers: ["ple\t", "plen\t", "plent\t"]
+    replace: plenty
+  - triggers: ["plo\t"]
+    replace: plot
+  - triggers: ["plu\t"]
+    replace: plus
+  - triggers: ["poc\t", "pock\t", "pocke\t"]
+    replace: pocket
+  - triggers: ["poe\t"]
+    replace: poem
+  - triggers: ["poe\t"]
+    replace: poet
+  - triggers: ["poe\t", "poet\t", "poetr\t"]
+    replace: poetry
+  - triggers: ["poi\t", "poin\t"]
+    replace: point
+  - triggers: ["pol\t"]
+    replace: pole
+  - triggers: ["pol\t", "poli\t", "polic\t"]
+    replace: police
+  - triggers: ["pol\t", "poli\t", "polic\t"]
+    replace: policy
+  - triggers: ["pol\t", "poli\t", "polit\t", "politi\t", "politic\t", "politica\t"]
+    replace: political
+  - triggers: ["pol\t", "poli\t", "polit\t", "politi\t", "politic\t", "politica\t", "political\t", "politicall\t"]
+    replace: politically
+  - triggers: ["pol\t", "poli\t", "polit\t", "politi\t", "politic\t", "politici\t", "politicia\t"]
+    replace: politician
+  - triggers: ["pol\t", "poli\t", "polit\t", "politi\t", "politic\t"]
+    replace: politics
+  - triggers: ["pol\t"]
+    replace: poll
+  - triggers: ["pol\t", "poll\t", "pollu\t", "pollut\t", "polluti\t", "pollutio\t"]
+    replace: pollution
+  - triggers: ["poo\t"]
+    replace: pool
+  - triggers: ["poo\t"]
+    replace: poor
+  - triggers: ["pop\t", "popu\t", "popul\t", "popula\t"]
+    replace: popular
+  - triggers: ["pop\t", "popu\t", "popul\t", "popula\t", "populat\t", "populati\t", "populatio\t"]
+    replace: population
+  - triggers: ["por\t", "porc\t"]
+    replace: porch
+  - triggers: ["por\t"]
+    replace: port
+  - triggers: ["por\t", "port\t", "porti\t", "portio\t"]
+    replace: portion
+  - triggers: ["por\t", "port\t", "portr\t", "portra\t", "portrai\t"]
+    replace: portrait
+  - triggers: ["por\t", "port\t", "portr\t", "portra\t"]
+    replace: portray
+  - triggers: ["pos\t"]
+    replace: pose
+  - triggers: ["pos\t", "posi\t", "posit\t", "positi\t", "positio\t"]
+    replace: position
+  - triggers: ["pos\t", "posi\t", "posit\t", "positi\t", "positiv\t"]
+    replace: positive
+  - triggers: ["pos\t", "poss\t", "posse\t", "posses\t"]
+    replace: possess
+  - triggers: ["pos\t", "poss\t", "possi\t", "possib\t", "possibi\t", "possibil\t", "possibili\t", "possibilit\t"]
+    replace: possibility
+  - triggers: ["pos\t", "poss\t", "possi\t", "possib\t", "possibl\t"]
+    replace: possible
+  - triggers: ["pos\t", "poss\t", "possi\t", "possib\t", "possibl\t"]
+    replace: possibly
+  - triggers: ["pos\t"]
+    replace: post
+  - triggers: ["pot\t", "pota\t", "potat\t"]
+    replace: potato
+  - triggers: ["pot\t", "pote\t", "poten\t", "potent\t", "potenti\t", "potentia\t"]
+    replace: potential
+  - triggers: ["pot\t", "pote\t", "poten\t", "potent\t", "potenti\t", "potentia\t", "potential\t", "potentiall\t"]
+    replace: potentially
+  - triggers: ["pou\t", "poun\t"]
+    replace: pound
+  - triggers: ["pou\t"]
+    replace: pour
+  - triggers: ["pov\t", "pove\t", "pover\t", "povert\t"]
+    replace: poverty
+  - triggers: ["pow\t", "powd\t", "powde\t"]
+    replace: powder
+  - triggers: ["pow\t", "powe\t"]
+    replace: power
+  - triggers: ["pow\t", "powe\t", "power\t", "powerf\t", "powerfu\t"]
+    replace: powerful
+  - triggers: ["pra\t", "prac\t", "pract\t", "practi\t", "practic\t", "practica\t"]
+    replace: practical
+  - triggers: ["pra\t", "prac\t", "pract\t", "practi\t", "practic\t"]
+    replace: practice
+  - triggers: ["pra\t"]
+    replace: pray
+  - triggers: ["pra\t", "pray\t", "praye\t"]
+    replace: prayer
+  - triggers: ["pre\t", "prec\t", "preci\t", "precis\t", "precise\t", "precisel\t"]
+    replace: precisely
+  - triggers: ["pre\t", "pred\t", "predi\t", "predic\t"]
+    replace: predict
+  - triggers: ["pre\t", "pref\t", "prefe\t"]
+    replace: prefer
+  - triggers: ["pre\t", "pref\t", "prefe\t", "prefer\t", "prefere\t", "preferen\t", "preferenc\t"]
+    replace: preference
+  - triggers: ["pre\t", "preg\t", "pregn\t", "pregna\t", "pregnan\t", "pregnanc\t"]
+    replace: pregnancy
+  - triggers: ["pre\t", "preg\t", "pregn\t", "pregna\t", "pregnan\t"]
+    replace: pregnant
+  - triggers: ["pre\t", "prep\t", "prepa\t", "prepar\t", "prepara\t", "preparat\t", "preparati\t", "preparatio\t"]
+    replace: preparation
+  - triggers: ["pre\t", "prep\t", "prepa\t", "prepar\t"]
+    replace: prepare
+  - triggers: ["pre\t", "pres\t", "presc\t", "prescr\t", "prescri\t", "prescrip\t", "prescript\t", "prescripti\t", "prescriptio\t"]
+    replace: prescription
+  - triggers: ["pre\t", "pres\t", "prese\t", "presen\t", "presenc\t"]
+    replace: presence
+  - triggers: ["pre\t", "pres\t", "prese\t", "presen\t"]
+    replace: present
+  - triggers: ["pre\t", "pres\t", "prese\t", "presen\t", "present\t", "presenta\t", "presentat\t", "presentati\t", "presentatio\t"]
+    replace: presentation
+  - triggers: ["pre\t", "pres\t", "prese\t", "preser\t", "preserv\t"]
+    replace: preserve
+  - triggers: ["pre\t", "pres\t", "presi\t", "presid\t", "preside\t", "presiden\t"]
+    replace: president
+  - triggers: ["pre\t", "pres\t", "presi\t", "presid\t", "preside\t", "presiden\t", "president\t", "presidenti\t", "presidentia\t"]
+    replace: presidential
+  - triggers: ["pre\t", "pres\t"]
+    replace: press
+  - triggers: ["pre\t", "pres\t", "press\t", "pressu\t", "pressur\t"]
+    replace: pressure
+  - triggers: ["pre\t", "pret\t", "prete\t", "preten\t"]
+    replace: pretend
+  - triggers: ["pre\t", "pret\t", "prett\t"]
+    replace: pretty
+  - triggers: ["pre\t", "prev\t", "preve\t", "preven\t"]
+    replace: prevent
+  - triggers: ["pre\t", "prev\t", "previ\t", "previo\t", "previou\t"]
+    replace: previous
+  - triggers: ["pre\t", "prev\t", "previ\t", "previo\t", "previou\t", "previous\t", "previousl\t"]
+    replace: previously
+  - triggers: ["pri\t", "pric\t"]
+    replace: price
+  - triggers: ["pri\t", "prid\t"]
+    replace: pride
+  - triggers: ["pri\t", "prie\t", "pries\t"]
+    replace: priest
+  - triggers: ["pri\t", "prim\t", "prima\t", "primar\t", "primari\t", "primaril\t"]
+    replace: primarily
+  - triggers: ["pri\t", "prim\t", "prima\t", "primar\t"]
+    replace: primary
+  - triggers: ["pri\t", "prim\t"]
+    replace: prime
+  - triggers: ["pri\t", "prin\t", "princ\t", "princi\t", "princip\t", "principa\t"]
+    replace: principal
+  - triggers: ["pri\t", "prin\t", "princ\t", "princi\t", "princip\t", "principl\t"]
+    replace: principle
+  - triggers: ["pri\t", "prin\t"]
+    replace: print
+  - triggers: ["pri\t", "prio\t"]
+    replace: prior
+  - triggers: ["pri\t", "prio\t", "prior\t", "priori\t", "priorit\t"]
+    replace: priority
+  - triggers: ["pri\t", "pris\t", "priso\t"]
+    replace: prison
+  - triggers: ["pri\t", "pris\t", "priso\t", "prison\t", "prisone\t"]
+    replace: prisoner
+  - triggers: ["pri\t", "priv\t", "priva\t", "privac\t"]
+    replace: privacy
+  - triggers: ["pri\t", "priv\t", "priva\t", "privat\t"]
+    replace: private
+  - triggers: ["pro\t", "prob\t", "proba\t", "probab\t", "probabl\t"]
+    replace: probably
+  - triggers: ["pro\t", "prob\t", "probl\t", "proble\t"]
+    replace: problem
+  - triggers: ["pro\t", "proc\t", "proce\t", "proced\t", "procedu\t", "procedur\t"]
+    replace: procedure
+  - triggers: ["pro\t", "proc\t", "proce\t", "procee\t"]
+    replace: proceed
+  - triggers: ["pro\t", "proc\t", "proce\t", "proces\t"]
+    replace: process
+  - triggers: ["pro\t", "prod\t", "produ\t", "produc\t"]
+    replace: produce
+  - triggers: ["pro\t", "prod\t", "produ\t", "produc\t", "produce\t"]
+    replace: producer
+  - triggers: ["pro\t", "prod\t", "produ\t", "produc\t"]
+    replace: product
+  - triggers: ["pro\t", "prod\t", "produ\t", "produc\t", "product\t", "producti\t", "productio\t"]
+    replace: production
+  - triggers: ["pro\t", "prof\t", "profe\t", "profes\t", "profess\t", "professi\t", "professio\t"]
+    replace: profession
+  - triggers: ["pro\t", "prof\t", "profe\t", "profes\t", "profess\t", "professi\t", "professio\t", "profession\t", "professiona\t"]
+    replace: professional
+  - triggers: ["pro\t", "prof\t", "profe\t", "profes\t", "profess\t", "professo\t"]
+    replace: professor
+  - triggers: ["pro\t", "prof\t", "profi\t", "profil\t"]
+    replace: profile
+  - triggers: ["pro\t", "prof\t", "profi\t"]
+    replace: profit
+  - triggers: ["pro\t", "prog\t", "progr\t", "progra\t"]
+    replace: program
+  - triggers: ["pro\t", "prog\t", "progr\t", "progre\t", "progres\t"]
+    replace: progress
+  - triggers: ["pro\t", "proj\t", "proje\t", "projec\t"]
+    replace: project
+  - triggers: ["pro\t", "prom\t", "promi\t", "promin\t", "promine\t", "prominen\t"]
+    replace: prominent
+  - triggers: ["pro\t", "prom\t", "promi\t", "promis\t"]
+    replace: promise
+  - triggers: ["pro\t", "prom\t", "promo\t", "promot\t"]
+    replace: promote
+  - triggers: ["pro\t", "prom\t", "promp\t"]
+    replace: prompt
+  - triggers: ["pro\t", "proo\t"]
+    replace: proof
+  - triggers: ["pro\t", "prop\t", "prope\t"]
+    replace: proper
+  - triggers: ["pro\t", "prop\t", "prope\t", "proper\t", "properl\t"]
+    replace: properly
+  - triggers: ["pro\t", "prop\t", "prope\t", "proper\t", "propert\t"]
+    replace: property
+  - triggers: ["pro\t", "prop\t", "propo\t", "propor\t", "proport\t", "proporti\t", "proportio\t"]
+    replace: proportion
+  - triggers: ["pro\t", "prop\t", "propo\t", "propos\t", "proposa\t"]
+    replace: proposal
+  - triggers: ["pro\t", "prop\t", "propo\t", "propos\t"]
+    replace: propose
+  - triggers: ["pro\t", "prop\t", "propo\t", "propos\t", "propose\t"]
+    replace: proposed
+  - triggers: ["pro\t", "pros\t", "prose\t", "prosec\t", "prosecu\t", "prosecut\t", "prosecuto\t"]
+    replace: prosecutor
+  - triggers: ["pro\t", "pros\t", "prosp\t", "prospe\t", "prospec\t"]
+    replace: prospect
+  - triggers: ["pro\t", "prot\t", "prote\t", "protec\t"]
+    replace: protect
+  - triggers: ["pro\t", "prot\t", "prote\t", "protec\t", "protect\t", "protecti\t", "protectio\t"]
+    replace: protection
+  - triggers: ["pro\t", "prot\t", "prote\t", "protei\t"]
+    replace: protein
+  - triggers: ["pro\t", "prot\t", "prote\t", "protes\t"]
+    replace: protest
+  - triggers: ["pro\t", "prou\t"]
+    replace: proud
+  - triggers: ["pro\t", "prov\t"]
+    replace: prove
+  - triggers: ["pro\t", "prov\t", "provi\t", "provid\t"]
+    replace: provide
+  - triggers: ["pro\t", "prov\t", "provi\t", "provid\t", "provide\t"]
+    replace: provider
+  - triggers: ["pro\t", "prov\t", "provi\t", "provin\t", "provinc\t"]
+    replace: province
+  - triggers: ["pro\t", "prov\t", "provi\t", "provis\t", "provisi\t", "provisio\t"]
+    replace: provision
+  - triggers: ["psy\t", "psyc\t", "psych\t", "psycho\t", "psychol\t", "psycholo\t", "psycholog\t", "psychologi\t", "psychologic\t", "psychologica\t"]
+    replace: psychological
+  - triggers: ["psy\t", "psyc\t", "psych\t", "psycho\t", "psychol\t", "psycholo\t", "psycholog\t", "psychologi\t", "psychologis\t"]
+    replace: psychologist
+  - triggers: ["psy\t", "psyc\t", "psych\t", "psycho\t", "psychol\t", "psycholo\t", "psycholog\t"]
+    replace: psychology
+  - triggers: ["pub\t", "publ\t", "publi\t"]
+    replace: public
+  - triggers: ["pub\t", "publ\t", "publi\t", "public\t", "publica\t", "publicat\t", "publicati\t", "publicatio\t"]
+    replace: publication
+  - triggers: ["pub\t", "publ\t", "publi\t", "public\t", "publicl\t"]
+    replace: publicly
+  - triggers: ["pub\t", "publ\t", "publi\t", "publis\t"]
+    replace: publish
+  - triggers: ["pub\t", "publ\t", "publi\t", "publis\t", "publish\t", "publishe\t"]
+    replace: publisher
+  - triggers: ["pul\t"]
+    replace: pull
+  - triggers: ["pun\t", "puni\t", "punis\t", "punish\t", "punishm\t", "punishme\t", "punishmen\t"]
+    replace: punishment
+  - triggers: ["pur\t", "purc\t", "purch\t", "purcha\t", "purchas\t"]
+    replace: purchase
+  - triggers: ["pur\t"]
+    replace: pure
+  - triggers: ["pur\t", "purp\t", "purpo\t", "purpos\t"]
+    replace: purpose
+  - triggers: ["pur\t", "purs\t", "pursu\t"]
+    replace: pursue
+  - triggers: ["pus\t"]
+    replace: push
+  - triggers: ["qua\t", "qual\t", "quali\t", "qualif\t"]
+    replace: qualify
+  - triggers: ["qua\t", "qual\t", "quali\t", "qualit\t"]
+    replace: quality
+  - triggers: ["qua\t", "quar\t", "quart\t", "quarte\t"]
+    replace: quarter
+  - triggers: ["qua\t", "quar\t", "quart\t", "quarte\t", "quarter\t", "quarterb\t", "quarterba\t", "quarterbac\t"]
+    replace: quarterback
+  - triggers: ["que\t", "ques\t", "quest\t", "questi\t", "questio\t"]
+    replace: question
+  - triggers: ["qui\t", "quic\t"]
+    replace: quick
+  - triggers: ["qui\t", "quic\t", "quick\t", "quickl\t"]
+    replace: quickly
+  - triggers: ["qui\t", "quie\t"]
+    replace: quiet
+  - triggers: ["qui\t", "quie\t", "quiet\t", "quietl\t"]
+    replace: quietly
+  - triggers: ["qui\t"]
+    replace: quit
+  - triggers: ["qui\t", "quit\t"]
+    replace: quite
+  - triggers: ["quo\t", "quot\t"]
+    replace: quote
+  - triggers: ["rac\t"]
+    replace: race
+  - triggers: ["rac\t", "raci\t", "racia\t"]
+    replace: racial
+  - triggers: ["rad\t", "radi\t", "radic\t", "radica\t"]
+    replace: radical
+  - triggers: ["rad\t", "radi\t"]
+    replace: radio
+  - triggers: ["rai\t"]
+    replace: rail
+  - triggers: ["rai\t"]
+    replace: rain
+  - triggers: ["rai\t", "rais\t"]
+    replace: raise
+  - triggers: ["ran\t", "rang\t"]
+    replace: range
+  - triggers: ["ran\t"]
+    replace: rank
+  - triggers: ["rap\t", "rapi\t"]
+    replace: rapid
+  - triggers: ["rap\t", "rapi\t", "rapid\t", "rapidl\t"]
+    replace: rapidly
+  - triggers: ["rar\t"]
+    replace: rare
+  - triggers: ["rar\t", "rare\t", "rarel\t"]
+    replace: rarely
+  - triggers: ["rat\t"]
+    replace: rate
+  - triggers: ["rat\t", "rath\t", "rathe\t"]
+    replace: rather
+  - triggers: ["rat\t", "rati\t", "ratin\t"]
+    replace: rating
+  - triggers: ["rat\t", "rati\t"]
+    replace: ratio
+  - triggers: ["rea\t", "reac\t"]
+    replace: reach
+  - triggers: ["rea\t", "reac\t"]
+    replace: react
+  - triggers: ["rea\t", "reac\t", "react\t", "reacti\t", "reactio\t"]
+    replace: reaction
+  - triggers: ["rea\t"]
+    replace: read
+  - triggers: ["rea\t", "read\t", "reade\t"]
+    replace: reader
+  - triggers: ["rea\t", "read\t", "readi\t", "readin\t"]
+    replace: reading
+  - triggers: ["rea\t", "read\t"]
+    replace: ready
+  - triggers: ["rea\t"]
+    replace: real
+  - triggers: ["rea\t", "real\t", "reali\t", "realit\t"]
+    replace: reality
+  - triggers: ["rea\t", "real\t", "reali\t", "realiz\t"]
+    replace: realize
+  - triggers: ["rea\t", "real\t", "reall\t"]
+    replace: really
+  - triggers: ["rea\t", "reas\t", "reaso\t"]
+    replace: reason
+  - triggers: ["rea\t", "reas\t", "reaso\t", "reason\t", "reasona\t", "reasonab\t", "reasonabl\t"]
+    replace: reasonable
+  - triggers: ["rec\t", "reca\t", "recal\t"]
+    replace: recall
+  - triggers: ["rec\t", "rece\t", "recei\t", "receiv\t"]
+    replace: receive
+  - triggers: ["rec\t", "rece\t", "recen\t"]
+    replace: recent
+  - triggers: ["rec\t", "rece\t", "recen\t", "recent\t", "recentl\t"]
+    replace: recently
+  - triggers: ["rec\t", "reci\t", "recip\t"]
+    replace: recipe
+  - triggers: ["rec\t", "reco\t", "recog\t", "recogn\t", "recogni\t", "recognit\t", "recogniti\t", "recognitio\t"]
+    replace: recognition
+  - triggers: ["rec\t", "reco\t", "recog\t", "recogn\t", "recogni\t", "recogniz\t"]
+    replace: recognize
+  - triggers: ["rec\t", "reco\t", "recom\t", "recomm\t", "recomme\t", "recommen\t"]
+    replace: recommend
+  - triggers: ["rec\t", "reco\t", "recom\t", "recomm\t", "recomme\t", "recommen\t", "recommend\t", "recommenda\t", "recommendat\t", "recommendati\t", "recommendatio\t"]
+    replace: recommendation
+  - triggers: ["rec\t", "reco\t", "recor\t"]
+    replace: record
+  - triggers: ["rec\t", "reco\t", "recor\t", "record\t", "recordi\t", "recordin\t"]
+    replace: recording
+  - triggers: ["rec\t", "reco\t", "recov\t", "recove\t"]
+    replace: recover
+  - triggers: ["rec\t", "reco\t", "recov\t", "recove\t", "recover\t"]
+    replace: recovery
+  - triggers: ["rec\t", "recr\t", "recru\t", "recrui\t"]
+    replace: recruit
+  - triggers: ["red\t", "redu\t", "reduc\t"]
+    replace: reduce
+  - triggers: ["red\t", "redu\t", "reduc\t", "reduct\t", "reducti\t", "reductio\t"]
+    replace: reduction
+  - triggers: ["ref\t", "refe\t"]
+    replace: refer
+  - triggers: ["ref\t", "refe\t", "refer\t", "refere\t", "referen\t", "referenc\t"]
+    replace: reference
+  - triggers: ["ref\t", "refl\t", "refle\t", "reflec\t"]
+    replace: reflect
+  - triggers: ["ref\t", "refl\t", "refle\t", "reflec\t", "reflect\t", "reflecti\t", "reflectio\t"]
+    replace: reflection
+  - triggers: ["ref\t", "refo\t", "refor\t"]
+    replace: reform
+  - triggers: ["ref\t", "refu\t", "refug\t", "refuge\t"]
+    replace: refugee
+  - triggers: ["ref\t", "refu\t", "refus\t"]
+    replace: refuse
+  - triggers: ["reg\t", "rega\t", "regar\t"]
+    replace: regard
+  - triggers: ["reg\t", "rega\t", "regar\t", "regard\t", "regardi\t", "regardin\t"]
+    replace: regarding
+  - triggers: ["reg\t", "rega\t", "regar\t", "regard\t", "regardl\t", "regardle\t", "regardles\t"]
+    replace: regardless
+  - triggers: ["reg\t", "regi\t", "regim\t"]
+    replace: regime
+  - triggers: ["reg\t", "regi\t", "regio\t"]
+    replace: region
+  - triggers: ["reg\t", "regi\t", "regio\t", "region\t", "regiona\t"]
+    replace: regional
+  - triggers: ["reg\t", "regi\t", "regis\t", "regist\t", "registe\t"]
+    replace: register
+  - triggers: ["reg\t", "regu\t", "regul\t", "regula\t"]
+    replace: regular
+  - triggers: ["reg\t", "regu\t", "regul\t", "regula\t", "regular\t", "regularl\t"]
+    replace: regularly
+  - triggers: ["reg\t", "regu\t", "regul\t", "regula\t", "regulat\t"]
+    replace: regulate
+  - triggers: ["reg\t", "regu\t", "regul\t", "regula\t", "regulat\t", "regulati\t", "regulatio\t"]
+    replace: regulation
+  - triggers: ["rei\t", "rein\t", "reinf\t", "reinfo\t", "reinfor\t", "reinforc\t"]
+    replace: reinforce
+  - triggers: ["rej\t", "reje\t", "rejec\t"]
+    replace: reject
+  - triggers: ["rel\t", "rela\t", "relat\t"]
+    replace: relate
+  - triggers: ["rel\t", "rela\t", "relat\t", "relati\t", "relatio\t"]
+    replace: relation
+  - triggers: ["rel\t", "rela\t", "relat\t", "relati\t", "relatio\t", "relation\t", "relations\t", "relationsh\t", "relationshi\t"]
+    replace: relationship
+  - triggers: ["rel\t", "rela\t", "relat\t", "relati\t", "relativ\t"]
+    replace: relative
+  - triggers: ["rel\t", "rela\t", "relat\t", "relati\t", "relativ\t", "relative\t", "relativel\t"]
+    replace: relatively
+  - triggers: ["rel\t", "rela\t"]
+    replace: relax
+  - triggers: ["rel\t", "rele\t", "relea\t", "releas\t"]
+    replace: release
+  - triggers: ["rel\t", "rele\t", "relev\t", "releva\t", "relevan\t"]
+    replace: relevant
+  - triggers: ["rel\t", "reli\t", "relie\t"]
+    replace: relief
+  - triggers: ["rel\t", "reli\t", "relig\t", "religi\t", "religio\t"]
+    replace: religion
+  - triggers: ["rel\t", "reli\t", "relig\t", "religi\t", "religio\t", "religiou\t"]
+    replace: religious
+  - triggers: ["rel\t"]
+    replace: rely
+  - triggers: ["rem\t", "rema\t", "remai\t"]
+    replace: remain
+  - triggers: ["rem\t", "rema\t", "remai\t", "remain\t", "remaini\t", "remainin\t"]
+    replace: remaining
+  - triggers: ["rem\t", "rema\t", "remar\t", "remark\t", "remarka\t", "remarkab\t", "remarkabl\t"]
+    replace: remarkable
+  - triggers: ["rem\t", "reme\t", "remem\t", "rememb\t", "remembe\t"]
+    replace: remember
+  - triggers: ["rem\t", "remi\t", "remin\t"]
+    replace: remind
+  - triggers: ["rem\t", "remo\t", "remot\t"]
+    replace: remote
+  - triggers: ["rem\t", "remo\t", "remov\t"]
+    replace: remove
+  - triggers: ["rep\t", "repe\t", "repea\t"]
+    replace: repeat
+  - triggers: ["rep\t", "repe\t", "repea\t", "repeat\t", "repeate\t", "repeated\t", "repeatedl\t"]
+    replace: repeatedly
+  - triggers: ["rep\t", "repl\t", "repla\t", "replac\t"]
+    replace: replace
+  - triggers: ["rep\t", "repl\t"]
+    replace: reply
+  - triggers: ["rep\t", "repo\t", "repor\t"]
+    replace: report
+  - triggers: ["rep\t", "repo\t", "repor\t", "report\t", "reporte\t"]
+    replace: reporter
+  - triggers: ["rep\t", "repr\t", "repre\t", "repres\t", "represe\t", "represen\t"]
+    replace: represent
+  - triggers: ["rep\t", "repr\t", "repre\t", "repres\t", "represe\t", "represen\t", "represent\t", "representa\t", "representat\t", "representati\t", "representatio\t"]
+    replace: representation
+  - triggers: ["rep\t", "repr\t", "repre\t", "repres\t", "represe\t", "represen\t", "represent\t", "representa\t", "representat\t", "representati\t", "representativ\t"]
+    replace: representative
+  - triggers: ["rep\t", "repu\t", "reput\t", "reputa\t", "reputat\t", "reputati\t", "reputatio\t"]
+    replace: reputation
+  - triggers: ["req\t", "requ\t", "reque\t", "reques\t"]
+    replace: request
+  - triggers: ["req\t", "requ\t", "requi\t", "requir\t"]
+    replace: require
+  - triggers: ["req\t", "requ\t", "requi\t", "requir\t", "require\t", "requirem\t", "requireme\t", "requiremen\t"]
+    replace: requirement
+  - triggers: ["res\t", "rese\t", "resea\t", "resear\t", "researc\t"]
+    replace: research
+  - triggers: ["res\t", "rese\t", "resea\t", "resear\t", "researc\t", "research\t", "researche\t"]
+    replace: researcher
+  - triggers: ["res\t", "rese\t", "resem\t", "resemb\t", "resembl\t"]
+    replace: resemble
+  - triggers: ["res\t", "rese\t", "reser\t", "reserv\t", "reserva\t", "reservat\t", "reservati\t", "reservatio\t"]
+    replace: reservation
+  - triggers: ["res\t", "resi\t", "resid\t", "reside\t", "residen\t"]
+    replace: resident
+  - triggers: ["res\t", "resi\t", "resis\t"]
+    replace: resist
+  - triggers: ["res\t", "resi\t", "resis\t", "resist\t", "resista\t", "resistan\t", "resistanc\t"]
+    replace: resistance
+  - triggers: ["res\t", "reso\t", "resol\t", "resolu\t", "resolut\t", "resoluti\t", "resolutio\t"]
+    replace: resolution
+  - triggers: ["res\t", "reso\t", "resol\t", "resolv\t"]
+    replace: resolve
+  - triggers: ["res\t", "reso\t", "resor\t"]
+    replace: resort
+  - triggers: ["res\t", "reso\t", "resou\t", "resour\t", "resourc\t"]
+    replace: resource
+  - triggers: ["res\t", "resp\t", "respe\t", "respec\t"]
+    replace: respect
+  - triggers: ["res\t", "resp\t", "respo\t", "respon\t"]
+    replace: respond
+  - triggers: ["res\t", "resp\t", "respo\t", "respon\t", "respond\t", "responde\t", "responden\t"]
+    replace: respondent
+  - triggers: ["res\t", "resp\t", "respo\t", "respon\t", "respons\t"]
+    replace: response
+  - triggers: ["res\t", "resp\t", "respo\t", "respon\t", "respons\t", "responsi\t", "responsib\t", "responsibi\t", "responsibil\t", "responsibili\t", "responsibilit\t"]
+    replace: responsibility
+  - triggers: ["res\t", "resp\t", "respo\t", "respon\t", "respons\t", "responsi\t", "responsib\t", "responsibl\t"]
+    replace: responsible
+  - triggers: ["res\t"]
+    replace: rest
+  - triggers: ["res\t", "rest\t", "resta\t", "restau\t", "restaur\t", "restaura\t", "restauran\t"]
+    replace: restaurant
+  - triggers: ["res\t", "rest\t", "resto\t", "restor\t"]
+    replace: restore
+  - triggers: ["res\t", "rest\t", "restr\t", "restri\t", "restric\t", "restrict\t", "restricti\t", "restrictio\t"]
+    replace: restriction
+  - triggers: ["res\t", "resu\t", "resul\t"]
+    replace: result
+  - triggers: ["ret\t", "reta\t", "retai\t"]
+    replace: retain
+  - triggers: ["ret\t", "reti\t", "retir\t"]
+    replace: retire
+  - triggers: ["ret\t", "reti\t", "retir\t", "retire\t", "retirem\t", "retireme\t", "retiremen\t"]
+    replace: retirement
+  - triggers: ["ret\t", "retu\t", "retur\t"]
+    replace: return
+  - triggers: ["rev\t", "reve\t", "revea\t"]
+    replace: reveal
+  - triggers: ["rev\t", "reve\t", "reven\t", "revenu\t"]
+    replace: revenue
+  - triggers: ["rev\t", "revi\t", "revie\t"]
+    replace: review
+  - triggers: ["rev\t", "revo\t", "revol\t", "revolu\t", "revolut\t", "revoluti\t", "revolutio\t"]
+    replace: revolution
+  - triggers: ["rhy\t", "rhyt\t", "rhyth\t"]
+    replace: rhythm
+  - triggers: ["ric\t"]
+    replace: rice
+  - triggers: ["ric\t"]
+    replace: rich
+  - triggers: ["rid\t"]
+    replace: ride
+  - triggers: ["rif\t", "rifl\t"]
+    replace: rifle
+  - triggers: ["rig\t", "righ\t"]
+    replace: right
+  - triggers: ["rin\t"]
+    replace: ring
+  - triggers: ["ris\t"]
+    replace: rise
+  - triggers: ["ris\t"]
+    replace: risk
+  - triggers: ["riv\t", "rive\t"]
+    replace: river
+  - triggers: ["roa\t"]
+    replace: road
+  - triggers: ["roc\t"]
+    replace: rock
+  - triggers: ["rol\t"]
+    replace: role
+  - triggers: ["rol\t"]
+    replace: roll
+  - triggers: ["rom\t", "roma\t", "roman\t", "romant\t", "romanti\t"]
+    replace: romantic
+  - triggers: ["roo\t"]
+    replace: roof
+  - triggers: ["roo\t"]
+    replace: room
+  - triggers: ["roo\t"]
+    replace: root
+  - triggers: ["rop\t"]
+    replace: rope
+  - triggers: ["ros\t"]
+    replace: rose
+  - triggers: ["rou\t", "roug\t"]
+    replace: rough
+  - triggers: ["rou\t", "roug\t", "rough\t", "roughl\t"]
+    replace: roughly
+  - triggers: ["rou\t", "roun\t"]
+    replace: round
+  - triggers: ["rou\t", "rout\t"]
+    replace: route
+  - triggers: ["rou\t", "rout\t", "routi\t", "routin\t"]
+    replace: routine
+  - triggers: ["rul\t"]
+    replace: rule
+  - triggers: ["run\t", "runn\t", "runni\t", "runnin\t"]
+    replace: running
+  - triggers: ["rur\t", "rura\t"]
+    replace: rural
+  - triggers: ["rus\t"]
+    replace: rush
+  - triggers: ["sac\t", "sacr\t", "sacre\t"]
+    replace: sacred
+  - triggers: ["saf\t"]
+    replace: safe
+  - triggers: ["saf\t", "safe\t", "safet\t"]
+    replace: safety
+  - triggers: ["sak\t"]
+    replace: sake
+  - triggers: ["sal\t", "sala\t"]
+    replace: salad
+  - triggers: ["sal\t", "sala\t", "salar\t"]
+    replace: salary
+  - triggers: ["sal\t"]
+    replace: sale
+  - triggers: ["sal\t", "sale\t"]
+    replace: sales
+  - triggers: ["sal\t"]
+    replace: salt
+  - triggers: ["sam\t"]
+    replace: same
+  - triggers: ["sam\t", "samp\t", "sampl\t"]
+    replace: sample
+  - triggers: ["san\t", "sanc\t", "sanct\t", "sancti\t", "sanctio\t"]
+    replace: sanction
+  - triggers: ["san\t"]
+    replace: sand
+  - triggers: ["sat\t", "sate\t", "satel\t", "satell\t", "satelli\t", "satellit\t"]
+    replace: satellite
+  - triggers: ["sat\t", "sati\t", "satis\t", "satisf\t", "satisfa\t", "satisfac\t", "satisfact\t", "satisfacti\t", "satisfactio\t"]
+    replace: satisfaction
+  - triggers: ["sat\t", "sati\t", "satis\t", "satisf\t"]
+    replace: satisfy
+  - triggers: ["sau\t", "sauc\t"]
+    replace: sauce
+  - triggers: ["sav\t"]
+    replace: save
+  - triggers: ["sav\t", "savi\t", "savin\t"]
+    replace: saving
+  - triggers: ["sca\t", "scal\t"]
+    replace: scale
+  - triggers: ["sca\t", "scan\t", "scand\t", "scanda\t"]
+    replace: scandal
+  - triggers: ["sca\t", "scar\t", "scare\t"]
+    replace: scared
+  - triggers: ["sce\t", "scen\t", "scena\t", "scenar\t", "scenari\t"]
+    replace: scenario
+  - triggers: ["sce\t", "scen\t"]
+    replace: scene
+  - triggers: ["sch\t", "sche\t", "sched\t", "schedu\t", "schedul\t"]
+    replace: schedule
+  - triggers: ["sch\t", "sche\t", "schem\t"]
+    replace: scheme
+  - triggers: ["sch\t", "scho\t", "schol\t", "schola\t"]
+    replace: scholar
+  - triggers: ["sch\t", "scho\t", "schol\t", "schola\t", "scholar\t", "scholars\t", "scholarsh\t", "scholarshi\t"]
+    replace: scholarship
+  - triggers: ["sch\t", "scho\t", "schoo\t"]
+    replace: school
+  - triggers: ["sci\t", "scie\t", "scien\t", "scienc\t"]
+    replace: science
+  - triggers: ["sci\t", "scie\t", "scien\t", "scient\t", "scienti\t", "scientif\t", "scientifi\t"]
+    replace: scientific
+  - triggers: ["sci\t", "scie\t", "scien\t", "scient\t", "scienti\t", "scientis\t"]
+    replace: scientist
+  - triggers: ["sco\t", "scop\t"]
+    replace: scope
+  - triggers: ["sco\t", "scor\t"]
+    replace: score
+  - triggers: ["scr\t", "scre\t", "screa\t"]
+    replace: scream
+  - triggers: ["scr\t", "scre\t", "scree\t"]
+    replace: screen
+  - triggers: ["scr\t", "scri\t", "scrip\t"]
+    replace: script
+  - triggers: ["sea\t", "sear\t", "searc\t"]
+    replace: search
+  - triggers: ["sea\t", "seas\t", "seaso\t"]
+    replace: season
+  - triggers: ["sea\t"]
+    replace: seat
+  - triggers: ["sec\t", "seco\t", "secon\t"]
+    replace: second
+  - triggers: ["sec\t", "secr\t", "secre\t"]
+    replace: secret
+  - triggers: ["sec\t", "secr\t", "secre\t", "secret\t", "secreta\t", "secretar\t"]
+    replace: secretary
+  - triggers: ["sec\t", "sect\t", "secti\t", "sectio\t"]
+    replace: section
+  - triggers: ["sec\t", "sect\t", "secto\t"]
+    replace: sector
+  - triggers: ["sec\t", "secu\t", "secur\t"]
+    replace: secure
+  - triggers: ["sec\t", "secu\t", "secur\t", "securi\t", "securit\t"]
+    replace: security
+  - triggers: ["see\t"]
+    replace: seed
+  - triggers: ["see\t"]
+    replace: seek
+  - triggers: ["see\t"]
+    replace: seem
+  - triggers: ["seg\t", "segm\t", "segme\t", "segmen\t"]
+    replace: segment
+  - triggers: ["sei\t", "seiz\t"]
+    replace: seize
+  - triggers: ["sel\t", "sele\t", "selec\t"]
+    replace: select
+  - triggers: ["sel\t", "sele\t", "selec\t", "select\t", "selecti\t", "selectio\t"]
+    replace: selection
+  - triggers: ["sel\t"]
+    replace: self
+  - triggers: ["sel\t"]
+    replace: sell
+  - triggers: ["sen\t", "sena\t", "senat\t", "senato\t"]
+    replace: senator
+  - triggers: ["sen\t"]
+    replace: send
+  - triggers: ["sen\t", "seni\t", "senio\t"]
+    replace: senior
+  - triggers: ["sen\t", "sens\t"]
+    replace: sense
+  - triggers: ["sen\t", "sens\t", "sensi\t", "sensit\t", "sensiti\t", "sensitiv\t"]
+    replace: sensitive
+  - triggers: ["sen\t", "sent\t", "sente\t", "senten\t", "sentenc\t"]
+    replace: sentence
+  - triggers: ["sep\t", "sepa\t", "separ\t", "separa\t", "separat\t"]
+    replace: separate
+  - triggers: ["seq\t", "sequ\t", "seque\t", "sequen\t", "sequenc\t"]
+    replace: sequence
+  - triggers: ["ser\t", "seri\t", "serie\t"]
+    replace: series
+  - triggers: ["ser\t", "seri\t", "serio\t", "seriou\t"]
+    replace: serious
+  - triggers: ["ser\t", "seri\t", "serio\t", "seriou\t", "serious\t", "seriousl\t"]
+    replace: seriously
+  - triggers: ["ser\t", "serv\t"]
+    replace: serve
+  - triggers: ["ser\t", "serv\t", "servi\t", "servic\t"]
+    replace: service
+  - triggers: ["ses\t", "sess\t", "sessi\t", "sessio\t"]
+    replace: session
+  - triggers: ["set\t", "sett\t", "setti\t", "settin\t"]
+    replace: setting
+  - triggers: ["set\t", "sett\t", "settl\t"]
+    replace: settle
+  - triggers: ["set\t", "sett\t", "settl\t", "settle\t", "settlem\t", "settleme\t", "settlemen\t"]
+    replace: settlement
+  - triggers: ["sev\t", "seve\t"]
+    replace: seven
+  - triggers: ["sev\t", "seve\t", "sever\t", "severa\t"]
+    replace: several
+  - triggers: ["sev\t", "seve\t", "sever\t"]
+    replace: severe
+  - triggers: ["sex\t", "sexu\t", "sexua\t"]
+    replace: sexual
+  - triggers: ["sha\t", "shad\t"]
+    replace: shade
+  - triggers: ["sha\t", "shad\t", "shado\t"]
+    replace: shadow
+  - triggers: ["sha\t", "shak\t"]
+    replace: shake
+  - triggers: ["sha\t", "shal\t"]
+    replace: shall
+  - triggers: ["sha\t", "shap\t"]
+    replace: shape
+  - triggers: ["sha\t", "shar\t"]
+    replace: share
+  - triggers: ["sha\t", "shar\t"]
+    replace: sharp
+  - triggers: ["she\t", "shee\t"]
+    replace: sheet
+  - triggers: ["she\t", "shel\t"]
+    replace: shelf
+  - triggers: ["she\t", "shel\t"]
+    replace: shell
+  - triggers: ["she\t", "shel\t", "shelt\t", "shelte\t"]
+    replace: shelter
+  - triggers: ["shi\t", "shif\t"]
+    replace: shift
+  - triggers: ["shi\t", "shin\t"]
+    replace: shine
+  - triggers: ["shi\t"]
+    replace: ship
+  - triggers: ["shi\t", "shir\t"]
+    replace: shirt
+  - triggers: ["shi\t"]
+    replace: shit
+  - triggers: ["sho\t", "shoc\t"]
+    replace: shock
+  - triggers: ["sho\t"]
+    replace: shoe
+  - triggers: ["sho\t", "shoo\t"]
+    replace: shoot
+  - triggers: ["sho\t", "shoo\t", "shoot\t", "shooti\t", "shootin\t"]
+    replace: shooting
+  - triggers: ["sho\t"]
+    replace: shop
+  - triggers: ["sho\t", "shop\t", "shopp\t", "shoppi\t", "shoppin\t"]
+    replace: shopping
+  - triggers: ["sho\t", "shor\t"]
+    replace: shore
+  - triggers: ["sho\t", "shor\t"]
+    replace: short
+  - triggers: ["sho\t", "shor\t", "short\t", "shortl\t"]
+    replace: shortly
+  - triggers: ["sho\t"]
+    replace: shot
+  - triggers: ["sho\t", "shou\t", "shoul\t"]
+    replace: should
+  - triggers: ["sho\t", "shou\t", "shoul\t", "should\t", "shoulde\t"]
+    replace: shoulder
+  - triggers: ["sho\t", "shou\t"]
+    replace: shout
+  - triggers: ["sho\t"]
+    replace: show
+  - triggers: ["sho\t", "show\t", "showe\t"]
+    replace: shower
+  - triggers: ["shr\t", "shru\t"]
+    replace: shrug
+  - triggers: ["shu\t"]
+    replace: shut
+  - triggers: ["sic\t"]
+    replace: sick
+  - triggers: ["sid\t"]
+    replace: side
+  - triggers: ["sig\t"]
+    replace: sigh
+  - triggers: ["sig\t", "sigh\t"]
+    replace: sight
+  - triggers: ["sig\t"]
+    replace: sign
+  - triggers: ["sig\t", "sign\t", "signa\t"]
+    replace: signal
+  - triggers: ["sig\t", "sign\t", "signi\t", "signif\t", "signifi\t", "signific\t", "significa\t", "significan\t", "significanc\t"]
+    replace: significance
+  - triggers: ["sig\t", "sign\t", "signi\t", "signif\t", "signifi\t", "signific\t", "significa\t", "significan\t"]
+    replace: significant
+  - triggers: ["sig\t", "sign\t", "signi\t", "signif\t", "signifi\t", "signific\t", "significa\t", "significan\t", "significant\t", "significantl\t"]
+    replace: significantly
+  - triggers: ["sil\t", "sile\t", "silen\t", "silenc\t"]
+    replace: silence
+  - triggers: ["sil\t", "sile\t", "silen\t"]
+    replace: silent
+  - triggers: ["sil\t", "silv\t", "silve\t"]
+    replace: silver
+  - triggers: ["sim\t", "simi\t", "simil\t", "simila\t"]
+    replace: similar
+  - triggers: ["sim\t", "simi\t", "simil\t", "simila\t", "similar\t", "similarl\t"]
+    replace: similarly
+  - triggers: ["sim\t", "simp\t", "simpl\t"]
+    replace: simple
+  - triggers: ["sim\t", "simp\t", "simpl\t"]
+    replace: simply
+  - triggers: ["sin\t", "sinc\t"]
+    replace: since
+  - triggers: ["sin\t"]
+    replace: sing
+  - triggers: ["sin\t", "sing\t", "singe\t"]
+    replace: singer
+  - triggers: ["sin\t", "sing\t", "singl\t"]
+    replace: single
+  - triggers: ["sin\t"]
+    replace: sink
+  - triggers: ["sis\t", "sist\t", "siste\t"]
+    replace: sister
+  - triggers: ["sit\t"]
+    replace: site
+  - triggers: ["sit\t", "situ\t", "situa\t", "situat\t", "situati\t", "situatio\t"]
+    replace: situation
+  - triggers: ["siz\t"]
+    replace: size
+  - triggers: ["ski\t", "skil\t"]
+    replace: skill
+  - triggers: ["ski\t"]
+    replace: skin
+  - triggers: ["sla\t", "slav\t"]
+    replace: slave
+  - triggers: ["sle\t", "slee\t"]
+    replace: sleep
+  - triggers: ["sli\t", "slic\t"]
+    replace: slice
+  - triggers: ["sli\t", "slid\t"]
+    replace: slide
+  - triggers: ["sli\t", "slig\t", "sligh\t"]
+    replace: slight
+  - triggers: ["sli\t", "slig\t", "sligh\t", "slight\t", "slightl\t"]
+    replace: slightly
+  - triggers: ["sli\t"]
+    replace: slip
+  - triggers: ["slo\t"]
+    replace: slow
+  - triggers: ["slo\t", "slow\t", "slowl\t"]
+    replace: slowly
+  - triggers: ["sma\t", "smal\t"]
+    replace: small
+  - triggers: ["sma\t", "smar\t"]
+    replace: smart
+  - triggers: ["sme\t", "smel\t"]
+    replace: smell
+  - triggers: ["smi\t", "smil\t"]
+    replace: smile
+  - triggers: ["smo\t", "smok\t"]
+    replace: smoke
+  - triggers: ["smo\t", "smoo\t", "smoot\t"]
+    replace: smooth
+  - triggers: ["sna\t"]
+    replace: snap
+  - triggers: ["sno\t"]
+    replace: snow
+  - triggers: ["so-\t", "so-c\t", "so-ca\t", "so-cal\t", "so-call\t", "so-calle\t"]
+    replace: so-called
+  - triggers: ["soc\t", "socc\t", "socce\t"]
+    replace: soccer
+  - triggers: ["soc\t", "soci\t", "socia\t"]
+    replace: social
+  - triggers: ["soc\t", "soci\t", "socie\t", "societ\t"]
+    replace: society
+  - triggers: ["sof\t"]
+    replace: soft
+  - triggers: ["sof\t", "soft\t", "softw\t", "softwa\t", "softwar\t"]
+    replace: software
+  - triggers: ["soi\t"]
+    replace: soil
+  - triggers: ["sol\t", "sola\t"]
+    replace: solar
+  - triggers: ["sol\t", "sold\t", "soldi\t", "soldie\t"]
+    replace: soldier
+  - triggers: ["sol\t", "soli\t"]
+    replace: solid
+  - triggers: ["sol\t", "solu\t", "solut\t", "soluti\t", "solutio\t"]
+    replace: solution
+  - triggers: ["sol\t", "solv\t"]
+    replace: solve
+  - triggers: ["som\t"]
+    replace: some
+  - triggers: ["som\t", "some\t", "someb\t", "somebo\t", "somebod\t"]
+    replace: somebody
+  - triggers: ["som\t", "some\t", "someh\t", "someho\t"]
+    replace: somehow
+  - triggers: ["som\t", "some\t", "someo\t", "someon\t"]
+    replace: someone
+  - triggers: ["som\t", "some\t", "somet\t", "someth\t", "somethi\t", "somethin\t"]
+    replace: something
+  - triggers: ["som\t", "some\t", "somet\t", "someti\t", "sometim\t", "sometime\t"]
+    replace: sometimes
+  - triggers: ["som\t", "some\t", "somew\t", "somewh\t", "somewha\t"]
+    replace: somewhat
+  - triggers: ["som\t", "some\t", "somew\t", "somewh\t", "somewhe\t", "somewher\t"]
+    replace: somewhere
+  - triggers: ["son\t"]
+    replace: song
+  - triggers: ["soo\t"]
+    replace: soon
+  - triggers: ["sop\t", "soph\t", "sophi\t", "sophis\t", "sophist\t", "sophisti\t", "sophistic\t", "sophistica\t", "sophisticat\t", "sophisticate\t"]
+    replace: sophisticated
+  - triggers: ["sor\t", "sorr\t"]
+    replace: sorry
+  - triggers: ["sor\t"]
+    replace: sort
+  - triggers: ["sou\t"]
+    replace: soul
+  - triggers: ["sou\t", "soun\t"]
+    replace: sound
+  - triggers: ["sou\t"]
+    replace: soup
+  - triggers: ["sou\t", "sour\t", "sourc\t"]
+    replace: source
+  - triggers: ["sou\t", "sout\t"]
+    replace: south
+  - triggers: ["sou\t", "sout\t", "south\t", "southe\t", "souther\t"]
+    replace: southern
+  - triggers: ["spa\t", "spac\t"]
+    replace: space
+  - triggers: ["spe\t", "spea\t"]
+    replace: speak
+  - triggers: ["spe\t", "spea\t", "speak\t", "speake\t"]
+    replace: speaker
+  - triggers: ["spe\t", "spec\t", "speci\t", "specia\t"]
+    replace: special
+  - triggers: ["spe\t", "spec\t", "speci\t", "specia\t", "special\t", "speciali\t", "specialis\t"]
+    replace: specialist
+  - triggers: ["spe\t", "spec\t", "speci\t", "specie\t"]
+    replace: species
+  - triggers: ["spe\t", "spec\t", "speci\t", "specif\t", "specifi\t"]
+    replace: specific
+  - triggers: ["spe\t", "spec\t", "speci\t", "specif\t", "specifi\t", "specific\t", "specifica\t", "specifical\t", "specificall\t"]
+    replace: specifically
+  - triggers: ["spe\t", "spee\t", "speec\t"]
+    replace: speech
+  - triggers: ["spe\t", "spee\t"]
+    replace: speed
+  - triggers: ["spe\t", "spen\t"]
+    replace: spend
+  - triggers: ["spe\t", "spen\t", "spend\t", "spendi\t", "spendin\t"]
+    replace: spending
+  - triggers: ["spi\t"]
+    replace: spin
+  - triggers: ["spi\t", "spir\t", "spiri\t"]
+    replace: spirit
+  - triggers: ["spi\t", "spir\t", "spiri\t", "spirit\t", "spiritu\t", "spiritua\t"]
+    replace: spiritual
+  - triggers: ["spl\t", "spli\t"]
+    replace: split
+  - triggers: ["spo\t", "spok\t", "spoke\t", "spokes\t", "spokesm\t", "spokesma\t"]
+    replace: spokesman
+  - triggers: ["spo\t", "spor\t"]
+    replace: sport
+  - triggers: ["spo\t"]
+    replace: spot
+  - triggers: ["spr\t", "spre\t", "sprea\t"]
+    replace: spread
+  - triggers: ["spr\t", "spri\t", "sprin\t"]
+    replace: spring
+  - triggers: ["squ\t", "squa\t", "squar\t"]
+    replace: square
+  - triggers: ["squ\t", "sque\t", "squee\t", "squeez\t"]
+    replace: squeeze
+  - triggers: ["sta\t", "stab\t", "stabi\t", "stabil\t", "stabili\t", "stabilit\t"]
+    replace: stability
+  - triggers: ["sta\t", "stab\t", "stabl\t"]
+    replace: stable
+  - triggers: ["sta\t", "staf\t"]
+    replace: staff
+  - triggers: ["sta\t", "stag\t"]
+    replace: stage
+  - triggers: ["sta\t", "stai\t"]
+    replace: stair
+  - triggers: ["sta\t", "stak\t"]
+    replace: stake
+  - triggers: ["sta\t", "stan\t"]
+    replace: stand
+  - triggers: ["sta\t", "stan\t", "stand\t", "standa\t", "standar\t"]
+    replace: standard
+  - triggers: ["sta\t", "stan\t", "stand\t", "standi\t", "standin\t"]
+    replace: standing
+  - triggers: ["sta\t"]
+    replace: star
+  - triggers: ["sta\t", "star\t"]
+    replace: stare
+  - triggers: ["sta\t", "star\t"]
+    replace: start
+  - triggers: ["sta\t", "stat\t"]
+    replace: state
+  - triggers: ["sta\t", "stat\t", "state\t", "statem\t", "stateme\t", "statemen\t"]
+    replace: statement
+  - triggers: ["sta\t", "stat\t", "stati\t", "statio\t"]
+    replace: station
+  - triggers: ["sta\t", "stat\t", "stati\t", "statis\t", "statist\t", "statisti\t", "statistic\t"]
+    replace: statistics
+  - triggers: ["sta\t", "stat\t", "statu\t"]
+    replace: status
+  - triggers: ["sta\t"]
+    replace: stay
+  - triggers: ["ste\t", "stea\t", "stead\t"]
+    replace: steady
+  - triggers: ["ste\t", "stea\t"]
+    replace: steal
+  - triggers: ["ste\t", "stee\t"]
+    replace: steel
+  - triggers: ["ste\t"]
+    replace: step
+  - triggers: ["sti\t", "stic\t"]
+    replace: stick
+  - triggers: ["sti\t", "stil\t"]
+    replace: still
+  - triggers: ["sti\t"]
+    replace: stir
+  - triggers: ["sto\t", "stoc\t"]
+    replace: stock
+  - triggers: ["sto\t", "stom\t", "stoma\t", "stomac\t"]
+    replace: stomach
+  - triggers: ["sto\t", "ston\t"]
+    replace: stone
+  - triggers: ["sto\t"]
+    replace: stop
+  - triggers: ["sto\t", "stor\t", "stora\t", "storag\t"]
+    replace: storage
+  - triggers: ["sto\t", "stor\t"]
+    replace: store
+  - triggers: ["sto\t", "stor\t"]
+    replace: storm
+  - triggers: ["sto\t", "stor\t"]
+    replace: story
+  - triggers: ["str\t", "stra\t", "strai\t", "straig\t", "straigh\t"]
+    replace: straight
+  - triggers: ["str\t", "stra\t", "stran\t", "strang\t"]
+    replace: strange
+  - triggers: ["str\t", "stra\t", "stran\t", "strang\t", "strange\t"]
+    replace: stranger
+  - triggers: ["str\t", "stra\t", "strat\t", "strate\t", "strateg\t", "strategi\t"]
+    replace: strategic
+  - triggers: ["str\t", "stra\t", "strat\t", "strate\t", "strateg\t"]
+    replace: strategy
+  - triggers: ["str\t", "stre\t", "strea\t"]
+    replace: stream
+  - triggers: ["str\t", "stre\t", "stree\t"]
+    replace: street
+  - triggers: ["str\t", "stre\t", "stren\t", "streng\t", "strengt\t"]
+    replace: strength
+  - triggers: ["str\t", "stre\t", "stren\t", "streng\t", "strengt\t", "strength\t", "strengthe\t"]
+    replace: strengthen
+  - triggers: ["str\t", "stre\t", "stres\t"]
+    replace: stress
+  - triggers: ["str\t", "stre\t", "stret\t", "stretc\t"]
+    replace: stretch
+  - triggers: ["str\t", "stri\t", "strik\t"]
+    replace: strike
+  - triggers: ["str\t", "stri\t", "strin\t"]
+    replace: string
+  - triggers: ["str\t", "stri\t"]
+    replace: strip
+  - triggers: ["str\t", "stro\t", "strok\t"]
+    replace: stroke
+  - triggers: ["str\t", "stro\t", "stron\t"]
+    replace: strong
+  - triggers: ["str\t", "stro\t", "stron\t", "strong\t", "strongl\t"]
+    replace: strongly
+  - triggers: ["str\t", "stru\t", "struc\t", "struct\t", "structu\t", "structur\t"]
+    replace: structure
+  - triggers: ["str\t", "stru\t", "strug\t", "strugg\t", "struggl\t"]
+    replace: struggle
+  - triggers: ["stu\t", "stud\t", "stude\t", "studen\t"]
+    replace: student
+  - triggers: ["stu\t", "stud\t", "studi\t"]
+    replace: studio
+  - triggers: ["stu\t", "stud\t"]
+    replace: study
+  - triggers: ["stu\t", "stuf\t"]
+    replace: stuff
+  - triggers: ["stu\t", "stup\t", "stupi\t"]
+    replace: stupid
+  - triggers: ["sty\t", "styl\t"]
+    replace: style
+  - triggers: ["sub\t", "subj\t", "subje\t", "subjec\t"]
+    replace: subject
+  - triggers: ["sub\t", "subm\t", "submi\t"]
+    replace: submit
+  - triggers: ["sub\t", "subs\t", "subse\t", "subseq\t", "subsequ\t", "subseque\t", "subsequen\t"]
+    replace: subsequent
+  - triggers: ["sub\t", "subs\t", "subst\t", "substa\t", "substan\t", "substanc\t"]
+    replace: substance
+  - triggers: ["sub\t", "subs\t", "subst\t", "substa\t", "substan\t", "substant\t", "substanti\t", "substantia\t"]
+    replace: substantial
+  - triggers: ["suc\t", "succ\t", "succe\t", "succee\t"]
+    replace: succeed
+  - triggers: ["suc\t", "succ\t", "succe\t", "succes\t"]
+    replace: success
+  - triggers: ["suc\t", "succ\t", "succe\t", "succes\t", "success\t", "successf\t", "successfu\t"]
+    replace: successful
+  - triggers: ["suc\t", "succ\t", "succe\t", "succes\t", "success\t", "successf\t", "successfu\t", "successful\t", "successfull\t"]
+    replace: successfully
+  - triggers: ["suc\t"]
+    replace: such
+  - triggers: ["sud\t", "sudd\t", "sudde\t"]
+    replace: sudden
+  - triggers: ["sud\t", "sudd\t", "sudde\t", "sudden\t", "suddenl\t"]
+    replace: suddenly
+  - triggers: ["suf\t", "suff\t", "suffe\t"]
+    replace: suffer
+  - triggers: ["suf\t", "suff\t", "suffi\t", "suffic\t", "suffici\t", "sufficie\t", "sufficien\t"]
+    replace: sufficient
+  - triggers: ["sug\t", "suga\t"]
+    replace: sugar
+  - triggers: ["sug\t", "sugg\t", "sugge\t", "sugges\t"]
+    replace: suggest
+  - triggers: ["sug\t", "sugg\t", "sugge\t", "sugges\t", "suggest\t", "suggesti\t", "suggestio\t"]
+    replace: suggestion
+  - triggers: ["sui\t", "suic\t", "suici\t", "suicid\t"]
+    replace: suicide
+  - triggers: ["sui\t"]
+    replace: suit
+  - triggers: ["sum\t", "summ\t", "summe\t"]
+    replace: summer
+  - triggers: ["sum\t", "summ\t", "summi\t"]
+    replace: summit
+  - triggers: ["sup\t", "supe\t"]
+    replace: super
+  - triggers: ["sup\t", "supp\t", "suppl\t"]
+    replace: supply
+  - triggers: ["sup\t", "supp\t", "suppo\t", "suppor\t"]
+    replace: support
+  - triggers: ["sup\t", "supp\t", "suppo\t", "suppor\t", "support\t", "supporte\t"]
+    replace: supporter
+  - triggers: ["sup\t", "supp\t", "suppo\t", "suppos\t"]
+    replace: suppose
+  - triggers: ["sup\t", "supp\t", "suppo\t", "suppos\t", "suppose\t"]
+    replace: supposed
+  - triggers: ["sur\t"]
+    replace: sure
+  - triggers: ["sur\t", "sure\t", "surel\t"]
+    replace: surely
+  - triggers: ["sur\t", "surf\t", "surfa\t", "surfac\t"]
+    replace: surface
+  - triggers: ["sur\t", "surg\t", "surge\t", "surger\t"]
+    replace: surgery
+  - triggers: ["sur\t", "surp\t", "surpr\t", "surpri\t", "surpris\t"]
+    replace: surprise
+  - triggers: ["sur\t", "surp\t", "surpr\t", "surpri\t", "surpris\t", "surprise\t"]
+    replace: surprised
+  - triggers: ["sur\t", "surp\t", "surpr\t", "surpri\t", "surpris\t", "surprisi\t", "surprisin\t"]
+    replace: surprising
+  - triggers: ["sur\t", "surp\t", "surpr\t", "surpri\t", "surpris\t", "surprisi\t", "surprisin\t", "surprising\t", "surprisingl\t"]
+    replace: surprisingly
+  - triggers: ["sur\t", "surr\t", "surro\t", "surrou\t", "surroun\t"]
+    replace: surround
+  - triggers: ["sur\t", "surv\t", "surve\t"]
+    replace: survey
+  - triggers: ["sur\t", "surv\t", "survi\t", "surviv\t", "surviva\t"]
+    replace: survival
+  - triggers: ["sur\t", "surv\t", "survi\t", "surviv\t"]
+    replace: survive
+  - triggers: ["sur\t", "surv\t", "survi\t", "surviv\t", "survivo\t"]
+    replace: survivor
+  - triggers: ["sus\t", "susp\t", "suspe\t", "suspec\t"]
+    replace: suspect
+  - triggers: ["sus\t", "sust\t", "susta\t", "sustai\t"]
+    replace: sustain
+  - triggers: ["swe\t", "swea\t"]
+    replace: swear
+  - triggers: ["swe\t", "swee\t"]
+    replace: sweep
+  - triggers: ["swe\t", "swee\t"]
+    replace: sweet
+  - triggers: ["swi\t"]
+    replace: swim
+  - triggers: ["swi\t", "swin\t"]
+    replace: swing
+  - triggers: ["swi\t", "swit\t", "switc\t"]
+    replace: switch
+  - triggers: ["sym\t", "symb\t", "symbo\t"]
+    replace: symbol
+  - triggers: ["sym\t", "symp\t", "sympt\t", "sympto\t"]
+    replace: symptom
+  - triggers: ["sys\t", "syst\t", "syste\t"]
+    replace: system
+  - triggers: ["tab\t", "tabl\t"]
+    replace: table
+  - triggers: ["tab\t", "tabl\t", "table\t", "tables\t", "tablesp\t", "tablespo\t", "tablespoo\t"]
+    replace: tablespoon
+  - triggers: ["tac\t", "tact\t", "tacti\t"]
+    replace: tactic
+  - triggers: ["tai\t"]
+    replace: tail
+  - triggers: ["tak\t"]
+    replace: take
+  - triggers: ["tal\t"]
+    replace: tale
+  - triggers: ["tal\t", "tale\t", "talen\t"]
+    replace: talent
+  - triggers: ["tal\t"]
+    replace: talk
+  - triggers: ["tal\t"]
+    replace: tall
+  - triggers: ["tan\t"]
+    replace: tank
+  - triggers: ["tap\t"]
+    replace: tape
+  - triggers: ["tar\t", "targ\t", "targe\t"]
+    replace: target
+  - triggers: ["tas\t"]
+    replace: task
+  - triggers: ["tas\t", "tast\t"]
+    replace: taste
+  - triggers: ["tax\t", "taxp\t", "taxpa\t", "taxpay\t", "taxpaye\t"]
+    replace: taxpayer
+  - triggers: ["tea\t", "teac\t"]
+    replace: teach
+  - triggers: ["tea\t", "teac\t", "teach\t", "teache\t"]
+    replace: teacher
+  - triggers: ["tea\t", "teac\t", "teach\t", "teachi\t", "teachin\t"]
+    replace: teaching
+  - triggers: ["tea\t"]
+    replace: team
+  - triggers: ["tea\t"]
+    replace: tear
+  - triggers: ["tea\t", "teas\t", "teasp\t", "teaspo\t", "teaspoo\t"]
+    replace: teaspoon
+  - triggers: ["tec\t", "tech\t", "techn\t", "techni\t", "technic\t", "technica\t"]
+    replace: technical
+  - triggers: ["tec\t", "tech\t", "techn\t", "techni\t", "techniq\t", "techniqu\t"]
+    replace: technique
+  - triggers: ["tec\t", "tech\t", "techn\t", "techno\t", "technol\t", "technolo\t", "technolog\t"]
+    replace: technology
+  - triggers: ["tee\t"]
+    replace: teen
+  - triggers: ["tee\t", "teen\t", "teena\t", "teenag\t", "teenage\t"]
+    replace: teenager
+  - triggers: ["tel\t", "tele\t", "telep\t", "teleph\t", "telepho\t", "telephon\t"]
+    replace: telephone
+  - triggers: ["tel\t", "tele\t", "teles\t", "telesc\t", "telesco\t", "telescop\t"]
+    replace: telescope
+  - triggers: ["tel\t", "tele\t", "telev\t", "televi\t", "televis\t", "televisi\t", "televisio\t"]
+    replace: television
+  - triggers: ["tel\t"]
+    replace: tell
+  - triggers: ["tem\t", "temp\t", "tempe\t", "temper\t", "tempera\t", "temperat\t", "temperatu\t", "temperatur\t"]
+    replace: temperature
+  - triggers: ["tem\t", "temp\t", "tempo\t", "tempor\t", "tempora\t", "temporar\t"]
+    replace: temporary
+  - triggers: ["ten\t"]
+    replace: tend
+  - triggers: ["ten\t", "tend\t", "tende\t", "tenden\t", "tendenc\t"]
+    replace: tendency
+  - triggers: ["ten\t", "tenn\t", "tenni\t"]
+    replace: tennis
+  - triggers: ["ten\t", "tens\t", "tensi\t", "tensio\t"]
+    replace: tension
+  - triggers: ["ten\t"]
+    replace: tent
+  - triggers: ["ter\t"]
+    replace: term
+  - triggers: ["ter\t", "term\t"]
+    replace: terms
+  - triggers: ["ter\t", "terr\t", "terri\t", "terrib\t", "terribl\t"]
+    replace: terrible
+  - triggers: ["ter\t", "terr\t", "terri\t", "territ\t", "territo\t", "territor\t"]
+    replace: territory
+  - triggers: ["ter\t", "terr\t", "terro\t"]
+    replace: terror
+  - triggers: ["ter\t", "terr\t", "terro\t", "terror\t", "terrori\t", "terroris\t"]
+    replace: terrorism
+  - triggers: ["ter\t", "terr\t", "terro\t", "terror\t", "terrori\t", "terroris\t"]
+    replace: terrorist
+  - triggers: ["tes\t"]
+    replace: test
+  - triggers: ["tes\t", "test\t", "testi\t", "testif\t"]
+    replace: testify
+  - triggers: ["tes\t", "test\t", "testi\t", "testim\t", "testimo\t", "testimon\t"]
+    replace: testimony
+  - triggers: ["tes\t", "test\t", "testi\t", "testin\t"]
+    replace: testing
+  - triggers: ["tex\t"]
+    replace: text
+  - triggers: ["tha\t"]
+    replace: than
+  - triggers: ["tha\t", "than\t"]
+    replace: thank
+  - triggers: ["tha\t", "than\t", "thank\t"]
+    replace: thanks
+  - triggers: ["tha\t"]
+    replace: that
+  - triggers: ["the\t", "thea\t", "theat\t", "theate\t"]
+    replace: theater
+  - triggers: ["the\t", "thei\t"]
+    replace: their
+  - triggers: ["the\t"]
+    replace: them
+  - triggers: ["the\t", "them\t"]
+    replace: theme
+  - triggers: ["the\t", "them\t", "thems\t", "themse\t", "themsel\t", "themselv\t", "themselve\t"]
+    replace: themselves
+  - triggers: ["the\t"]
+    replace: then
+  - triggers: ["the\t", "theo\t", "theor\t"]
+    replace: theory
+  - triggers: ["the\t", "ther\t", "thera\t", "therap\t"]
+    replace: therapy
+  - triggers: ["the\t", "ther\t"]
+    replace: there
+  - triggers: ["the\t", "ther\t", "there\t", "theref\t", "therefo\t", "therefor\t"]
+    replace: therefore
+  - triggers: ["the\t", "thes\t"]
+    replace: these
+  - triggers: ["the\t"]
+    replace: they
+  - triggers: ["thi\t", "thic\t"]
+    replace: thick
+  - triggers: ["thi\t"]
+    replace: thin
+  - triggers: ["thi\t", "thin\t"]
+    replace: thing
+  - triggers: ["thi\t", "thin\t"]
+    replace: think
+  - triggers: ["thi\t", "thin\t", "think\t", "thinki\t", "thinkin\t"]
+    replace: thinking
+  - triggers: ["thi\t", "thir\t"]
+    replace: third
+  - triggers: ["thi\t", "thir\t", "thirt\t"]
+    replace: thirty
+  - triggers: ["thi\t"]
+    replace: this
+  - triggers: ["tho\t", "thos\t"]
+    replace: those
+  - triggers: ["tho\t", "thou\t", "thoug\t"]
+    replace: though
+  - triggers: ["tho\t", "thou\t", "thoug\t", "though\t"]
+    replace: thought
+  - triggers: ["tho\t", "thou\t", "thous\t", "thousa\t", "thousan\t"]
+    replace: thousand
+  - triggers: ["thr\t", "thre\t", "threa\t"]
+    replace: threat
+  - triggers: ["thr\t", "thre\t", "threa\t", "threat\t", "threate\t"]
+    replace: threaten
+  - triggers: ["thr\t", "thre\t"]
+    replace: three
+  - triggers: ["thr\t", "thro\t", "throa\t"]
+    replace: throat
+  - triggers: ["thr\t", "thro\t", "throu\t", "throug\t"]
+    replace: through
+  - triggers: ["thr\t", "thro\t", "throu\t", "throug\t", "through\t", "througho\t", "throughou\t"]
+    replace: throughout
+  - triggers: ["thr\t", "thro\t"]
+    replace: throw
+  - triggers: ["thu\t"]
+    replace: thus
+  - triggers: ["tic\t", "tick\t", "ticke\t"]
+    replace: ticket
+  - triggers: ["tig\t", "tigh\t"]
+    replace: tight
+  - triggers: ["tim\t"]
+    replace: time
+  - triggers: ["tin\t"]
+    replace: tiny
+  - triggers: ["tir\t"]
+    replace: tire
+  - triggers: ["tir\t", "tire\t"]
+    replace: tired
+  - triggers: ["tis\t", "tiss\t", "tissu\t"]
+    replace: tissue
+  - triggers: ["tit\t", "titl\t"]
+    replace: title
+  - triggers: ["tob\t", "toba\t", "tobac\t", "tobacc\t"]
+    replace: tobacco
+  - triggers: ["tod\t", "toda\t"]
+    replace: today
+  - triggers: ["tog\t", "toge\t", "toget\t", "togeth\t", "togethe\t"]
+    replace: together
+  - triggers: ["tom\t", "toma\t", "tomat\t"]
+    replace: tomato
+  - triggers: ["tom\t", "tomo\t", "tomor\t", "tomorr\t", "tomorro\t"]
+    replace: tomorrow
+  - triggers: ["ton\t"]
+    replace: tone
+  - triggers: ["ton\t", "tong\t", "tongu\t"]
+    replace: tongue
+  - triggers: ["ton\t", "toni\t", "tonig\t", "tonigh\t"]
+    replace: tonight
+  - triggers: ["too\t"]
+    replace: tool
+  - triggers: ["too\t", "toot\t"]
+    replace: tooth
+  - triggers: ["top\t", "topi\t"]
+    replace: topic
+  - triggers: ["tos\t"]
+    replace: toss
+  - triggers: ["tot\t", "tota\t"]
+    replace: total
+  - triggers: ["tot\t", "tota\t", "total\t", "totall\t"]
+    replace: totally
+  - triggers: ["tou\t", "touc\t"]
+    replace: touch
+  - triggers: ["tou\t", "toug\t"]
+    replace: tough
+  - triggers: ["tou\t"]
+    replace: tour
+  - triggers: ["tou\t", "tour\t", "touri\t", "touris\t"]
+    replace: tourist
+  - triggers: ["tou\t", "tour\t", "tourn\t", "tourna\t", "tournam\t", "tourname\t", "tournamen\t"]
+    replace: tournament
+  - triggers: ["tow\t", "towa\t", "towar\t"]
+    replace: toward
+  - triggers: ["tow\t", "towa\t", "towar\t", "toward\t"]
+    replace: towards
+  - triggers: ["tow\t", "towe\t"]
+    replace: tower
+  - triggers: ["tow\t"]
+    replace: town
+  - triggers: ["tra\t", "trac\t"]
+    replace: trace
+  - triggers: ["tra\t", "trac\t"]
+    replace: track
+  - triggers: ["tra\t", "trad\t"]
+    replace: trade
+  - triggers: ["tra\t", "trad\t", "tradi\t", "tradit\t", "traditi\t", "traditio\t"]
+    replace: tradition
+  - triggers: ["tra\t", "trad\t", "tradi\t", "tradit\t", "traditi\t", "traditio\t", "tradition\t", "traditiona\t"]
+    replace: traditional
+  - triggers: ["tra\t", "traf\t", "traff\t", "traffi\t"]
+    replace: traffic
+  - triggers: ["tra\t", "trag\t", "trage\t", "traged\t"]
+    replace: tragedy
+  - triggers: ["tra\t", "trai\t"]
+    replace: trail
+  - triggers: ["tra\t", "trai\t"]
+    replace: train
+  - triggers: ["tra\t", "trai\t", "train\t", "traini\t", "trainin\t"]
+    replace: training
+  - triggers: ["tra\t", "tran\t", "trans\t", "transf\t", "transfe\t"]
+    replace: transfer
+  - triggers: ["tra\t", "tran\t", "trans\t", "transf\t", "transfo\t", "transfor\t"]
+    replace: transform
+  - triggers: ["tra\t", "tran\t", "trans\t", "transf\t", "transfo\t", "transfor\t", "transform\t", "transforma\t", "transformat\t", "transformati\t", "transformatio\t"]
+    replace: transformation
+  - triggers: ["tra\t", "tran\t", "trans\t", "transi\t", "transit\t", "transiti\t", "transitio\t"]
+    replace: transition
+  - triggers: ["tra\t", "tran\t", "trans\t", "transl\t", "transla\t", "translat\t"]
+    replace: translate
+  - triggers: ["tra\t", "tran\t", "trans\t", "transp\t", "transpo\t", "transpor\t", "transport\t", "transporta\t", "transportat\t", "transportati\t", "transportatio\t"]
+    replace: transportation
+  - triggers: ["tra\t", "trav\t", "trave\t"]
+    replace: travel
+  - triggers: ["tre\t", "trea\t"]
+    replace: treat
+  - triggers: ["tre\t", "trea\t", "treat\t", "treatm\t", "treatme\t", "treatmen\t"]
+    replace: treatment
+  - triggers: ["tre\t", "trea\t", "treat\t"]
+    replace: treaty
+  - triggers: ["tre\t"]
+    replace: tree
+  - triggers: ["tre\t", "trem\t", "treme\t", "tremen\t", "tremend\t", "tremendo\t", "tremendou\t"]
+    replace: tremendous
+  - triggers: ["tre\t", "tren\t"]
+    replace: trend
+  - triggers: ["tri\t", "tria\t"]
+    replace: trial
+  - triggers: ["tri\t", "trib\t"]
+    replace: tribe
+  - triggers: ["tri\t", "tric\t"]
+    replace: trick
+  - triggers: ["tri\t"]
+    replace: trip
+  - triggers: ["tro\t", "troo\t"]
+    replace: troop
+  - triggers: ["tro\t", "trou\t", "troub\t", "troubl\t"]
+    replace: trouble
+  - triggers: ["tru\t", "truc\t"]
+    replace: truck
+  - triggers: ["tru\t", "trul\t"]
+    replace: truly
+  - triggers: ["tru\t", "trus\t"]
+    replace: trust
+  - triggers: ["tru\t", "trut\t"]
+    replace: truth
+  - triggers: ["tub\t"]
+    replace: tube
+  - triggers: ["tun\t", "tunn\t", "tunne\t"]
+    replace: tunnel
+  - triggers: ["tur\t"]
+    replace: turn
+  - triggers: ["twe\t", "twel\t", "twelv\t"]
+    replace: twelve
+  - triggers: ["twe\t", "twen\t", "twent\t"]
+    replace: twenty
+  - triggers: ["twi\t", "twic\t"]
+    replace: twice
+  - triggers: ["twi\t"]
+    replace: twin
+  - triggers: ["typ\t"]
+    replace: type
+  - triggers: ["typ\t", "typi\t", "typic\t", "typica\t"]
+    replace: typical
+  - triggers: ["typ\t", "typi\t", "typic\t", "typica\t", "typical\t", "typicall\t"]
+    replace: typically
+  - triggers: ["ugl\t"]
+    replace: ugly
+  - triggers: ["ult\t", "ulti\t", "ultim\t", "ultima\t", "ultimat\t"]
+    replace: ultimate
+  - triggers: ["ult\t", "ulti\t", "ultim\t", "ultima\t", "ultimat\t", "ultimate\t", "ultimatel\t"]
+    replace: ultimately
+  - triggers: ["una\t", "unab\t", "unabl\t"]
+    replace: unable
+  - triggers: ["unc\t", "uncl\t"]
+    replace: uncle
+  - triggers: ["und\t", "unde\t"]
+    replace: under
+  - triggers: ["und\t", "unde\t", "under\t", "underg\t"]
+    replace: undergo
+  - triggers: ["und\t", "unde\t", "under\t", "unders\t", "underst\t", "understa\t", "understan\t"]
+    replace: understand
+  - triggers: ["und\t", "unde\t", "under\t", "unders\t", "underst\t", "understa\t", "understan\t", "understand\t", "understandi\t", "understandin\t"]
+    replace: understanding
+  - triggers: ["unf\t", "unfo\t", "unfor\t", "unfort\t", "unfortu\t", "unfortun\t", "unfortuna\t", "unfortunat\t", "unfortunate\t", "unfortunatel\t"]
+    replace: unfortunately
+  - triggers: ["uni\t", "unif\t", "unifo\t", "unifor\t"]
+    replace: uniform
+  - triggers: ["uni\t", "unio\t"]
+    replace: union
+  - triggers: ["uni\t", "uniq\t", "uniqu\t"]
+    replace: unique
+  - triggers: ["uni\t"]
+    replace: unit
+  - triggers: ["uni\t", "univ\t", "unive\t", "univer\t", "univers\t", "universa\t"]
+    replace: universal
+  - triggers: ["uni\t", "univ\t", "unive\t", "univer\t", "univers\t"]
+    replace: universe
+  - triggers: ["uni\t", "univ\t", "unive\t", "univer\t", "univers\t", "universi\t", "universit\t"]
+    replace: university
+  - triggers: ["unk\t", "unkn\t", "unkno\t", "unknow\t"]
+    replace: unknown
+  - triggers: ["unl\t", "unle\t", "unles\t"]
+    replace: unless
+  - triggers: ["unl\t", "unli\t", "unlik\t"]
+    replace: unlike
+  - triggers: ["unl\t", "unli\t", "unlik\t", "unlike\t", "unlikel\t"]
+    replace: unlikely
+  - triggers: ["unt\t", "unti\t"]
+    replace: until
+  - triggers: ["unu\t", "unus\t", "unusu\t", "unusua\t"]
+    replace: unusual
+  - triggers: ["upo\t"]
+    replace: upon
+  - triggers: ["upp\t", "uppe\t"]
+    replace: upper
+  - triggers: ["urb\t", "urba\t"]
+    replace: urban
+  - triggers: ["urg\t"]
+    replace: urge
+  - triggers: ["use\t"]
+    replace: used
+  - triggers: ["use\t", "usef\t", "usefu\t"]
+    replace: useful
+  - triggers: ["use\t"]
+    replace: user
+  - triggers: ["usu\t", "usua\t"]
+    replace: usual
+  - triggers: ["usu\t", "usua\t", "usual\t", "usuall\t"]
+    replace: usually
+  - triggers: ["uti\t", "util\t", "utili\t", "utilit\t"]
+    replace: utility
+  - triggers: ["vac\t", "vaca\t", "vacat\t", "vacati\t", "vacatio\t"]
+    replace: vacation
+  - triggers: ["val\t", "vall\t", "valle\t"]
+    replace: valley
+  - triggers: ["val\t", "valu\t", "valua\t", "valuab\t", "valuabl\t"]
+    replace: valuable
+  - triggers: ["val\t", "valu\t"]
+    replace: value
+  - triggers: ["var\t", "vari\t", "varia\t", "variab\t", "variabl\t"]
+    replace: variable
+  - triggers: ["var\t", "vari\t", "varia\t", "variat\t", "variati\t", "variatio\t"]
+    replace: variation
+  - triggers: ["var\t", "vari\t", "varie\t", "variet\t"]
+    replace: variety
+  - triggers: ["var\t", "vari\t", "vario\t", "variou\t"]
+    replace: various
+  - triggers: ["var\t"]
+    replace: vary
+  - triggers: ["vas\t"]
+    replace: vast
+  - triggers: ["veg\t", "vege\t", "veget\t", "vegeta\t", "vegetab\t", "vegetabl\t"]
+    replace: vegetable
+  - triggers: ["veh\t", "vehi\t", "vehic\t", "vehicl\t"]
+    replace: vehicle
+  - triggers: ["ven\t", "vent\t", "ventu\t", "ventur\t"]
+    replace: venture
+  - triggers: ["ver\t", "vers\t", "versi\t", "versio\t"]
+    replace: version
+  - triggers: ["ver\t", "vers\t", "versu\t"]
+    replace: versus
+  - triggers: ["ver\t"]
+    replace: very
+  - triggers: ["ves\t", "vess\t", "vesse\t"]
+    replace: vessel
+  - triggers: ["vet\t", "vete\t", "veter\t", "vetera\t"]
+    replace: veteran
+  - triggers: ["vic\t", "vict\t", "victi\t"]
+    replace: victim
+  - triggers: ["vic\t", "vict\t", "victo\t", "victor\t"]
+    replace: victory
+  - triggers: ["vid\t", "vide\t"]
+    replace: video
+  - triggers: ["vie\t"]
+    replace: view
+  - triggers: ["vie\t", "view\t", "viewe\t"]
+    replace: viewer
+  - triggers: ["vil\t", "vill\t", "villa\t", "villag\t"]
+    replace: village
+  - triggers: ["vio\t", "viol\t", "viola\t", "violat\t"]
+    replace: violate
+  - triggers: ["vio\t", "viol\t", "viola\t", "violat\t", "violati\t", "violatio\t"]
+    replace: violation
+  - triggers: ["vio\t", "viol\t", "viole\t", "violen\t", "violenc\t"]
+    replace: violence
+  - triggers: ["vio\t", "viol\t", "viole\t", "violen\t"]
+    replace: violent
+  - triggers: ["vir\t", "virt\t", "virtu\t", "virtua\t", "virtual\t", "virtuall\t"]
+    replace: virtually
+  - triggers: ["vir\t", "virt\t", "virtu\t"]
+    replace: virtue
+  - triggers: ["vir\t", "viru\t"]
+    replace: virus
+  - triggers: ["vis\t", "visi\t", "visib\t", "visibl\t"]
+    replace: visible
+  - triggers: ["vis\t", "visi\t", "visio\t"]
+    replace: vision
+  - triggers: ["vis\t", "visi\t"]
+    replace: visit
+  - triggers: ["vis\t", "visi\t", "visit\t", "visito\t"]
+    replace: visitor
+  - triggers: ["vis\t", "visu\t", "visua\t"]
+    replace: visual
+  - triggers: ["vit\t", "vita\t"]
+    replace: vital
+  - triggers: ["voi\t", "voic\t"]
+    replace: voice
+  - triggers: ["vol\t", "volu\t", "volum\t"]
+    replace: volume
+  - triggers: ["vol\t", "volu\t", "volun\t", "volunt\t", "volunte\t", "voluntee\t"]
+    replace: volunteer
+  - triggers: ["vot\t"]
+    replace: vote
+  - triggers: ["vot\t", "vote\t"]
+    replace: voter
+  - triggers: ["vul\t", "vuln\t", "vulne\t", "vulner\t", "vulnera\t", "vulnerab\t", "vulnerabl\t"]
+    replace: vulnerable
+  - triggers: ["wag\t"]
+    replace: wage
+  - triggers: ["wai\t"]
+    replace: wait
+  - triggers: ["wak\t"]
+    replace: wake
+  - triggers: ["wal\t"]
+    replace: walk
+  - triggers: ["wal\t"]
+    replace: wall
+  - triggers: ["wan\t", "wand\t", "wande\t"]
+    replace: wander
+  - triggers: ["wan\t"]
+    replace: want
+  - triggers: ["war\t"]
+    replace: warm
+  - triggers: ["war\t"]
+    replace: warn
+  - triggers: ["war\t", "warn\t", "warni\t", "warnin\t"]
+    replace: warning
+  - triggers: ["was\t"]
+    replace: wash
+  - triggers: ["was\t", "wast\t"]
+    replace: waste
+  - triggers: ["wat\t", "watc\t"]
+    replace: watch
+  - triggers: ["wat\t", "wate\t"]
+    replace: water
+  - triggers: ["wav\t"]
+    replace: wave
+  - triggers: ["wea\t"]
+    replace: weak
+  - triggers: ["wea\t", "weal\t", "wealt\t"]
+    replace: wealth
+  - triggers: ["wea\t", "weal\t", "wealt\t", "wealth\t"]
+    replace: wealthy
+  - triggers: ["wea\t", "weap\t", "weapo\t"]
+    replace: weapon
+  - triggers: ["wea\t"]
+    replace: wear
+  - triggers: ["wea\t", "weat\t", "weath\t", "weathe\t"]
+    replace: weather
+  - triggers: ["wed\t", "wedd\t", "weddi\t", "weddin\t"]
+    replace: wedding
+  - triggers: ["wee\t"]
+    replace: week
+  - triggers: ["wee\t", "week\t", "weeke\t", "weeken\t"]
+    replace: weekend
+  - triggers: ["wee\t", "week\t", "weekl\t"]
+    replace: weekly
+  - triggers: ["wei\t", "weig\t"]
+    replace: weigh
+  - triggers: ["wei\t", "weig\t", "weigh\t"]
+    replace: weight
+  - triggers: ["wel\t", "welc\t", "welco\t", "welcom\t"]
+    replace: welcome
+  - triggers: ["wel\t", "welf\t", "welfa\t", "welfar\t"]
+    replace: welfare
+  - triggers: ["wel\t"]
+    replace: well
+  - triggers: ["wes\t"]
+    replace: west
+  - triggers: ["wes\t", "west\t", "weste\t", "wester\t"]
+    replace: western
+  - triggers: ["wha\t"]
+    replace: what
+  - triggers: ["wha\t", "what\t", "whate\t", "whatev\t", "whateve\t"]
+    replace: whatever
+  - triggers: ["whe\t", "whee\t"]
+    replace: wheel
+  - triggers: ["whe\t"]
+    replace: when
+  - triggers: ["whe\t", "when\t", "whene\t", "whenev\t", "wheneve\t"]
+    replace: whenever
+  - triggers: ["whe\t", "wher\t"]
+    replace: where
+  - triggers: ["whe\t", "wher\t", "where\t", "wherea\t"]
+    replace: whereas
+  - triggers: ["whe\t", "whet\t", "wheth\t", "whethe\t"]
+    replace: whether
+  - triggers: ["whi\t", "whic\t"]
+    replace: which
+  - triggers: ["whi\t", "whil\t"]
+    replace: while
+  - triggers: ["whi\t", "whis\t", "whisp\t", "whispe\t"]
+    replace: whisper
+  - triggers: ["whi\t", "whit\t"]
+    replace: white
+  - triggers: ["who\t", "whol\t"]
+    replace: whole
+  - triggers: ["who\t"]
+    replace: whom
+  - triggers: ["who\t", "whos\t"]
+    replace: whose
+  - triggers: ["wid\t"]
+    replace: wide
+  - triggers: ["wid\t", "wide\t", "widel\t"]
+    replace: widely
+  - triggers: ["wid\t", "wide\t", "wides\t", "widesp\t", "widespr\t", "widespre\t", "widesprea\t"]
+    replace: widespread
+  - triggers: ["wif\t"]
+    replace: wife
+  - triggers: ["wil\t"]
+    replace: wild
+  - triggers: ["wil\t"]
+    replace: will
+  - triggers: ["wil\t", "will\t", "willi\t", "willin\t"]
+    replace: willing
+  - triggers: ["win\t"]
+    replace: wind
+  - triggers: ["win\t", "wind\t", "windo\t"]
+    replace: window
+  - triggers: ["win\t"]
+    replace: wine
+  - triggers: ["win\t"]
+    replace: wing
+  - triggers: ["win\t", "winn\t", "winne\t"]
+    replace: winner
+  - triggers: ["win\t", "wint\t", "winte\t"]
+    replace: winter
+  - triggers: ["wip\t"]
+    replace: wipe
+  - triggers: ["wir\t"]
+    replace: wire
+  - triggers: ["wis\t", "wisd\t", "wisdo\t"]
+    replace: wisdom
+  - triggers: ["wis\t"]
+    replace: wise
+  - triggers: ["wis\t"]
+    replace: wish
+  - triggers: ["wit\t"]
+    replace: with
+  - triggers: ["wit\t", "with\t", "withd\t", "withdr\t", "withdra\t"]
+    replace: withdraw
+  - triggers: ["wit\t", "with\t", "withi\t"]
+    replace: within
+  - triggers: ["wit\t", "with\t", "witho\t", "withou\t"]
+    replace: without
+  - triggers: ["wit\t", "witn\t", "witne\t", "witnes\t"]
+    replace: witness
+  - triggers: ["wom\t", "woma\t"]
+    replace: woman
+  - triggers: ["won\t", "wond\t", "wonde\t"]
+    replace: wonder
+  - triggers: ["won\t", "wond\t", "wonde\t", "wonder\t", "wonderf\t", "wonderfu\t"]
+    replace: wonderful
+  - triggers: ["woo\t"]
+    replace: wood
+  - triggers: ["woo\t", "wood\t", "woode\t"]
+    replace: wooden
+  - triggers: ["wor\t"]
+    replace: word
+  - triggers: ["wor\t"]
+    replace: work
+  - triggers: ["wor\t", "work\t", "worke\t"]
+    replace: worker
+  - triggers: ["wor\t", "work\t", "worki\t", "workin\t"]
+    replace: working
+  - triggers: ["wor\t", "work\t"]
+    replace: works
+  - triggers: ["wor\t", "work\t", "works\t", "worksh\t", "worksho\t"]
+    replace: workshop
+  - triggers: ["wor\t", "worl\t"]
+    replace: world
+  - triggers: ["wor\t", "worr\t", "worri\t", "worrie\t"]
+    replace: worried
+  - triggers: ["wor\t", "worr\t"]
+    replace: worry
+  - triggers: ["wor\t", "wort\t"]
+    replace: worth
+  - triggers: ["wou\t", "woul\t"]
+    replace: would
+  - triggers: ["wou\t", "woun\t"]
+    replace: wound
+  - triggers: ["wra\t"]
+    replace: wrap
+  - triggers: ["wri\t", "writ\t"]
+    replace: write
+  - triggers: ["wri\t", "writ\t", "write\t"]
+    replace: writer
+  - triggers: ["wri\t", "writ\t", "writi\t", "writin\t"]
+    replace: writing
+  - triggers: ["wro\t", "wron\t"]
+    replace: wrong
+  - triggers: ["yar\t"]
+    replace: yard
+  - triggers: ["yea\t"]
+    replace: yeah
+  - triggers: ["yea\t"]
+    replace: year
+  - triggers: ["yel\t"]
+    replace: yell
+  - triggers: ["yel\t", "yell\t", "yello\t"]
+    replace: yellow
+  - triggers: ["yes\t", "yest\t", "yeste\t", "yester\t", "yesterd\t", "yesterda\t"]
+    replace: yesterday
+  - triggers: ["yie\t", "yiel\t"]
+    replace: yield
+  - triggers: ["you\t", "youn\t"]
+    replace: young
+  - triggers: ["you\t"]
+    replace: your
+  - triggers: ["you\t", "your\t"]
+    replace: yours
+  - triggers: ["you\t", "your\t", "yours\t", "yourse\t", "yoursel\t"]
+    replace: yourself
+  - triggers: ["you\t", "yout\t"]
+    replace: youth
+  - triggers: ["zon\t"]
+    replace: zone


### PR DESCRIPTION
Autocomplete-en: modified to demonstrate multiple triggers and reduce size.

Accented-words: many additions, sorted alphabetically for easy editing, unnecessary quote marks removed. 

The original forks don't appear to be under active maintenance, but I can try to submit them by that route if you think appropriate.