### PR TITLE
Add quick-translate Package to translate between many languages using translate-shell

### DIFF
--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -10,6 +10,7 @@ Once you have it installed, you can install this package using the following com
 
 ```bash
 espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external
+espanso restart
 ```
 
 After Installing, you can change the `sourcelang` and `targetlang` variables in [defaultlang.yml](defaultlang.yml) to your desired default languages. You can find the valid names at the bottom of [package.yml](package.yml). Please note that if there's an update in the future, those files could be overwritten.

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -1,16 +1,18 @@
 # Espanso Translate-Shell Extension
 
-This package utilizes the functionality of [translate-shell](https://github.com/soimort/translate-shell) to translate texts into various languages.
+This package utilizes the functionality of [translate-shell](https://github.com/soimort/translate-shell) to translate texts into various languages using [Espanso Open-Source Text-Expander](https://github.com/espanso/espanso).
 
 ## Installation
-a
+
 Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros)
 
-Once you have translate-shell installed, you can install this package using the following command:
+Once you have it installed, you can install this package using the following command:
 
 ```bash
 espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external
 ```
+
+After Installing, you can change the `sourcelang` and `targetlang` variables in [defaultlang.yml](defaultlang.yml) to your desired default languages. You can find the valid names at the bottom of [package.yml](package.yml)
 
 ## Usage
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -9,7 +9,7 @@ Before using this package, make sure you have [translate-shell](https://github.c
 Once you have translate-shell installed, you can install this package using the following command:
 
 ```bash
-espanso install quick-translate 
+espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external 
 espanso restart
 ```
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -15,4 +15,4 @@ espanso restart
 
 ## Usage
 
-Type `:trans` to open the form and then enter your to and from languages and the text you want to translate. The translated text will be outputted.
+Type `::trans` to open the form and then enter your to and from languages and the text you want to translate. The translated text will be outputted.

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -4,11 +4,11 @@ This package utilizes the functionality of [translate-shell](https://github.com/
 
 ## Installation
 
-Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. You can download and install it from the official GitHub page.
+Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros): 
 
 Once you have translate-shell installed, you can install this package using the following command:
 
-```
+```bash
 espanso install quick-translate 
 espanso restart
 ```

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -12,7 +12,7 @@ Once you have it installed, you can install this package using the following com
 espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external
 ```
 
-After Installing, you can change the `sourcelang` and `targetlang` variables in [defaultlang.yml](defaultlang.yml) to your desired default languages. You can find the valid names at the bottom of [package.yml](package.yml)
+After Installing, you can change the `sourcelang` and `targetlang` variables in [defaultlang.yml](defaultlang.yml) to your desired default languages. You can find the valid names at the bottom of [package.yml](package.yml). Please note that if there's an update in the future, those files could be overwritten.
 
 ## Usage
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -4,7 +4,7 @@ This package utilizes the functionality of [translate-shell](https://github.com/
 
 ## Installation
 
-Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros): 
+Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros)
 
 Once you have translate-shell installed, you can install this package using the following command:
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -9,7 +9,7 @@ Before using this package, make sure you have [translate-shell](https://github.c
 Once you have it installed, you can install this package using the following command:
 
 ```bash
-espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external
+espanso install quick-translate
 espanso restart
 ```
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -3,7 +3,7 @@
 This package utilizes the functionality of [translate-shell](https://github.com/soimort/translate-shell) to translate texts into various languages.
 
 ## Installation
-
+a
 Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros)
 
 Once you have translate-shell installed, you can install this package using the following command:
@@ -14,4 +14,5 @@ espanso install quick-translate --git https://github.com/p0ly60n/quick-translate
 
 ## Usage
 
-Type `::trans` to open the form and then enter your to and from languages and the text you want to translate. The translated text will be outputted.
+- `::trans`: Translates the selected text to the target language (default: English)
+- `::etrans`: Extended Translate - Translates the Text from a source language (default: German) to a target language (default: English)

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -4,7 +4,7 @@ This package utilizes the functionality of [translate-shell](https://github.com/
 
 ## Installation
 
-Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros)
+Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. If you don't, you can install it for your OS [here](https://github.com/soimort/translate-shell/wiki/Distros). Make sure to install and use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) when using Windows.
 
 Once you have it installed, you can install this package using the following command:
 

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -9,8 +9,7 @@ Before using this package, make sure you have [translate-shell](https://github.c
 Once you have translate-shell installed, you can install this package using the following command:
 
 ```bash
-espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external 
-espanso restart
+espanso install quick-translate --git https://github.com/p0ly60n/quick-translate --external
 ```
 
 ## Usage

--- a/packages/quick-translate/0.1.0/README.md
+++ b/packages/quick-translate/0.1.0/README.md
@@ -1,0 +1,18 @@
+# Espanso Translate-Shell Extension
+
+This package utilizes the functionality of [translate-shell](https://github.com/soimort/translate-shell) to translate texts into various languages.
+
+## Installation
+
+Before using this package, make sure you have [translate-shell](https://github.com/soimort/translate-shell/wiki/Distros) installed on your system. You can download and install it from the official GitHub page.
+
+Once you have translate-shell installed, you can install this package using the following command:
+
+```
+espanso install quick-translate 
+espanso restart
+```
+
+## Usage
+
+Type `:trans` to open the form and then enter your to and from languages and the text you want to translate. The translated text will be outputted.

--- a/packages/quick-translate/0.1.0/_manifest.yml
+++ b/packages/quick-translate/0.1.0/_manifest.yml
@@ -1,0 +1,6 @@
+name: "quick-translate"
+title: "Quick Translate"
+description: A Package to quickly translate text of various languages
+version: 0.1.0
+author: Marco Weiss
+tags: ["translator"]

--- a/packages/quick-translate/0.1.0/_manifest.yml
+++ b/packages/quick-translate/0.1.0/_manifest.yml
@@ -3,4 +3,4 @@ title: "Quick Translate"
 description: A Package to quickly translate text of various languages
 version: 0.1.0
 author: Marco Weiss
-tags: ["translator"]
+tags: ["Languages", "Translation", "Dictionary"]

--- a/packages/quick-translate/0.1.0/_manifest.yml
+++ b/packages/quick-translate/0.1.0/_manifest.yml
@@ -2,5 +2,6 @@ name: quick-translate
 title: Quick Translate
 description: A Package to quickly translate text of various languages
 version: 0.1.0
-author: Marco Weiss
+author: p0ly60n
+homepage: https://github.com/p0ly60n/quick-translate
 tags: ["languages", "translation", "dictionary"]

--- a/packages/quick-translate/0.1.0/_manifest.yml
+++ b/packages/quick-translate/0.1.0/_manifest.yml
@@ -1,6 +1,6 @@
-name: "quick-translate"
-title: "Quick Translate"
+name: quick-translate
+title: Quick Translate
 description: A Package to quickly translate text of various languages
 version: 0.1.0
 author: Marco Weiss
-tags: ["Languages", "Translation", "Dictionary"]
+tags: ["languages", "translation", "dictionary"]

--- a/packages/quick-translate/0.1.0/defaultlang.yml
+++ b/packages/quick-translate/0.1.0/defaultlang.yml
@@ -1,0 +1,10 @@
+# Default Variables for the source and target language
+global_vars:
+  - name: sourcelang
+    type: echo
+    params:
+      echo: German
+  - name: targetlang
+    type: echo
+    params:
+      echo: English

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -25,6 +25,7 @@ matches:
         type: shell
         params:
           cmd: "trans -b -t '{{input.target}}' '{{input.text}}'"
+          shell: wsl
 
   - trigger: "::etrans"
     label: "Extended Translate"

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -1,3 +1,179 @@
+global_vars:
+  - name: lang
+    type: echo
+    params:
+      echo: |
+        Afrikaans
+        Albanian
+        Amharic
+        Arabic
+        Armenian
+        Assamese
+        Aymara
+        Azerbaijani
+        Bambara
+        Bashkir
+        Basque
+        Belarusian
+        Bengali
+        Bhojpuri
+        Bosnian
+        Breton
+        Bulgarian
+        Cantonese
+        Catalan
+        Cebuano
+        Cherokee
+        Chichewa
+        Chinese (Literary)
+        Chinese (Simplified)
+        Chinese (Traditional)
+        Chuvash
+        Corsican
+        Croatian
+        Czech
+        Danish
+        Dari
+        Dhivehi
+        Dogri
+        Dutch
+        Dzongkha
+        Eastern Mari
+        English
+        Esperanto
+        Estonian
+        Ewe
+        Faroese
+        Fijian
+        Filipino
+        Finnish
+        French
+        French (Canadian)
+        Frisian
+        Galician
+        Georgian
+        German
+        Greek
+        Greenlandic
+        Guarani
+        Gujarati
+        Haitian Creole
+        Hausa
+        Hawaiian
+        Hebrew
+        Hill Mari
+        Hindi
+        Hmong
+        Hungarian
+        Icelandic
+        Igbo
+        Ilocano
+        Indonesian
+        Interlingue
+        Inuinnaqtun
+        Inuktitut
+        Inuktitut (Latin)
+        Irish
+        Italian
+        Japanese
+        Javanese
+        Kannada
+        Kazakh
+        Khmer
+        Kinyarwanda
+        Klingon
+        Konkani
+        Korean
+        Krio
+        Kurdish (Central)
+        Kurdish (Northern)
+        Kyrgyz
+        Lao
+        Latin
+        Latvian
+        Lingala
+        Lithuanian
+        Luganda
+        Luxembourgish
+        Macedonian
+        Maithili
+        Malagasy
+        Malay
+        Malayalam
+        Maltese
+        Maori
+        Marathi
+        Meiteilon
+        Mizo
+        Mongolian
+        Mongolian (Traditional)
+        Myanmar
+        Nepali
+        Norwegian
+        Occitan
+        Odia
+        Oromo
+        Papiamento
+        Pashto
+        Persian
+        Polish
+        Portuguese (Brazilian)
+        Portuguese (European)
+        Punjabi
+        Quechua
+        Querétaro Otomi
+        Romanian
+        Romansh
+        Russian
+        Samoan
+        Sanskrit
+        Scots Gaelic
+        Sepedi
+        Serbian (Cyrillic)
+        Serbian (Latin)
+        Sesotho
+        Setswana
+        Shona
+        Sindhi
+        Sinhala
+        Slovak
+        Slovenian
+        Somali
+        Spanish
+        Sundanese
+        Swahili
+        Swedish
+        Tahitian
+        Tajik
+        Tamil
+        Tatar
+        Telugu
+        Thai
+        Tibetan
+        Tigrinya
+        Tongan
+        Tsonga
+        Turkish
+        Turkmen
+        Twi
+        Udmurt
+        Ukrainian
+        Upper Sorbian
+        Urdu
+        Uyghur
+        Uzbek
+        Vietnamese
+        Volapük
+        Welsh
+        Wolof
+        Xhosa
+        Yakut
+        Yiddish
+        Yoruba
+        Yucatec Maya
+        Zulu
+        
+
 matches:
   - trigger: "::trans"
     label: "Translate"
@@ -7,9 +183,33 @@ matches:
         type: form
         params:
           layout: |
-            source:
-            [[source]]
+            Target:
+            [[target]]
+            Text:
+            [[text]]
+          fields:
             target:
+              type: choice
+              default: English
+              values:
+                "{{lang}}"
+
+      - name: "output"
+        type: shell
+        params:
+          cmd: "trans -b -t '{{input.target}}' '{{input.text}}'"
+
+  - trigger: "::etrans"
+    label: "Extended Translate"
+    replace: "{{output}}"
+    vars:
+      - name: "input"
+        type: form
+        params:
+          layout: |
+            Source:
+            [[source]]
+            Target:
             [[target]]
             Text:
             [[text]]
@@ -18,349 +218,13 @@ matches:
               type: choice
               default: German
               values:
-                - Afrikaans
-                - Albanian
-                - Amharic
-                - Arabic
-                - Armenian
-                - Assamese
-                - Aymara
-                - Azerbaijani
-                - Bambara
-                - Bashkir
-                - Basque
-                - Belarusian
-                - Bengali
-                - Bhojpuri
-                - Bosnian
-                - Breton
-                - Bulgarian
-                - Cantonese
-                - Catalan
-                - Cebuano
-                - Cherokee
-                - Chichewa
-                - Chinese (Literary)
-                - Chinese (Simplified)
-                - Chinese (Traditional)
-                - Chuvash
-                - Corsican
-                - Croatian
-                - Czech
-                - Danish
-                - Dari
-                - Dhivehi
-                - Dogri
-                - Dutch
-                - Dzongkha
-                - Eastern Mari
-                - English
-                - Esperanto
-                - Estonian
-                - Ewe
-                - Faroese
-                - Fijian
-                - Filipino
-                - Finnish
-                - French
-                - French (Canadian)
-                - Frisian
-                - Galician
-                - Georgian
-                - German
-                - Greek
-                - Greenlandic
-                - Guarani
-                - Gujarati
-                - Haitian Creole
-                - Hausa
-                - Hawaiian
-                - Hebrew
-                - Hill Mari
-                - Hindi
-                - Hmong
-                - Hungarian
-                - Icelandic
-                - Igbo
-                - Ilocano
-                - Indonesian
-                - Interlingue
-                - Inuinnaqtun
-                - Inuktitut
-                - Inuktitut (Latin)
-                - Irish
-                - Italian
-                - Japanese
-                - Javanese
-                - Kannada
-                - Kazakh
-                - Khmer
-                - Kinyarwanda
-                - Klingon
-                - Konkani
-                - Korean
-                - Krio
-                - Kurdish (Central)
-                - Kurdish (Northern)
-                - Kyrgyz
-                - Lao
-                - Latin
-                - Latvian
-                - Lingala
-                - Lithuanian
-                - Luganda
-                - Luxembourgish
-                - Macedonian
-                - Maithili
-                - Malagasy
-                - Malay
-                - Malayalam
-                - Maltese
-                - Maori
-                - Marathi
-                - Meiteilon
-                - Mizo
-                - Mongolian
-                - Mongolian (Traditional)
-                - Myanmar
-                - Nepali
-                - Norwegian
-                - Occitan
-                - Odia
-                - Oromo
-                - Papiamento
-                - Pashto
-                - Persian
-                - Polish
-                - Portuguese (Brazilian)
-                - Portuguese (European)
-                - Punjabi
-                - Quechua
-                - Querétaro Otomi
-                - Romanian
-                - Romansh
-                - Russian
-                - Samoan
-                - Sanskrit
-                - Scots Gaelic
-                - Sepedi
-                - Serbian (Cyrillic)
-                - Serbian (Latin)
-                - Sesotho
-                - Setswana
-                - Shona
-                - Sindhi
-                - Sinhala
-                - Slovak
-                - Slovenian
-                - Somali
-                - Spanish
-                - Sundanese
-                - Swahili
-                - Swedish
-                - Tahitian
-                - Tajik
-                - Tamil
-                - Tatar
-                - Telugu
-                - Thai
-                - Tibetan
-                - Tigrinya
-                - Tongan
-                - Tsonga
-                - Turkish
-                - Turkmen
-                - Twi
-                - Udmurt
-                - Ukrainian
-                - Upper Sorbian
-                - Urdu
-                - Uyghur
-                - Uzbek
-                - Vietnamese
-                - Volapük
-                - Welsh
-                - Wolof
-                - Xhosa
-                - Yakut
-                - Yiddish
-                - Yoruba
-                - Yucatec Maya
-                - Zulu
+                "{{lang}}"
               default: German
             target:
               type: choice
               default: English
               values:
-                - Afrikaans
-                - Albanian
-                - Amharic
-                - Arabic
-                - Armenian
-                - Assamese
-                - Aymara
-                - Azerbaijani
-                - Bambara
-                - Bashkir
-                - Basque
-                - Belarusian
-                - Bengali
-                - Bhojpuri
-                - Bosnian
-                - Breton
-                - Bulgarian
-                - Cantonese
-                - Catalan
-                - Cebuano
-                - Cherokee
-                - Chichewa
-                - Chinese (Literary)
-                - Chinese (Simplified)
-                - Chinese (Traditional)
-                - Chuvash
-                - Corsican
-                - Croatian
-                - Czech
-                - Danish
-                - Dari
-                - Dhivehi
-                - Dogri
-                - Dutch
-                - Dzongkha
-                - Eastern Mari
-                - English
-                - Esperanto
-                - Estonian
-                - Ewe
-                - Faroese
-                - Fijian
-                - Filipino
-                - Finnish
-                - French
-                - French (Canadian)
-                - Frisian
-                - Galician
-                - Georgian
-                - German
-                - Greek
-                - Greenlandic
-                - Guarani
-                - Gujarati
-                - Haitian Creole
-                - Hausa
-                - Hawaiian
-                - Hebrew
-                - Hill Mari
-                - Hindi
-                - Hmong
-                - Hungarian
-                - Icelandic
-                - Igbo
-                - Ilocano
-                - Indonesian
-                - Interlingue
-                - Inuinnaqtun
-                - Inuktitut
-                - Inuktitut (Latin)
-                - Irish
-                - Italian
-                - Japanese
-                - Javanese
-                - Kannada
-                - Kazakh
-                - Khmer
-                - Kinyarwanda
-                - Klingon
-                - Konkani
-                - Korean
-                - Krio
-                - Kurdish (Central)
-                - Kurdish (Northern)
-                - Kyrgyz
-                - Lao
-                - Latin
-                - Latvian
-                - Lingala
-                - Lithuanian
-                - Luganda
-                - Luxembourgish
-                - Macedonian
-                - Maithili
-                - Malagasy
-                - Malay
-                - Malayalam
-                - Maltese
-                - Maori
-                - Marathi
-                - Meiteilon
-                - Mizo
-                - Mongolian
-                - Mongolian (Traditional)
-                - Myanmar
-                - Nepali
-                - Norwegian
-                - Occitan
-                - Odia
-                - Oromo
-                - Papiamento
-                - Pashto
-                - Persian
-                - Polish
-                - Portuguese (Brazilian)
-                - Portuguese (European)
-                - Punjabi
-                - Quechua
-                - Querétaro Otomi
-                - Romanian
-                - Romansh
-                - Russian
-                - Samoan
-                - Sanskrit
-                - Scots Gaelic
-                - Sepedi
-                - Serbian (Cyrillic)
-                - Serbian (Latin)
-                - Sesotho
-                - Setswana
-                - Shona
-                - Sindhi
-                - Sinhala
-                - Slovak
-                - Slovenian
-                - Somali
-                - Spanish
-                - Sundanese
-                - Swahili
-                - Swedish
-                - Tahitian
-                - Tajik
-                - Tamil
-                - Tatar
-                - Telugu
-                - Thai
-                - Tibetan
-                - Tigrinya
-                - Tongan
-                - Tsonga
-                - Turkish
-                - Turkmen
-                - Twi
-                - Udmurt
-                - Ukrainian
-                - Upper Sorbian
-                - Urdu
-                - Uyghur
-                - Uzbek
-                - Vietnamese
-                - Volapük
-                - Welsh
-                - Wolof
-                - Xhosa
-                - Yakut
-                - Yiddish
-                - Yoruba
-                - Yucatec Maya
-                - Zulu
+                "{{lang}}"
             text:
               multiline: true
 

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -16,350 +16,351 @@ matches:
           fields:
             source:
               type: choice
+              default: German
               values:
                 - Afrikaans
+                - Albanian
                 - Amharic
                 - Arabic
+                - Armenian
                 - Assamese
                 - Aymara
                 - Azerbaijani
-                - Bashkir
-                - Belarusian
-                - Bulgarian
-                - Bhojpuri
                 - Bambara
+                - Bashkir
+                - Basque
+                - Belarusian
                 - Bengali
-                - Tibetan
-                - Breton
+                - Bhojpuri
                 - Bosnian
+                - Breton
+                - Bulgarian
+                - Cantonese
                 - Catalan
                 - Cebuano
                 - Cherokee
-                - Kurdish (Central)
-                - Corsican
-                - Czech
+                - Chichewa
+                - Chinese (Literary)
+                - Chinese (Simplified)
+                - Chinese (Traditional)
                 - Chuvash
-                - Welsh
+                - Corsican
+                - Croatian
+                - Czech
                 - Danish
-                - German
-                - Dogri
+                - Dari
                 - Dhivehi
+                - Dogri
+                - Dutch
                 - Dzongkha
-                - Ewe
-                - Greek
+                - Eastern Mari
                 - English
                 - Esperanto
-                - Spanish
                 - Estonian
-                - Basque
-                - Persian
-                - Finnish
-                - Fijian
+                - Ewe
                 - Faroese
+                - Fijian
+                - Filipino
+                - Finnish
                 - French
                 - French (Canadian)
                 - Frisian
-                - Irish
-                - Scots Gaelic
                 - Galician
+                - Georgian
+                - German
+                - Greek
+                - Greenlandic
                 - Guarani
-                - Konkani
                 - Gujarati
+                - Haitian Creole
                 - Hausa
                 - Hawaiian
                 - Hebrew
+                - Hill Mari
                 - Hindi
                 - Hmong
-                - Croatian
-                - Upper Sorbian
-                - Haitian Creole
                 - Hungarian
-                - Armenian
+                - Icelandic
+                - Igbo
+                - Ilocano
                 - Indonesian
                 - Interlingue
-                - Igbo
                 - Inuinnaqtun
-                - Ilocano
-                - Icelandic
-                - Italian
                 - Inuktitut
                 - Inuktitut (Latin)
+                - Irish
+                - Italian
                 - Japanese
                 - Javanese
-                - Georgian
-                - Kazakh
-                - Greenlandic
-                - Khmer
                 - Kannada
+                - Kazakh
+                - Khmer
+                - Kinyarwanda
+                - Klingon
+                - Konkani
                 - Korean
                 - Krio
+                - Kurdish (Central)
                 - Kurdish (Northern)
                 - Kyrgyz
-                - Latin
-                - Luxembourgish
-                - Luganda
-                - Lingala
                 - Lao
-                - Lithuanian
-                - Mizo
+                - Latin
                 - Latvian
-                - Chinese (Literary)
+                - Lingala
+                - Lithuanian
+                - Luganda
+                - Luxembourgish
+                - Macedonian
                 - Maithili
                 - Malagasy
-                - Eastern Mari
-                - Maori
-                - Macedonian
+                - Malay
                 - Malayalam
+                - Maltese
+                - Maori
+                - Marathi
+                - Meiteilon
+                - Mizo
                 - Mongolian
                 - Mongolian (Traditional)
-                - Meiteilon
-                - Marathi
-                - Hill Mari
-                - Malay
-                - Maltese
                 - Myanmar
                 - Nepali
-                - Dutch
                 - Norwegian
-                - Sepedi
-                - Chichewa
                 - Occitan
-                - Oromo
                 - Odia
-                - Querétaro Otomi
-                - Punjabi
+                - Oromo
                 - Papiamento
-                - Polish
-                - Dari
                 - Pashto
+                - Persian
+                - Polish
                 - Portuguese (Brazilian)
                 - Portuguese (European)
+                - Punjabi
                 - Quechua
-                - Romansh
+                - Querétaro Otomi
                 - Romanian
+                - Romansh
                 - Russian
-                - Kinyarwanda
+                - Samoan
                 - Sanskrit
-                - Yakut
+                - Scots Gaelic
+                - Sepedi
+                - Serbian (Cyrillic)
+                - Serbian (Latin)
+                - Sesotho
+                - Setswana
+                - Shona
                 - Sindhi
                 - Sinhala
                 - Slovak
                 - Slovenian
-                - Samoan
-                - Shona
                 - Somali
-                - Albanian
-                - Serbian (Cyrillic)
-                - Serbian (Latin)
-                - Sesotho
+                - Spanish
                 - Sundanese
-                - Swedish
                 - Swahili
-                - Tamil
-                - Telugu
-                - Tajik
-                - Thai
-                - Tigrinya
-                - Turkmen
-                - Filipino
-                - Klingon
-                - Setswana
-                - Tongan
-                - Turkish
-                - Tsonga
-                - Tatar
-                - Twi
+                - Swedish
                 - Tahitian
+                - Tajik
+                - Tamil
+                - Tatar
+                - Telugu
+                - Thai
+                - Tibetan
+                - Tigrinya
+                - Tongan
+                - Tsonga
+                - Turkish
+                - Turkmen
+                - Twi
                 - Udmurt
-                - Uyghur
                 - Ukrainian
+                - Upper Sorbian
                 - Urdu
+                - Uyghur
                 - Uzbek
                 - Vietnamese
                 - Volapük
+                - Welsh
                 - Wolof
                 - Xhosa
+                - Yakut
                 - Yiddish
                 - Yoruba
                 - Yucatec Maya
-                - Cantonese
-                - Chinese (Simplified)
-                - Chinese (Traditional)
                 - Zulu
               default: German
             target:
               type: choice
+              default: English
               values:
                 - Afrikaans
+                - Albanian
                 - Amharic
                 - Arabic
+                - Armenian
                 - Assamese
                 - Aymara
                 - Azerbaijani
-                - Bashkir
-                - Belarusian
-                - Bulgarian
-                - Bhojpuri
                 - Bambara
+                - Bashkir
+                - Basque
+                - Belarusian
                 - Bengali
-                - Tibetan
-                - Breton
+                - Bhojpuri
                 - Bosnian
+                - Breton
+                - Bulgarian
+                - Cantonese
                 - Catalan
                 - Cebuano
                 - Cherokee
-                - Kurdish (Central)
-                - Corsican
-                - Czech
+                - Chichewa
+                - Chinese (Literary)
+                - Chinese (Simplified)
+                - Chinese (Traditional)
                 - Chuvash
-                - Welsh
+                - Corsican
+                - Croatian
+                - Czech
                 - Danish
-                - German
-                - Dogri
+                - Dari
                 - Dhivehi
+                - Dogri
+                - Dutch
                 - Dzongkha
-                - Ewe
-                - Greek
+                - Eastern Mari
                 - English
                 - Esperanto
-                - Spanish
                 - Estonian
-                - Basque
-                - Persian
-                - Finnish
-                - Fijian
+                - Ewe
                 - Faroese
+                - Fijian
+                - Filipino
+                - Finnish
                 - French
                 - French (Canadian)
                 - Frisian
-                - Irish
-                - Scots Gaelic
                 - Galician
+                - Georgian
+                - German
+                - Greek
+                - Greenlandic
                 - Guarani
-                - Konkani
                 - Gujarati
+                - Haitian Creole
                 - Hausa
                 - Hawaiian
                 - Hebrew
+                - Hill Mari
                 - Hindi
                 - Hmong
-                - Croatian
-                - Upper Sorbian
-                - Haitian Creole
                 - Hungarian
-                - Armenian
+                - Icelandic
+                - Igbo
+                - Ilocano
                 - Indonesian
                 - Interlingue
-                - Igbo
                 - Inuinnaqtun
-                - Ilocano
-                - Icelandic
-                - Italian
                 - Inuktitut
                 - Inuktitut (Latin)
+                - Irish
+                - Italian
                 - Japanese
                 - Javanese
-                - Georgian
-                - Kazakh
-                - Greenlandic
-                - Khmer
                 - Kannada
+                - Kazakh
+                - Khmer
+                - Kinyarwanda
+                - Klingon
+                - Konkani
                 - Korean
                 - Krio
+                - Kurdish (Central)
                 - Kurdish (Northern)
                 - Kyrgyz
-                - Latin
-                - Luxembourgish
-                - Luganda
-                - Lingala
                 - Lao
-                - Lithuanian
-                - Mizo
+                - Latin
                 - Latvian
-                - Chinese (Literary)
+                - Lingala
+                - Lithuanian
+                - Luganda
+                - Luxembourgish
+                - Macedonian
                 - Maithili
                 - Malagasy
-                - Eastern Mari
-                - Maori
-                - Macedonian
+                - Malay
                 - Malayalam
+                - Maltese
+                - Maori
+                - Marathi
+                - Meiteilon
+                - Mizo
                 - Mongolian
                 - Mongolian (Traditional)
-                - Meiteilon
-                - Marathi
-                - Hill Mari
-                - Malay
-                - Maltese
                 - Myanmar
                 - Nepali
-                - Dutch
                 - Norwegian
-                - Sepedi
-                - Chichewa
                 - Occitan
-                - Oromo
                 - Odia
-                - Querétaro Otomi
-                - Punjabi
+                - Oromo
                 - Papiamento
-                - Polish
-                - Dari
                 - Pashto
+                - Persian
+                - Polish
                 - Portuguese (Brazilian)
                 - Portuguese (European)
+                - Punjabi
                 - Quechua
-                - Romansh
+                - Querétaro Otomi
                 - Romanian
+                - Romansh
                 - Russian
-                - Kinyarwanda
+                - Samoan
                 - Sanskrit
-                - Yakut
+                - Scots Gaelic
+                - Sepedi
+                - Serbian (Cyrillic)
+                - Serbian (Latin)
+                - Sesotho
+                - Setswana
+                - Shona
                 - Sindhi
                 - Sinhala
                 - Slovak
                 - Slovenian
-                - Samoan
-                - Shona
                 - Somali
-                - Albanian
-                - Serbian (Cyrillic)
-                - Serbian (Latin)
-                - Sesotho
+                - Spanish
                 - Sundanese
-                - Swedish
                 - Swahili
-                - Tamil
-                - Telugu
-                - Tajik
-                - Thai
-                - Tigrinya
-                - Turkmen
-                - Filipino
-                - Klingon
-                - Setswana
-                - Tongan
-                - Turkish
-                - Tsonga
-                - Tatar
-                - Twi
+                - Swedish
                 - Tahitian
+                - Tajik
+                - Tamil
+                - Tatar
+                - Telugu
+                - Thai
+                - Tibetan
+                - Tigrinya
+                - Tongan
+                - Tsonga
+                - Turkish
+                - Turkmen
+                - Twi
                 - Udmurt
-                - Uyghur
                 - Ukrainian
+                - Upper Sorbian
                 - Urdu
+                - Uyghur
                 - Uzbek
                 - Vietnamese
                 - Volapük
+                - Welsh
                 - Wolof
                 - Xhosa
+                - Yakut
                 - Yiddish
                 - Yoruba
                 - Yucatec Maya
-                - Cantonese
-                - Chinese (Simplified)
-                - Chinese (Traditional)
                 - Zulu
-              default: English
             text:
               multiline: true
 

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -60,6 +60,7 @@ matches:
         type: shell
         params:
           cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}'"
+          shell: wsl
 
 global_vars:
   - name: lang

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -1,3 +1,62 @@
+matches:
+  - trigger: "::trans"
+    label: "Translate"
+    replace: "{{output}}"
+    vars:
+      - name: "input"
+        type: form
+        params:
+          layout: |
+            Target:
+            [[target]]
+            Text:
+            [[text]]
+          fields:
+            target:
+              type: choice
+              default: "{{targetlang}}"
+              values:
+                "{{lang}}"
+
+      - name: "output"
+        type: shell
+        params:
+          cmd: "trans -b -t '{{input.target}}' '{{input.text}}'"
+
+  - trigger: "::etrans"
+    label: "Extended Translate"
+    replace: "{{output}}"
+    vars:
+      - name: "input"
+        type: form
+        params:
+          layout: |
+            Source:
+            [[source]]
+            Target:
+            [[target]]
+            Text:
+            [[text]]
+          fields:
+            source:
+              type: choice
+              default: German
+              values:
+                "{{lang}}"
+              default: "{{sourcelang}}"
+            target:
+              type: choice
+              default: "{{targetlang}}"
+              values:
+                "{{lang}}"
+            text:
+              multiline: true
+
+      - name: "output"
+        type: shell
+        params:
+          cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}'"
+
 global_vars:
   - name: lang
     type: echo
@@ -172,63 +231,3 @@ global_vars:
         Yoruba
         Yucatec Maya
         Zulu
-        
-
-matches:
-  - trigger: "::trans"
-    label: "Translate"
-    replace: "{{output}}"
-    vars:
-      - name: "input"
-        type: form
-        params:
-          layout: |
-            Target:
-            [[target]]
-            Text:
-            [[text]]
-          fields:
-            target:
-              type: choice
-              default: English
-              values:
-                "{{lang}}"
-
-      - name: "output"
-        type: shell
-        params:
-          cmd: "trans -b -t '{{input.target}}' '{{input.text}}'"
-
-  - trigger: "::etrans"
-    label: "Extended Translate"
-    replace: "{{output}}"
-    vars:
-      - name: "input"
-        type: form
-        params:
-          layout: |
-            Source:
-            [[source]]
-            Target:
-            [[target]]
-            Text:
-            [[text]]
-          fields:
-            source:
-              type: choice
-              default: German
-              values:
-                "{{lang}}"
-              default: German
-            target:
-              type: choice
-              default: English
-              values:
-                "{{lang}}"
-            text:
-              multiline: true
-
-      - name: "output"
-        type: shell
-        params:
-          cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}'"

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -8,13 +8,13 @@ matches:
         params:
           layout: |
             source:
-            [[from]]
+            [[source]]
             target:
-            [[to]]
+            [[target]]
             Text:
             [[text]]
           fields:
-            from:
+            source:
               type: choice
               values:
                 - Afrikaans
@@ -186,7 +186,8 @@ matches:
                 - Chinese (Simplified)
                 - Chinese (Traditional)
                 - Zulu
-            to:
+              default: German
+            target:
               type: choice
               values:
                 - Afrikaans
@@ -358,10 +359,11 @@ matches:
                 - Chinese (Simplified)
                 - Chinese (Traditional)
                 - Zulu
+              default: English
             text:
               multiline: true
 
       - name: "output"
         type: shell
         params:
-          cmd: "trans -b -s {{input.from}} -t {{input.to}} '{{input.text}}'"
+          cmd: "trans -b -s '{{input.source}}' -t '{{input.target}}' '{{input.text}}'"

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -18,6 +18,8 @@ matches:
                 "{{targetlang}}"
               values:
                 "{{lang}}"
+            text:
+              multiline: true
 
       - name: "output"
         type: shell
@@ -41,10 +43,10 @@ matches:
           fields:
             source:
               type: choice
-              values:
-                "{{lang}}"
               default: 
                 "{{sourcelang}}"
+              values:
+                "{{lang}}"
             target:
               type: choice
               default: 

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -7,10 +7,10 @@ matches:
         type: form
         params:
           layout: |
-            Target:
-            [[target]]
             Text:
             [[text]]
+            Target:
+            [[target]]
           fields:
             target:
               type: choice
@@ -35,12 +35,12 @@ matches:
         type: form
         params:
           layout: |
+            Text:
+            [[text]]
             Source:
             [[source]]
             Target:
             [[target]]
-            Text:
-            [[text]]
           fields:
             source:
               type: choice

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -1,0 +1,367 @@
+matches:
+  - trigger: "::trans"
+    label: "Translate"
+    replace: "{{output}}"
+    vars:
+      - name: "input"
+        type: form
+        params:
+          layout: |
+            fr:
+            [[from]]
+            to:
+            [[to]]
+            Text:
+            [[text]]
+          fields:
+            from:
+              type: choice
+              values:
+                - Afrikaans
+                - Amharic
+                - Arabic
+                - Assamese
+                - Aymara
+                - Azerbaijani
+                - Bashkir
+                - Belarusian
+                - Bulgarian
+                - Bhojpuri
+                - Bambara
+                - Bengali
+                - Tibetan
+                - Breton
+                - Bosnian
+                - Catalan
+                - Cebuano
+                - Cherokee
+                - Kurdish (Central)
+                - Corsican
+                - Czech
+                - Chuvash
+                - Welsh
+                - Danish
+                - German
+                - Dogri
+                - Dhivehi
+                - Dzongkha
+                - Ewe
+                - Greek
+                - English
+                - Esperanto
+                - Spanish
+                - Estonian
+                - Basque
+                - Persian
+                - Finnish
+                - Fijian
+                - Faroese
+                - French
+                - French (Canadian)
+                - Frisian
+                - Irish
+                - Scots Gaelic
+                - Galician
+                - Guarani
+                - Konkani
+                - Gujarati
+                - Hausa
+                - Hawaiian
+                - Hebrew
+                - Hindi
+                - Hmong
+                - Croatian
+                - Upper Sorbian
+                - Haitian Creole
+                - Hungarian
+                - Armenian
+                - Indonesian
+                - Interlingue
+                - Igbo
+                - Inuinnaqtun
+                - Ilocano
+                - Icelandic
+                - Italian
+                - Inuktitut
+                - Inuktitut (Latin)
+                - Japanese
+                - Javanese
+                - Georgian
+                - Kazakh
+                - Greenlandic
+                - Khmer
+                - Kannada
+                - Korean
+                - Krio
+                - Kurdish (Northern)
+                - Kyrgyz
+                - Latin
+                - Luxembourgish
+                - Luganda
+                - Lingala
+                - Lao
+                - Lithuanian
+                - Mizo
+                - Latvian
+                - Chinese (Literary)
+                - Maithili
+                - Malagasy
+                - Eastern Mari
+                - Maori
+                - Macedonian
+                - Malayalam
+                - Mongolian
+                - Mongolian (Traditional)
+                - Meiteilon
+                - Marathi
+                - Hill Mari
+                - Malay
+                - Maltese
+                - Myanmar
+                - Nepali
+                - Dutch
+                - Norwegian
+                - Sepedi
+                - Chichewa
+                - Occitan
+                - Oromo
+                - Odia
+                - Querétaro Otomi
+                - Punjabi
+                - Papiamento
+                - Polish
+                - Dari
+                - Pashto
+                - Portuguese (Brazilian)
+                - Portuguese (European)
+                - Quechua
+                - Romansh
+                - Romanian
+                - Russian
+                - Kinyarwanda
+                - Sanskrit
+                - Yakut
+                - Sindhi
+                - Sinhala
+                - Slovak
+                - Slovenian
+                - Samoan
+                - Shona
+                - Somali
+                - Albanian
+                - Serbian (Cyrillic)
+                - Serbian (Latin)
+                - Sesotho
+                - Sundanese
+                - Swedish
+                - Swahili
+                - Tamil
+                - Telugu
+                - Tajik
+                - Thai
+                - Tigrinya
+                - Turkmen
+                - Filipino
+                - Klingon
+                - Setswana
+                - Tongan
+                - Turkish
+                - Tsonga
+                - Tatar
+                - Twi
+                - Tahitian
+                - Udmurt
+                - Uyghur
+                - Ukrainian
+                - Urdu
+                - Uzbek
+                - Vietnamese
+                - Volapük
+                - Wolof
+                - Xhosa
+                - Yiddish
+                - Yoruba
+                - Yucatec Maya
+                - Cantonese
+                - Chinese (Simplified)
+                - Chinese (Traditional)
+                - Zulu
+            to:
+              type: choice
+              values:
+                - Afrikaans
+                - Amharic
+                - Arabic
+                - Assamese
+                - Aymara
+                - Azerbaijani
+                - Bashkir
+                - Belarusian
+                - Bulgarian
+                - Bhojpuri
+                - Bambara
+                - Bengali
+                - Tibetan
+                - Breton
+                - Bosnian
+                - Catalan
+                - Cebuano
+                - Cherokee
+                - Kurdish (Central)
+                - Corsican
+                - Czech
+                - Chuvash
+                - Welsh
+                - Danish
+                - German
+                - Dogri
+                - Dhivehi
+                - Dzongkha
+                - Ewe
+                - Greek
+                - English
+                - Esperanto
+                - Spanish
+                - Estonian
+                - Basque
+                - Persian
+                - Finnish
+                - Fijian
+                - Faroese
+                - French
+                - French (Canadian)
+                - Frisian
+                - Irish
+                - Scots Gaelic
+                - Galician
+                - Guarani
+                - Konkani
+                - Gujarati
+                - Hausa
+                - Hawaiian
+                - Hebrew
+                - Hindi
+                - Hmong
+                - Croatian
+                - Upper Sorbian
+                - Haitian Creole
+                - Hungarian
+                - Armenian
+                - Indonesian
+                - Interlingue
+                - Igbo
+                - Inuinnaqtun
+                - Ilocano
+                - Icelandic
+                - Italian
+                - Inuktitut
+                - Inuktitut (Latin)
+                - Japanese
+                - Javanese
+                - Georgian
+                - Kazakh
+                - Greenlandic
+                - Khmer
+                - Kannada
+                - Korean
+                - Krio
+                - Kurdish (Northern)
+                - Kyrgyz
+                - Latin
+                - Luxembourgish
+                - Luganda
+                - Lingala
+                - Lao
+                - Lithuanian
+                - Mizo
+                - Latvian
+                - Chinese (Literary)
+                - Maithili
+                - Malagasy
+                - Eastern Mari
+                - Maori
+                - Macedonian
+                - Malayalam
+                - Mongolian
+                - Mongolian (Traditional)
+                - Meiteilon
+                - Marathi
+                - Hill Mari
+                - Malay
+                - Maltese
+                - Myanmar
+                - Nepali
+                - Dutch
+                - Norwegian
+                - Sepedi
+                - Chichewa
+                - Occitan
+                - Oromo
+                - Odia
+                - Querétaro Otomi
+                - Punjabi
+                - Papiamento
+                - Polish
+                - Dari
+                - Pashto
+                - Portuguese (Brazilian)
+                - Portuguese (European)
+                - Quechua
+                - Romansh
+                - Romanian
+                - Russian
+                - Kinyarwanda
+                - Sanskrit
+                - Yakut
+                - Sindhi
+                - Sinhala
+                - Slovak
+                - Slovenian
+                - Samoan
+                - Shona
+                - Somali
+                - Albanian
+                - Serbian (Cyrillic)
+                - Serbian (Latin)
+                - Sesotho
+                - Sundanese
+                - Swedish
+                - Swahili
+                - Tamil
+                - Telugu
+                - Tajik
+                - Thai
+                - Tigrinya
+                - Turkmen
+                - Filipino
+                - Klingon
+                - Setswana
+                - Tongan
+                - Turkish
+                - Tsonga
+                - Tatar
+                - Twi
+                - Tahitian
+                - Udmurt
+                - Uyghur
+                - Ukrainian
+                - Urdu
+                - Uzbek
+                - Vietnamese
+                - Volapük
+                - Wolof
+                - Xhosa
+                - Yiddish
+                - Yoruba
+                - Yucatec Maya
+                - Cantonese
+                - Chinese (Simplified)
+                - Chinese (Traditional)
+                - Zulu
+            text:
+              multiline: true
+
+      - name: "output"
+        type: shell
+        params:
+          cmd: "trans -b -s {{input.from}} -t {{input.to}} '{{input.text}}'"

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -14,7 +14,8 @@ matches:
           fields:
             target:
               type: choice
-              default: "{{targetlang}}"
+              default: 
+                "{{targetlang}}"
               values:
                 "{{lang}}"
 
@@ -40,13 +41,14 @@ matches:
           fields:
             source:
               type: choice
-              default: German
               values:
                 "{{lang}}"
-              default: "{{sourcelang}}"
+              default: 
+                "{{sourcelang}}"
             target:
               type: choice
-              default: "{{targetlang}}"
+              default: 
+                "{{targetlang}}"
               values:
                 "{{lang}}"
             text:

--- a/packages/quick-translate/0.1.0/package.yml
+++ b/packages/quick-translate/0.1.0/package.yml
@@ -7,9 +7,9 @@ matches:
         type: form
         params:
           layout: |
-            fr:
+            source:
             [[from]]
-            to:
+            target:
             [[to]]
             Text:
             [[text]]


### PR DESCRIPTION
This expansion uses the [translate-shell](https://github.com/soimort/translate-shell) CLI-tool to do in-line translations from and to many languages. The default source and target languages of the user can be defined within `defaultlang.yml` as this file serves as the global variable definition of them