### PR TITLE
:fire: remove posting comment section in CI

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -22,26 +22,4 @@ jobs:
       - name: "Publish report"
         if: always()
         run: cat validation_report.md >> $GITHUB_STEP_SUMMARY
-      - name: "Create Github comment body"
-        if: always()
-        run: |
-          import json
-          with open("validation_report.md", "r", encoding="utf-8") as input:
-            with open("body.json", "w", encoding="utf-8") as output:
-              output.write(json.dumps({"body": input.read()}))
-        shell: python
-      - name: Post report as Comment
-        if: always()
-        run: |
-          BRANCH=$(git branch --show-current)
-          if [ "$BRANCH" = "main" ]; then
-            echo "Skipping on main branch"
-            exit 0
-          fi
 
-          curl -sL  -X POST -d @body.json \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "$GITHUB_COMMENT_URL"
-        env:
-          GITHUB_COMMENT_URL: ${{ github.event.pull_request.comments_url }}


### PR DESCRIPTION
The comment isn't really useful, as you need to enter the Actions section anyway to read it
