### PR TITLE
New version of calc-macos

### DIFF
--- a/packages/calc-macos/0.1.1/README.md
+++ b/packages/calc-macos/0.1.1/README.md
@@ -1,0 +1,26 @@
+# espanso-calc-macos
+Basic calculation package for espanso that works in macOS.
+
+## Example
+
+![Screen Recording 2022-06-23 at 10 13 21](https://user-images.githubusercontent.com/23709916/175312182-e6372ce2-b296-4d5b-bdc0-a9d8543ab85e.gif)
+
+## Usage
+1. Type `:calc`
+2. You'll see a form, type the calculation
+  <img width="185" alt="image" src="https://user-images.githubusercontent.com/23709916/175305102-2453d39b-b7d8-45f2-8a42-9286a2ab2d25.png"></img>
+  3. The text will be replaced with the result
+
+## Commands
+
+| Command                    | Match  | Example       | Result     |
+|----------------------------|--------|---------------|------------|
+| Calculate                  | :calc  | Input: 10 - 3 | 7          |
+| Calculate and show account | :ecalc | Input: 10 - 3 | 10 - 3 = 7 |
+
+## Implementation
+
+This package uses `bc` to do the calculations
+```
+echo '10 * 4' | bc
+```

--- a/packages/calc-macos/0.1.1/_manifest.yml
+++ b/packages/calc-macos/0.1.1/_manifest.yml
@@ -1,0 +1,6 @@
+name: "calc-macos"
+title: "Calc Macos"
+description: Espanso package for doing basic arithmetic in the shell.
+version: 0.1.1
+author: Tashima42
+tags: ["utility", "math", "calculator"]

--- a/packages/calc-macos/0.1.1/package.yml
+++ b/packages/calc-macos/0.1.1/package.yml
@@ -1,0 +1,32 @@
+# Calculator
+
+name: calc-macos
+parent: default
+
+matches:
+  # Calculator
+  - trigger: ":calc"
+    replace: "{{solved}}"
+    vars:
+      - name: "input"
+        type: "form"
+        params: 
+          layout: |
+            [[val]]
+      - name: "solved"
+        type: shell
+        params: 
+          cmd: "echo '{{input.val}}' | bc"
+  # Calculator w/ input
+  - trigger: ":ecalc"
+    replace: "{{input.val}} = {{solved}}"
+    vars:
+      - name: "input"
+        type: "form"
+        params: 
+          layout: |
+            [[val]]
+      - name: "solved"
+        type: shell
+        params: 
+          cmd: "echo '{{input.val}}' | bc"


### PR DESCRIPTION
Version number updated to cause the hub to pick up the package. 
README.md already amended with a missing `</img>` tag added.