### PR TITLE
Blank Page For Discord-Snippets in Hubs

### DIFF
--- a/packages/discord-snippet/0.1.0/README.md
+++ b/packages/discord-snippet/0.1.0/README.md
@@ -36,5 +36,3 @@ Improve your Discord experience using this snippets triggers.
 | :dch            | <#$\|$>                                  | Channel Mention |
 | :dro            | <@&$\|$>                                 | Role Mention    |
 | :dli            | \[\$\|$\](Clipboard)                     | Masked Link     |
-
-<br>

--- a/packages/discord-snippet/0.1.0/_manifest.yml
+++ b/packages/discord-snippet/0.1.0/_manifest.yml
@@ -3,5 +3,5 @@ title: "Discord Snippets"
 description: A Collection of snippets for Discord Markdown
 version: 0.1.0
 author: Nathanel Moulin
-homepage: https://github.com/NathanelM/discord-snippet/tree/main
+homepage: "https://github.com/NathanelM/discord-snippet/tree/main"
 tags: ["utility", "discord", "markdown"]


### PR DESCRIPTION
Hi,
It's me again
It's appear that the hub page for my package is blank.
I suppose it's the missing "" for the link in HomePage.

![image](https://github.com/user-attachments/assets/5fa8c139-94d6-4b9f-9abe-242c44601304)
