### PR TITLE
Add package `linter-control-comments` (Golint, Rubocop/Ruby, Clippy/Rust and Shellcheck)

### DIFF
--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -1,11 +1,14 @@
 # Linter Control Comments
 
-A collection of linter control comments for
-[Golint](https://golangci-lint.run/)/Go,
-[Rubocop](https://rubocop.org)/Ruby,
-[Clippy](https://doc.rust-lang.org/stable/clippy/)/Rust,
-and [Shellcheck](https://www.shellcheck.net/)/Shell
-.
+A collection of linter control comments for:
+
+Language | Linter
+-- | --
+Go | [Golint](https://golangci-lint.run/)
+Ruby | [Rubocop](https://rubocop.org)
+Rust | [Clippy](https://doc.rust-lang.org/stable/clippy/)
+Shell | [Shellcheck](https://www.shellcheck.net/)
+
 
 ## Trigger composition
 

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -2,6 +2,7 @@
 
 A collection of linter control comments for
 [Rubocop](https://rubocop.org)/Ruby
+and [Clippy](https://doc.rust-lang.org/stable/clippy/)/Rust
 .
 
 ## Trigger composition
@@ -22,3 +23,7 @@ Trigger | Replace
 `#rcd` | `# rubocop:disable {clipboard}`
 `#rce` | `# rubocop:enable {clipboard}`
 `#rct` | `# rubocop:todo {clipboard}`
+`#cla` | `#[allow({clipboard})]`
+`#clw` | `#[warn({clipboard})]`
+`#cld` | `#[deny({clipboard})]`
+`#clp` | `#![deny(clippy::pedantic)]`

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -1,0 +1,17 @@
+# Linter Control Comments
+
+A collection of linter control comments for
+[Rubocop](https://rubocop.org).
+
+## Trigger composition
+
+Symbol | Why that one in particular?
+-- | --
+`#` | Comment symbol for the relevant language.
+`rb` | Abbreviated name of the linter, ideally following its syllables.
+`d` | First letter of the linter's keyword
+
+This hopefully helps to reuse existing muscle memory,
+from having already used these linters manually.
+
+## Espansions

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -9,6 +9,10 @@ Ruby | [Rubocop](https://rubocop.org)
 Rust | [Clippy](https://doc.rust-lang.org/stable/clippy/)
 Shell | [Shellcheck](https://www.shellcheck.net/)
 
+## How to use
+
+1. Copy a particular linting rule name (from docs, terminal output, etc.).
+1. Triggering the espansion. Most `replace`ments use the `{{clipboard}}`.
 
 ## Trigger composition
 

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -1,8 +1,9 @@
 # Linter Control Comments
 
 A collection of linter control comments for
-[Rubocop](https://rubocop.org)/Ruby
-and [Clippy](https://doc.rust-lang.org/stable/clippy/)/Rust
+[Rubocop](https://rubocop.org)/Ruby,
+[Clippy](https://doc.rust-lang.org/stable/clippy/)/Rust,
+and [Shellcheck](https://www.shellcheck.net/)/Shell
 .
 
 ## Trigger composition
@@ -27,3 +28,4 @@ Trigger | Replace
 `#clw` | `#[warn({clipboard})]`
 `#cld` | `#[deny({clipboard})]`
 `#clp` | `#![deny(clippy::pedantic)]`
+`#scd` | `# shellcheck disable={clipboard}`

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -1,6 +1,7 @@
 # Linter Control Comments
 
 A collection of linter control comments for
+[Golint](https://golangci-lint.run/)/Go,
 [Rubocop](https://rubocop.org)/Ruby,
 [Clippy](https://doc.rust-lang.org/stable/clippy/)/Rust,
 and [Shellcheck](https://www.shellcheck.net/)/Shell
@@ -21,6 +22,7 @@ from having already used these linters manually.
 
 Trigger | Replace
 -- | --
+`/nl` | `//nolint:{clipboard}`
 `#rcd` | `# rubocop:disable {clipboard}`
 `#rce` | `# rubocop:enable {clipboard}`
 `#rct` | `# rubocop:todo {clipboard}`

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -29,12 +29,13 @@ from having already used these linters manually.
 
 Trigger | Replace
 -- | --
-`/nl` | `//nolint:{clipboard}`
-`#rcd` | `# rubocop:disable {clipboard}`
-`#rce` | `# rubocop:enable {clipboard}`
-`#rct` | `# rubocop:todo {clipboard}`
-`#cla` | `#[allow({clipboard})]`
-`#clw` | `#[warn({clipboard})]`
-`#cld` | `#[deny({clipboard})]`
+`/nol` | `//nolint:{{clipboard}}`
+`/noa` | `//nolint:all`
+`#rcd` | `# rubocop:disable {{clipboard}}`
+`#rce` | `# rubocop:enable {{clipboard}}`
+`#rct` | `# rubocop:todo {{clipboard}}`
+`#cla` | `#[allow({{clipboard}})]`
+`#clw` | `#[warn({{clipboard}})]`
+`#cld` | `#[deny({{clipboard}})]`
 `#clp` | `#![deny(clippy::pedantic)]`
-`#scd` | `# shellcheck disable={clipboard}`
+`#scd` | `# shellcheck disable={{clipboard}}`

--- a/packages/linter-control-comments/0.1.0/README.md
+++ b/packages/linter-control-comments/0.1.0/README.md
@@ -1,7 +1,8 @@
 # Linter Control Comments
 
 A collection of linter control comments for
-[Rubocop](https://rubocop.org).
+[Rubocop](https://rubocop.org)/Ruby
+.
 
 ## Trigger composition
 
@@ -15,3 +16,9 @@ This hopefully helps to reuse existing muscle memory,
 from having already used these linters manually.
 
 ## Espansions
+
+Trigger | Replace
+-- | --
+`#rcd` | `# rubocop:disable {clipboard}`
+`#rce` | `# rubocop:enable {clipboard}`
+`#rct` | `# rubocop:todo {clipboard}`

--- a/packages/linter-control-comments/0.1.0/_manifest.yml
+++ b/packages/linter-control-comments/0.1.0/_manifest.yml
@@ -1,10 +1,11 @@
 name: "linter-control-comments"
 title: "Linter Control Comments"
-description: "A collection of linter control comments (currently: Rubocop, Clippy, and Shellcheck)"
+description: "A collection of linter control comments (currently: Golint, Rubocop, Clippy, and Shellcheck)"
 version: 0.1.0
 author: Katrin Leinweber
 tags:
   - "development"
+  - "go"
   - "ruby"
   - "rust"
   - "shell"

--- a/packages/linter-control-comments/0.1.0/_manifest.yml
+++ b/packages/linter-control-comments/0.1.0/_manifest.yml
@@ -1,9 +1,10 @@
 name: "linter-control-comments"
 title: "Linter Control Comments"
-description: "A collection of linter control comments (currently: Rubocop and Clippy)"
+description: "A collection of linter control comments (currently: Rubocop, Clippy, and Shellcheck)"
 version: 0.1.0
 author: Katrin Leinweber
 tags:
   - "development"
   - "ruby"
   - "rust"
+  - "shell"

--- a/packages/linter-control-comments/0.1.0/_manifest.yml
+++ b/packages/linter-control-comments/0.1.0/_manifest.yml
@@ -1,10 +1,12 @@
 name: "linter-control-comments"
 title: "Linter Control Comments"
 description: "A collection of linter control comments (currently: Golint, Rubocop, Clippy, and Shellcheck)"
+homepage: "https://github.com/katrinleinweber/espanso-hub/tree/package-linter-control-comments"
 version: 0.1.0
 author: Katrin Leinweber
 tags:
   - "development"
+  - "linter"
   - "go"
   - "ruby"
   - "rust"

--- a/packages/linter-control-comments/0.1.0/_manifest.yml
+++ b/packages/linter-control-comments/0.1.0/_manifest.yml
@@ -1,0 +1,8 @@
+name: "linter-control-comments"
+title: "Linter Control Comments"
+description: "A collection of linter control comments (currently: Rubocop)"
+version: 0.1.0
+author: Katrin Leinweber
+tags:
+  - "development"
+  - "ruby"

--- a/packages/linter-control-comments/0.1.0/_manifest.yml
+++ b/packages/linter-control-comments/0.1.0/_manifest.yml
@@ -1,8 +1,9 @@
 name: "linter-control-comments"
 title: "Linter Control Comments"
-description: "A collection of linter control comments (currently: Rubocop)"
+description: "A collection of linter control comments (currently: Rubocop and Clippy)"
 version: 0.1.0
 author: Katrin Leinweber
 tags:
   - "development"
   - "ruby"
+  - "rust"

--- a/packages/linter-control-comments/0.1.0/package.yml
+++ b/packages/linter-control-comments/0.1.0/package.yml
@@ -4,6 +4,13 @@ global_vars:
 
 matches:
 
+  ### Go
+  # https://golangci-lint.run/usage/false-positives/#nolint-directive
+  - trigger: "/nol"
+    replace: "//nolint:{{clipboard}}"
+  - trigger: "/noa"
+    replace: "//nolint:all"
+
   ### Ruby
   # https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code
   - trigger: "#rcd"

--- a/packages/linter-control-comments/0.1.0/package.yml
+++ b/packages/linter-control-comments/0.1.0/package.yml
@@ -11,4 +11,16 @@ matches:
   - trigger: "#rce"
     replace: "# rubocop:enable {{clipboard}}"
   - trigger: "#rct"
-    replace: "# rubocop:todo {clipboard}"
+    replace: "# rubocop:todo {{clipboard}}"
+
+  ### Rust
+  # https://doc.rust-lang.org/stable/clippy/usage.html#lint-configuration
+  # https://github.com/rust-lang/rust-clippy?tab=readme-ov-file#allowingdenying-lints
+  - trigger: "#cla"
+    replace: "#[allow({{clipboard}})]"
+  - trigger: "#clw"
+    replace: "#[warn({{clipboard}})]"
+  - trigger: "#cld"
+    replace: "#[deny({{clipboard}})]"
+  - trigger: "#clp"
+    replace: "#![deny(clippy::pedantic)]" # prone to false positives!

--- a/packages/linter-control-comments/0.1.0/package.yml
+++ b/packages/linter-control-comments/0.1.0/package.yml
@@ -6,3 +6,9 @@ matches:
 
   ### Ruby
   # https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code
+  - trigger: "#rcd"
+    replace: "# rubocop:disable {{clipboard}}"
+  - trigger: "#rce"
+    replace: "# rubocop:enable {{clipboard}}"
+  - trigger: "#rct"
+    replace: "# rubocop:todo {clipboard}"

--- a/packages/linter-control-comments/0.1.0/package.yml
+++ b/packages/linter-control-comments/0.1.0/package.yml
@@ -24,3 +24,8 @@ matches:
     replace: "#[deny({{clipboard}})]"
   - trigger: "#clp"
     replace: "#![deny(clippy::pedantic)]" # prone to false positives!
+
+  ### Shell
+  # https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#directives
+  - trigger: "#scd"
+    replace: "# shellcheck disable={{clipboard}}"

--- a/packages/linter-control-comments/0.1.0/package.yml
+++ b/packages/linter-control-comments/0.1.0/package.yml
@@ -1,0 +1,8 @@
+global_vars:
+  - name: "clipboard"
+    type: "clipboard"
+
+matches:
+
+  ### Ruby
+  # https://docs.rubocop.org/rubocop/configuration.html#disabling-cops-within-source-code


### PR DESCRIPTION
This is intended to provide editor-independent access to comments like `# rubocop:disable …`, `//nolint:…` etc. in order to control linter behaviour in source code files.

They make heavy use of the `{clipboard}`, into which one can copy a particular linting rule name (from docs, terminal output, etc.) before triggering the espansion.

Would this be a useful addition here?

*PS: The specific snippets are just a rough start. Not necessarily complete with respect to what their respective docs list as available, nor based on any analysis of real-world usage.*