### PR TITLE
Add homepage field to pkg template

### DIFF
--- a/packages/dummy-package/0.1.0/_manifest.yml
+++ b/packages/dummy-package/0.1.0/_manifest.yml
@@ -1,6 +1,7 @@
 name: "dummy-package"
 title: "Dummy package"
 description: A dummy package for testing
+homepage: "https://espanso.org/docs/packages/creating-a-package/#publish-on-the-hub-public"
 version: 0.1.0
 author: Federico Terzi
 tags: ["example"]


### PR DESCRIPTION
Follow-up to https://github.com/espanso/hub/pull/132#issuecomment-2408869971 as per:

> … we've had problems merging some packages where this is omitted

Should it be moved into the mandatory list in [package-specification.md@website](https://github.com/espanso/website/blob/7ff68ce0f81abe51fac1a13d66d21ff1b8286df1/docs/packages/package-specification.md#the-_manifestyml-file) as well?