### PR TITLE
Reworking of verbose-form-template package

### DIFF
--- a/packages/verbose-form-template/1.0.1/README.md
+++ b/packages/verbose-form-template/1.0.1/README.md
@@ -1,0 +1,58 @@
+# Espanso Form Extension Shortcut
+
+> This package allows you to quickly create a new Espanso shortcut containing a list Form extension. Please see the example below. 
+
+## Usage
+
+Let's say you want to create a new Espanso shortcut that will allow you to choose between different options such as a list of colors that you frequently use in styling. Or you have a list of co-worker logins that you need to use but can't always remember off-hand. You can use the Form extension to quickly generate a shortcut template to give you a list of options to choose from.
+
+Type `:vblf` (verbose list form) in your YAML code-editor and complete the information in the popup form. Once you click `Submit` a form trigger will be pasted in its place. Further edits, such as additional options, or changing the field `type:` to `choice`, can then be inserted.
+
+Please see [![espanso-verbose-form-template](https://img.youtube.com/vi/videoid/0.jpg)](https://www.youtube.com/watch?v=VEGv4aHV1d8)
+for a short video demo of an earlier version.
+
+```yaml
+# Example usage
+
+  - triggers: ['csscolors--', 'csscol--']
+    replace: "color:  {{CSS.color_name}}"
+    vars:
+      - name: "CSS"
+        type: form
+        params:
+          layout: "color_name: [[color_name]]" 
+          fields:
+            color_name:
+              type: list
+              values:
+              - red
+              - orange
+              - black
+              - white
+              - green
+              - blue
+              - purple
+              - pink
+              - yellow
+              - brown
+              - gray
+              - cyan
+              - magenta
+              - lime
+              - teal
+              - indigo
+              - violet
+              - fuchsia
+              - aqua
+              - maroon
+              - navy
+              - olive
+              - silver
+              - limegreen
+              - skyblue
+              - tan
+```
+
+## Source 
+
+Please refer to the awesome documentation for verbose syntax forms here https://espanso.org/docs/matches/forms/#controls-with-the-verbose-syntax

--- a/packages/verbose-form-template/1.0.1/_manifest.yml
+++ b/packages/verbose-form-template/1.0.1/_manifest.yml
@@ -1,0 +1,9 @@
+name: verbose-form-template
+title: A form trigger to generate form triggers!
+version: 1.0.1
+author: Omar Elmenawi, reworked by Stephen Meech
+description: Espanso shortcode to create espanso forms with the list extension
+tags: ["shortcut", "template", "form", "yml"]
+homepage: https://github.com/menawi/hub/tree/main/packages
+
+

--- a/packages/verbose-form-template/1.0.1/package.yml
+++ b/packages/verbose-form-template/1.0.1/package.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/dev/schemas/match.schema.json
+
+matches:
+
+# Description:
+#   - Allows you to specify:
+#     - form name
+#     - trigger
+#     - variable
+#     - replace
+#     - three starter list options
+
+  - trigger: ':vblf'
+    label: 'Espanso: Form - Verbose'
+    replace: |2-
+        - triggers: ['{{FORM.trigger}}']
+          replace: "{{FORM.replace}} {{{{FORM.form_name}}.{{FORM.variable}}}}"
+          vars:
+            - name: {{FORM.form_name}}
+              type: form
+              params:
+                layout: "{{FORM.variable}}: [[{{FORM.variable}}]]" 
+                fields:
+                  {{FORM.variable}}:
+                    type: list
+                    values:
+                    - {{FORM.list_option_one}}
+                    - {{FORM.list_option_two}}
+                    - {{FORM.list_option_three}}
+    vars:
+      - name: FORM
+        type: form
+        params:
+          layout: |-
+            Trigger: [[trigger]] Replace text: [[replace]] 
+            Form:
+            Name: [[form_name]] Variable: [[variable]]
+            Form list:        
+            Option one: [[list_option_one]] 
+            Option two: [[list_option_two]]
+            Option three: [[list_option_three]]
+


### PR DESCRIPTION
I liked what the original package could do, but following an initial dialogue with the author, we were still left with various issues in the original PR https://github.com/espanso/hub/pull/85/files#diff-e9a373201f8cc15904a47996833a6560bd9c676535441158e0cf832b61f2f309

I decided to rework it and:
- removed the original package whose name was prefixed with 'espanso-'
- rewritten `README.md` to replace the emphasis on `choice` in favour of `list`
- removed the image from the package
- updated `_manifest.yml` with corrected `name:`, `homepage:`, `title:`, and added my name as a contributor
- reformatted `package.yml` to make it more readable, shortened the trigger, and reformatted the form so it displays better and is easier to use.

I submitted a PR to the author's repo three months ago, but no response, so it's time to submit it directly.