### PR TITLE
Add refuos packages: italiano, accenti, dev

### DIFF
--- a/packages/refuos-accenti/0.1.0/README.md
+++ b/packages/refuos-accenti/0.1.0/README.md
@@ -1,0 +1,19 @@
+# Refuos Accenti
+
+Real-time autocorrection for Italian accented words and future-tense verbs, powered by [Espanso](https://espanso.org).
+
+## What it fixes
+
+Missing accents, future-tense verbs (1st and 3rd person) and nouns ending in *-ità* — for example:
+
+| You type      | Corrected to   |
+|---------------|----------------|
+| `perche`      | `perché`       |
+| `aggiungero`  | `aggiungerò`   |
+| `disponibilita` | `disponibilità` |
+
+~4,700 rules.
+
+## Source
+
+<https://github.com/heavybeard/refuos>

--- a/packages/refuos-accenti/0.1.0/_manifest.yml
+++ b/packages/refuos-accenti/0.1.0/_manifest.yml
@@ -1,0 +1,7 @@
+name: "refuos-accenti"
+title: "Refuos Accenti"
+description: "Autocorrection for Italian accents, future-tense verbs and -ità nouns. Fixes perche→perché, aggiungero→aggiungerò."
+version: "0.1.0"
+author: "Andrea Cognini"
+tags: ["italian", "autocorrect", "accents", "accenti", "italiano"]
+homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-accenti/0.1.0/_manifest.yml
+++ b/packages/refuos-accenti/0.1.0/_manifest.yml
@@ -3,5 +3,5 @@ title: "Refuos Accenti"
 description: "Autocorrection for Italian accents, future-tense verbs and -ità nouns. Fixes perche→perché, aggiungero→aggiungerò."
 version: "0.1.0"
 author: "Andrea Cognini"
-tags: ["italian", "autocorrect", "accents", "accenti", "italiano"]
+tags: ["italian", "autocorrect", "accents", "accenti", "italiano", "languages", "spell-correction", "typofixer"]
 homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-accenti/0.1.0/package.yml
+++ b/packages/refuos-accenti/0.1.0/package.yml
@@ -1,0 +1,21649 @@
+# Refuos - Accenti
+# Missing accents, future tense verbs, -ità nouns
+# https://github.com/heavybeard/refuos
+# Auto-generated - regenerate with: python3 generate_espanso.py
+
+matches:
+
+  - trigger: "affiché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "afficnhé"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affinche"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affinche'"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affinche1"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affincé"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affincéh"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affinhcé"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affinhé"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affnché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "affniché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "afifnché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "afinché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "fafinché"
+    replace: "affinché"
+    word: true
+
+  - trigger: "aggionerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionrerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorenrai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneari"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneri"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneria"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornrai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornreai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggirnerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggironerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggoirnerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggornerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigornerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiornerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiornerai"
+    replace: "aggiornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionreranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorenranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioreranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneanno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornearnno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornerano"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneranon"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornernano"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornernno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornreanno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggirneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggironeranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggoirneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggorneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigorneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiorneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiorneranno"
+    replace: "aggiorneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionreremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorenremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioreremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneemo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiorneermo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornereo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornereom"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornermeo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornermo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornreemo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggirneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggironeremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggoirneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggorneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigorneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiorneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiorneremo"
+    replace: "aggiorneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggionrerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiorenrà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiorerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiornera"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiornera'"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiornera1"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiorneà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiorneàr"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiornreà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggiornrà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggirnerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggironerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggoirnerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggornerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "agigornerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "agiornerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "gagiornerà"
+    replace: "aggiornerà"
+    word: true
+
+  - trigger: "aggionerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggionrerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiorenrò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiorerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiornero"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiornero'"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiornero1"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiorneò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiorneòr"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiornreò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggiornrò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggirnerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggironerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggoirnerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggornerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "agigornerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "agiornerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "gagiornerò"
+    replace: "aggiornerò"
+    word: true
+
+  - trigger: "aggingerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agginugerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugnerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiunegrai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiunerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeari"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeri"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeria"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungrai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungreai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agguingerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggungerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigungerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiungerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiungerai"
+    replace: "aggiungerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggingeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agginugeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugneranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiunegranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiuneranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeanno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungearnno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungerano"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeranon"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungernano"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungernno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungreanno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agguingeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggungeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigungeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiungeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiungeranno"
+    replace: "aggiungeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggingeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agginugeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiugneremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiunegremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiuneremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeemo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungeermo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungereo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungereom"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungermeo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungermo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungreemo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiungremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agguingeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggungeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigungeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiungeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiungeremo"
+    replace: "aggiungeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggingerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "agginugerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiugerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiugnerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiunegrà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiunerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungera"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungera'"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungera1"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungeà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungeàr"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungreà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggiungrà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "agguingerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggungerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "agigungerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "agiungerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "gagiungerà"
+    replace: "aggiungerà"
+    word: true
+
+  - trigger: "aggingerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "agginugerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiugerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiugnerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiunegrò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiunerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungero"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungero'"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungero1"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungeò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungeòr"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungreò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggiungrò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "agguingerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aggungerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "agigungerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "agiungerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "gagiungerò"
+    replace: "aggiungerò"
+    word: true
+
+  - trigger: "aiterai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aituerai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuerai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuetrai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteari"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteri"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteria"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutrai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutreai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "auiterai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "auterai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iauterai"
+    replace: "aiuterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiteranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aitueranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiueranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuetranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteanno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutearnno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuterano"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteranon"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuternano"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuternno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutreanno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "auiteranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "auteranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iauteranno"
+    replace: "aiuteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiteremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aitueremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiueremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuetremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteemo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuteermo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutereo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutereom"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutermeo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutermo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutreemo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "auiteremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "auteremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iauteremo"
+    replace: "aiuteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiterà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aituerà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiuerà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiuetrà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiutera"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiutera'"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiutera1"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiuteà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiuteàr"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiutreà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiutrà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "auiterà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "auterà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "iauterà"
+    replace: "aiuterà"
+    word: true
+
+  - trigger: "aiterò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aituerò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiuerò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiuetrò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiutero"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiutero'"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiutero1"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiuteò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiuteòr"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiutreò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "aiutrò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "auiterò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "auterò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "iauterò"
+    replace: "aiuterò"
+    word: true
+
+  - trigger: "alloché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allocrhé"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorche"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorche'"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorche1"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorcé"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorcéh"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorhcé"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allorhé"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allrché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "allroché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "alolrché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "alorché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "lalorché"
+    replace: "allorché"
+    word: true
+
+  - trigger: "adnrai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "adrai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "andai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "andari"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "andri"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "andria"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "anrai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "anrdai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadrai"
+    replace: "andrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "adnranno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "adranno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andanno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andarnno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrano"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andranon"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrnano"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrnno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "anranno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "anrdanno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadranno"
+    replace: "andranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "adnremo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "adremo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andemo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andermo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andreo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andreom"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrmeo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrmo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "anrdemo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "anremo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadremo"
+    replace: "andremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "adnrà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "adrà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "andra"
+    replace: "andrà"
+    word: true
+
+  - trigger: "andra'"
+    replace: "andrà"
+    word: true
+
+  - trigger: "andra1"
+    replace: "andrà"
+    word: true
+
+  - trigger: "andà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "andàr"
+    replace: "andrà"
+    word: true
+
+  - trigger: "anrdà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "anrà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "nadrà"
+    replace: "andrà"
+    word: true
+
+  - trigger: "adnrò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "adrò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "andro"
+    replace: "andrò"
+    word: true
+
+  - trigger: "andro'"
+    replace: "andrò"
+    word: true
+
+  - trigger: "andro1"
+    replace: "andrò"
+    word: true
+
+  - trigger: "andò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "andòr"
+    replace: "andrò"
+    word: true
+
+  - trigger: "anrdò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "anrò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "nadrò"
+    replace: "andrò"
+    word: true
+
+  - trigger: "arirverai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ariverai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrierai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrievrai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveari"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveri"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveria"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivrai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivreai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrverai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrvierai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rariverai"
+    replace: "arriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arirveranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ariveranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrieranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrievranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveanno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivearnno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriverano"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveranon"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivernano"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivernno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivreanno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrveranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrvieranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rariveranno"
+    replace: "arriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arirveremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ariveremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrieremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrievremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveemo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveermo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivereo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivereom"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivermeo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivermo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivreemo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrveremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrvieremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rariveremo"
+    replace: "arriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arirverà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "ariverà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrierà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrievrà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrivera"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrivera'"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrivera1"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arriveà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arriveàr"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrivreà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrivrà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrverà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arrvierà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "rariverà"
+    replace: "arriverà"
+    word: true
+
+  - trigger: "arirverò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "ariverò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrierò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrievrò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrivero"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrivero'"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrivero1"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arriveò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arriveòr"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrivreò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrivrò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrverò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "arrvierò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "rariverò"
+    replace: "arriverò"
+    word: true
+
+  - trigger: "apetterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsetterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aseptterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "asetterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspeterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetetrai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteari"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteri"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteria"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettrai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettreai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspteterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "asptterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapetterai"
+    replace: "aspetterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "apetteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsetteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aseptteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "asetteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspeteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetetranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteanno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettearnno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetterano"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteranon"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetternano"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetternno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettreanno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspteteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "asptteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapetteranno"
+    replace: "aspetteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "apetteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsetteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aseptteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "asetteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspeteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetetremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteemo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetteermo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettereo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettereom"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettermeo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettermo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettreemo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspteteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "asptteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapetteremo"
+    replace: "aspetteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "apetterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "apsetterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aseptterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "asetterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspeterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspetetrà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspettera"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspettera'"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspettera1"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspetteà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspetteàr"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspettreà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspettrà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "aspteterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "asptterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "sapetterà"
+    replace: "aspetterà"
+    word: true
+
+  - trigger: "apetterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "apsetterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aseptterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "asetterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspeterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspetetrò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspettero"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspettero'"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspettero1"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspetteò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspetteòr"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspettreò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspettrò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "aspteterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "asptterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "sapetterò"
+    replace: "aspetterò"
+    word: true
+
+  - trigger: "atitvità"
+    replace: "attività"
+    word: true
+
+  - trigger: "atività"
+    replace: "attività"
+    word: true
+
+  - trigger: "attiità"
+    replace: "attività"
+    word: true
+
+  - trigger: "attiivtà"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivita"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivita'"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivita1"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivià"
+    replace: "attività"
+    word: true
+
+  - trigger: "attiviàt"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivtià"
+    replace: "attività"
+    word: true
+
+  - trigger: "attivtà"
+    replace: "attività"
+    word: true
+
+  - trigger: "attviità"
+    replace: "attività"
+    word: true
+
+  - trigger: "attvità"
+    replace: "attività"
+    word: true
+
+  - trigger: "tatività"
+    replace: "attività"
+    word: true
+
+  - trigger: "arai"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "arvai"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "avai"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "avari"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "avri"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "avria"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "varai"
+    replace: "avrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aranno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "arvanno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avanno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avarnno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avrano"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avranon"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avrnano"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "avrnno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "varanno"
+    replace: "avranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aremo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arvemo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avemo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avermo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avreo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avreom"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avrmeo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "avrmo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "varemo"
+    replace: "avremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "arvà"
+    replace: "avrà"
+    word: true
+
+  - trigger: "avra"
+    replace: "avrà"
+    word: true
+
+  - trigger: "avra'"
+    replace: "avrà"
+    word: true
+
+  - trigger: "avra1"
+    replace: "avrà"
+    word: true
+
+  - trigger: "avàr"
+    replace: "avrà"
+    word: true
+
+  - trigger: "varà"
+    replace: "avrà"
+    word: true
+
+  - trigger: "arvò"
+    replace: "avrò"
+    word: true
+
+  - trigger: "avro"
+    replace: "avrò"
+    word: true
+
+  - trigger: "avro'"
+    replace: "avrò"
+    word: true
+
+  - trigger: "avro1"
+    replace: "avrò"
+    word: true
+
+  - trigger: "avòr"
+    replace: "avrò"
+    word: true
+
+  - trigger: "varò"
+    replace: "avrò"
+    word: true
+
+  - trigger: "beché"
+    replace: "benché"
+    word: true
+
+  - trigger: "becnhé"
+    replace: "benché"
+    word: true
+
+  - trigger: "benche"
+    replace: "benché"
+    word: true
+
+  - trigger: "benche'"
+    replace: "benché"
+    word: true
+
+  - trigger: "benche1"
+    replace: "benché"
+    word: true
+
+  - trigger: "bencé"
+    replace: "benché"
+    word: true
+
+  - trigger: "bencéh"
+    replace: "benché"
+    word: true
+
+  - trigger: "benhcé"
+    replace: "benché"
+    word: true
+
+  - trigger: "benhé"
+    replace: "benché"
+    word: true
+
+  - trigger: "bnché"
+    replace: "benché"
+    word: true
+
+  - trigger: "bneché"
+    replace: "benché"
+    word: true
+
+  - trigger: "ebnché"
+    replace: "benché"
+    word: true
+
+  - trigger: "acmbierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabmierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambeirai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "camberai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieari"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieri"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieria"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambirai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambireai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "camiberai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "camierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmabierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmbierai"
+    replace: "cambierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "acmbieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabmieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambeiranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "camberanno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieanno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiearnno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambierano"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieranon"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiernano"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiernno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambireanno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "camiberanno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "camieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmabieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmbieranno"
+    replace: "cambieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "acmbieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabmieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambeiremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "camberemo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieemo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambieermo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiereo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiereom"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiermeo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiermo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambireemo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "camiberemo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "camieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmabieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmbieremo"
+    replace: "cambieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "acmbierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cabierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cabmierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambeirà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "camberà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambiera"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambiera'"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambiera1"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambieà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambieàr"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambireà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cambirà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "camiberà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "camierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cmabierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "cmbierà"
+    replace: "cambierà"
+    word: true
+
+  - trigger: "acmbierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cabierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cabmierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambeirò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "camberò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambiero"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambiero'"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambiero1"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambieò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambieòr"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambireò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cambirò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "camiberò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "camierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cmabierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "cmbierò"
+    replace: "cambierò"
+    word: true
+
+  - trigger: "acpacità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "caacità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "caapcità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capacita"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capacita'"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capacita1"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capacià"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capaciàt"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capactià"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capactà"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capaictà"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capaità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capcaità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "capcità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "cpaacità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "cpacità"
+    replace: "capacità"
+    word: true
+
+  - trigger: "acpirai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "caiprai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cairai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiari"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiri"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiria"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "caprai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "capriai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpairai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpirai"
+    replace: "capirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "acpiranno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "caipranno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cairanno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capianno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiarnno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capirano"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiranon"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capirnano"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capirnno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "capranno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "caprianno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpairanno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpiranno"
+    replace: "capiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "acpiremo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "caipremo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cairemo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiemo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capiermo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capireo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capireom"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capirmeo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capirmo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capremo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "capriemo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpairemo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpiremo"
+    replace: "capiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "acpirà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "caiprà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "cairà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "capira"
+    replace: "capirà"
+    word: true
+
+  - trigger: "capira'"
+    replace: "capirà"
+    word: true
+
+  - trigger: "capira1"
+    replace: "capirà"
+    word: true
+
+  - trigger: "capià"
+    replace: "capirà"
+    word: true
+
+  - trigger: "capiàr"
+    replace: "capirà"
+    word: true
+
+  - trigger: "caprià"
+    replace: "capirà"
+    word: true
+
+  - trigger: "caprà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "cpairà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "cpirà"
+    replace: "capirà"
+    word: true
+
+  - trigger: "acpirò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "caiprò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "cairò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capiro"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capiro'"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capiro1"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capiò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capiòr"
+    replace: "capirò"
+    word: true
+
+  - trigger: "capriò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "caprò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "cpairò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "cpirò"
+    replace: "capirò"
+    word: true
+
+  - trigger: "chaimerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chamerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaemrai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameari"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameri"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameria"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamrai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamreai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimaerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciamerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihamerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciamerai"
+    replace: "chiamerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chaimeranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chameranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaemranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaeranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameanno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamearnno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamerano"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameranon"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamernano"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamernno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamreanno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimaeranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimeranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciameranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihameranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciameranno"
+    replace: "chiameranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chaimeremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chameremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaemremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaeremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameemo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiameermo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamereo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamereom"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamermeo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamermo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamreemo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimaeremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimeremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciameremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihameremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciameremo"
+    replace: "chiameremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chaimerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chamerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiaemrà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiaerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiamera"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiamera'"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiamera1"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiameà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiameàr"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiamreà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chiamrà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chimaerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chimerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "ciamerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "cihamerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "hciamerà"
+    replace: "chiamerà"
+    word: true
+
+  - trigger: "chaimerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chamerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiaemrò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiaerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiamero"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiamero'"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiamero1"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiameò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiameòr"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiamreò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chiamrò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chimaerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chimerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "ciamerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "cihamerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "hciamerò"
+    replace: "chiamerò"
+    word: true
+
+  - trigger: "chederai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cheiderai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chideerai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiderai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedeai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedeari"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiederi"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiederia"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedrai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedreai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieedrai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieerai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciederai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihederai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciederai"
+    replace: "chiederai"
+    propagate_case: true
+    word: true
+
+  - trigger: "chederanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cheideranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chideeranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chideranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedeanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedearnno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiederano"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiederanon"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedernano"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedernno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedreanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieedranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieeranno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciederanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihederanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciederanno"
+    replace: "chiederanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "chederemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cheideremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chideeremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chideremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedeemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedeermo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedereo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedereom"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedermeo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedermo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedreemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiedremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieedremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chieeremo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciederemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihederemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciederemo"
+    replace: "chiederemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "chederà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "cheiderà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chideerà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiderà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedera"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedera'"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedera1"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedeà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedeàr"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedreà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chiedrà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chieedrà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chieerà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "ciederà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "cihederà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "hciederà"
+    replace: "chiederà"
+    word: true
+
+  - trigger: "chederò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "cheiderò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chideerò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiderò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedero"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedero'"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedero1"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedeò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedeòr"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedreò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chiedrò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chieedrò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "chieerò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "ciederò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "cihederò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "hciederò"
+    replace: "chiederò"
+    word: true
+
+  - trigger: "cioe"
+    replace: "cioè"
+    word: true
+
+  - trigger: "cioe'"
+    replace: "cioè"
+    word: true
+
+  - trigger: "cioe1"
+    replace: "cioè"
+    word: true
+
+  - trigger: "cièo"
+    replace: "cioè"
+    word: true
+
+  - trigger: "coiè"
+    replace: "cioè"
+    word: true
+
+  - trigger: "icoè"
+    replace: "cioè"
+    word: true
+
+  - trigger: "citta"
+    replace: "città"
+    word: true
+
+  - trigger: "citta'"
+    replace: "città"
+    word: true
+
+  - trigger: "citta1"
+    replace: "città"
+    word: true
+
+  - trigger: "cità"
+    replace: "città"
+    word: true
+
+  - trigger: "citàt"
+    replace: "città"
+    word: true
+
+  - trigger: "ctità"
+    replace: "città"
+    word: true
+
+  - trigger: "cttà"
+    replace: "città"
+    word: true
+
+  - trigger: "icttà"
+    replace: "città"
+    word: true
+
+  - trigger: "cio"
+    replace: "ciò"
+    word: true
+
+  - trigger: "cio'"
+    replace: "ciò"
+    word: true
+
+  - trigger: "cio1"
+    replace: "ciò"
+    word: true
+
+  - trigger: "còi"
+    replace: "ciò"
+    word: true
+
+  - trigger: "icò"
+    replace: "ciò"
+    word: true
+
+  - trigger: "cmopleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmpleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comlpeterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "compelterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "competerai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleerai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleetrai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeari"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeri"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeria"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completrai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "completreai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "complteerai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "complterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "copleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "copmleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmpleterai"
+    replace: "completerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmopleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmpleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comlpeteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "compelteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "competeranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleeranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleetranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeanno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completearnno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completerano"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeranon"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completernano"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completernno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "completreanno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "complteeranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "complteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "copleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "copmleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmpleteranno"
+    replace: "completeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmopleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmpleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comlpeteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "compelteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "competeremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleeremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "compleetremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeemo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completeermo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completereo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completereom"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completermeo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completermo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completreemo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "completremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "complteeremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "complteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "copleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "copmleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmpleteremo"
+    replace: "completeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmopleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "cmpleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "comleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "comlpeterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "compelterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "competerà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "compleerà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "compleetrà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completera"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completera'"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completera1"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completeà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completeàr"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completreà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "completrà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "complteerà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "complterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "copleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "copmleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "ocmpleterà"
+    replace: "completerà"
+    word: true
+
+  - trigger: "cmopleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "cmpleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "comleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "comlpeterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "compelterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "competerò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "compleerò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "compleetrò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completero"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completero'"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completero1"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completeò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completeòr"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completreò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "completrò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "complteerò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "complterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "copleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "copmleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "ocmpleterò"
+    replace: "completerò"
+    word: true
+
+  - trigger: "cmounicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmunicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnuicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuincherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuncherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunciherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicehrai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicerai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheari"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheri"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheria"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichrai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichreai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunihcerai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "coumnicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "counicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmunicherai"
+    replace: "comunicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmounicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmunicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnuicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuincheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuncheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunciheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicehranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniceranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheanno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichearnno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicherano"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheranon"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichernano"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichernno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichreanno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunihceranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "coumnicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "counicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmunicheranno"
+    replace: "comunicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmounicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmunicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnuicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuincheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuncheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunciheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicehremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniceremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheemo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicheermo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichereo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichereom"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichermeo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichermo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichreemo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunichremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunihceremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "coumnicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "counicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmunicheremo"
+    replace: "comunicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmounicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "cmunicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comnicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comnuicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comuicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comuincherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comuncherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunciherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunicehrà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunicerà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunichera"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunichera'"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunichera1"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunicheà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunicheàr"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunichreà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunichrà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comunihcerà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "comuniherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "coumnicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "counicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "ocmunicherà"
+    replace: "comunicherà"
+    word: true
+
+  - trigger: "cmounicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "cmunicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comnicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comnuicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comuicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comuincherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comuncherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunciherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunicehrò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunicerò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunichero"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunichero'"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunichero1"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunicheò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunicheòr"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunichreò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunichrò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comunihcerò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "comuniherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "coumnicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "counicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "ocmunicherò"
+    replace: "comunicherò"
+    word: true
+
+  - trigger: "cndividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnodividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "codividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "codnividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiiderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiivderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivdierai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideari"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideri"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideria"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividrai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividreai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiviedrai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivierai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condviderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "condviiderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "conidviderai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "conividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocndividerai"
+    replace: "condividerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cndivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnodivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "codivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "codnivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiivderanno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivderanno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivdieranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideanno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividearnno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividerano"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideranon"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividernano"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividernno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividreanno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiviedranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivieranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condvideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "condviideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "conidvideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "conivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocndivideranno"
+    replace: "condivideranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cndivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnodivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "codivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "codnivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiivderemo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivderemo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivdieremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideemo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivideermo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividereo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividereom"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividermeo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividermo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividreemo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condividremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiviedremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condivieremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condvideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "condviideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "conidvideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "conivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocndivideremo"
+    replace: "condivideremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cndividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "cnodividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "codividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "codnividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condiiderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condiivderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condivderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condivdierà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condividera"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condividera'"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condividera1"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condivideà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condivideàr"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condividreà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condividrà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condiviedrà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condivierà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condviderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "condviiderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "conidviderà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "conividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "ocndividerà"
+    replace: "condividerà"
+    word: true
+
+  - trigger: "cndividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "cnodividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "codividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "codnividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condiiderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condiivderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condivderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condivdierò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condividero"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condividero'"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condividero1"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condivideò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condivideòr"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condividreò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condividrò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condiviedrò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condivierò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condviderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "condviiderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "conidviderò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "conividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "ocndividerò"
+    replace: "condividerò"
+    word: true
+
+  - trigger: "cnfermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnofermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofnermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "conefrmerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "conermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemrerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "conferemrai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confererai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeari"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeri"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeria"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermrai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermreai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confremerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "confrmerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnfermerai"
+    replace: "confermerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnfermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnofermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofnermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "conefrmeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "conermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemreranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "conferemranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confereranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeanno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermearnno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermerano"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeranon"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermernano"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermernno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermreanno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confremeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "confrmeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnfermeranno"
+    replace: "confermeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnfermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnofermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofnermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "conefrmeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "conermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confemreremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "conferemremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confereremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeemo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermeermo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermereo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermereom"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermermeo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermermo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermreemo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confermremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confremeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "confrmeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnfermeremo"
+    replace: "confermeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnfermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "cnofermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "cofermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "cofnermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "conefrmerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "conermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confemerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confemrerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "conferemrà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confererà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermera"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermera'"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermera1"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermeà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermeàr"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermreà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confermrà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confremerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "confrmerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "ocnfermerà"
+    replace: "confermerà"
+    word: true
+
+  - trigger: "cnfermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "cnofermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "cofermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "cofnermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "conefrmerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "conermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confemerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confemrerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "conferemrò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confererò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermero"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermero'"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermero1"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermeò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermeòr"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermreò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confermrò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confremerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "confrmerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "ocnfermerò"
+    replace: "confermerò"
+    word: true
+
+  - trigger: "coreggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "corerggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregegrai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeari"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeri"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeria"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggrai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggreai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrgegerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "croreggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "crreggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrreggerai"
+    replace: "correggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "coreggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "corerggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregegranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeanno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggearnno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggerano"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeranon"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggernano"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggernno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggreanno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrgegeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "croreggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "crreggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrreggeranno"
+    replace: "correggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "coreggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corerggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregegremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corregeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeemo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggeermo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggereo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggereom"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggermeo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggermo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggreemo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "correggremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrgegeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corrggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "croreggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "crreggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrreggeremo"
+    replace: "correggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "coreggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "corerggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "corregegrà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "corregerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggera"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggera'"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggera1"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggeà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggeàr"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggreà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "correggrà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "corrgegerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "corrggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "croreggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "crreggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "ocrreggerà"
+    replace: "correggerà"
+    word: true
+
+  - trigger: "coreggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "corerggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "corregegrò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "corregerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggero"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggero'"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggero1"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggeò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggeòr"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggreò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "correggrò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "corrgegerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "corrggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "croreggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "crreggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "ocrreggerò"
+    replace: "correggerò"
+    word: true
+
+  - trigger: "coicché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "coiscché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "coscché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosciché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosicche"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosicche'"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosicche1"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosiccé"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosiccéh"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosichcé"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosiché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "csicché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "csoicché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "ocsicché"
+    replace: "cosicché"
+    word: true
+
+  - trigger: "cosi"
+    replace: "così"
+    word: true
+
+  - trigger: "cosi'"
+    replace: "così"
+    word: true
+
+  - trigger: "cosi1"
+    replace: "così"
+    word: true
+
+  - trigger: "coìs"
+    replace: "così"
+    word: true
+
+  - trigger: "csoì"
+    replace: "così"
+    word: true
+
+  - trigger: "ocsì"
+    replace: "così"
+    word: true
+
+  - trigger: "ceatività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "ceratività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "craetività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "cratività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creaitvità"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creaività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creatiità"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creatiivtà"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativita"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativita'"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativita1"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativià"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativiàt"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativtià"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creativtà"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creatviità"
+    replace: "creatività"
+    word: true
+
+  - trigger: "creatvità"
+    replace: "creatività"
+    word: true
+
+  - trigger: "cretaività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "cretività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "rceatività"
+    replace: "creatività"
+    word: true
+
+  - trigger: "ceerai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "cererai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeari"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeri"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeria"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "crerai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "crereai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceerai"
+    replace: "creerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceeranno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cereranno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeanno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creearnno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creerano"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeranon"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creernano"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creernno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "creranno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "crereanno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceeranno"
+    replace: "creeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceeremo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cereremo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeemo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creeermo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creereo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creereom"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creermeo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creermo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "crereemo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "creremo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceeremo"
+    replace: "creeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceerà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "cererà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "creera"
+    replace: "creerà"
+    word: true
+
+  - trigger: "creera'"
+    replace: "creerà"
+    word: true
+
+  - trigger: "creera1"
+    replace: "creerà"
+    word: true
+
+  - trigger: "creeà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "creeàr"
+    replace: "creerà"
+    word: true
+
+  - trigger: "crereà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "crerà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "rceerà"
+    replace: "creerà"
+    word: true
+
+  - trigger: "ceerò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "cererò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "creero"
+    replace: "creerò"
+    word: true
+
+  - trigger: "creero'"
+    replace: "creerò"
+    word: true
+
+  - trigger: "creero1"
+    replace: "creerò"
+    word: true
+
+  - trigger: "creeò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "creeòr"
+    replace: "creerò"
+    word: true
+
+  - trigger: "crereò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "crerò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "rceerò"
+    replace: "creerò"
+    word: true
+
+  - trigger: "criosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "cruiosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "cuiosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "cuirosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curioistà"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curioità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiosita"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiosita'"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiosita1"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiosià"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiosiàt"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiostià"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curiostà"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curisità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curisoità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curoisità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "curosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "ucriosità"
+    replace: "curiosità"
+    word: true
+
+  - trigger: "daai"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "daari"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dari"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "daria"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "draai"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "drai"
+    replace: "darai"
+    propagate_case: true
+    word: true
+
+  - trigger: "daanno"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "daarnno"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "darano"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "daranon"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "darnano"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "darnno"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "draanno"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dranno"
+    replace: "daranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "daemo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "daermo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dareo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dareom"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "darmeo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "darmo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "draemo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dremo"
+    replace: "daremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dara"
+    replace: "darà"
+    word: true
+
+  - trigger: "dara'"
+    replace: "darà"
+    word: true
+
+  - trigger: "dara1"
+    replace: "darà"
+    word: true
+
+  - trigger: "daàr"
+    replace: "darà"
+    word: true
+
+  - trigger: "draà"
+    replace: "darà"
+    word: true
+
+  - trigger: "daro"
+    replace: "darò"
+    word: true
+
+  - trigger: "daro'"
+    replace: "darò"
+    word: true
+
+  - trigger: "daro1"
+    replace: "darò"
+    word: true
+
+  - trigger: "daòr"
+    replace: "darò"
+    word: true
+
+  - trigger: "draò"
+    replace: "darò"
+    word: true
+
+  - trigger: "dfficoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "dfificoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "diffcioltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "diffcoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficlotà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficolta"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficolta'"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficolta1"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficolà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficolàt"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficotlà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "difficotà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "diffiocltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "diffioltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "dificoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "dififcoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "idfficoltà"
+    replace: "difficoltà"
+    word: true
+
+  - trigger: "diai"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "diari"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "diri"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "diria"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "driai"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "idrai"
+    replace: "dirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dianno"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "diarnno"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirano"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "diranon"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirnano"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirnno"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "drianno"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "idranno"
+    replace: "diranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "diemo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "diermo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "direo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "direom"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirmeo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirmo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "driemo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "idremo"
+    replace: "diremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dira"
+    replace: "dirà"
+    word: true
+
+  - trigger: "dira'"
+    replace: "dirà"
+    word: true
+
+  - trigger: "dira1"
+    replace: "dirà"
+    word: true
+
+  - trigger: "diàr"
+    replace: "dirà"
+    word: true
+
+  - trigger: "drià"
+    replace: "dirà"
+    word: true
+
+  - trigger: "idrà"
+    replace: "dirà"
+    word: true
+
+  - trigger: "diro"
+    replace: "dirò"
+    word: true
+
+  - trigger: "diro'"
+    replace: "dirò"
+    word: true
+
+  - trigger: "diro1"
+    replace: "dirò"
+    word: true
+
+  - trigger: "diòr"
+    replace: "dirò"
+    word: true
+
+  - trigger: "driò"
+    replace: "dirò"
+    word: true
+
+  - trigger: "idrò"
+    replace: "dirò"
+    word: true
+
+  - trigger: "diponibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dipsonibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disonibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disopnibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dispnibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dispnoibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dispoibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dispoinbilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponbiilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponbilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibiiltà"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibiità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibilita"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibilita'"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibilita1"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibilià"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibiliàt"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibiltià"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibiltà"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponibliità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponiblità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponiiblità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "disponiilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dsiponibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dsponibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "idsponibilità"
+    replace: "disponibilità"
+    word: true
+
+  - trigger: "dorai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorvai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovari"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovri"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovria"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvorai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvrai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "odvrai"
+    replace: "dovrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "doranno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorvanno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovanno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovarnno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovrano"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovranon"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovrnano"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovrnno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvoranno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvranno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "odvranno"
+    replace: "dovranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "doremo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorvemo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovemo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovermo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovreo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovreom"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovrmeo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovrmo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvoremo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvremo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "odvremo"
+    replace: "dovremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorvà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dorà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dovra"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dovra'"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dovra1"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dovà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dovàr"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dvorà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dvrà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "odvrà"
+    replace: "dovrà"
+    word: true
+
+  - trigger: "dorvò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dorò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dovro"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dovro'"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dovro1"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dovò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dovòr"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dvorò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "dvrò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "odvrò"
+    replace: "dovrò"
+    word: true
+
+  - trigger: "afcilità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faciiltà"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faciità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "facilita'"
+    replace: "facilità"
+    word: true
+
+  - trigger: "facilita1"
+    replace: "facilità"
+    word: true
+
+  - trigger: "facilià"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faciliàt"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faciltià"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faciltà"
+    replace: "facilità"
+    word: true
+
+  - trigger: "facliità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faclità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "faiclità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "failità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "fcailità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "fcilità"
+    replace: "facilità"
+    word: true
+
+  - trigger: "afrai"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "faai"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "faari"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fari"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "faria"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraai"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "frai"
+    replace: "farai"
+    propagate_case: true
+    word: true
+
+  - trigger: "afranno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "faanno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "faarnno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "farano"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "faranon"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "farnano"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "farnno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraanno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "franno"
+    replace: "faranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "afremo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faemo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faermo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fareo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fareom"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "farmeo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "farmo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraemo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fremo"
+    replace: "faremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "afrà"
+    replace: "farà"
+    word: true
+
+  - trigger: "fara"
+    replace: "farà"
+    word: true
+
+  - trigger: "fara'"
+    replace: "farà"
+    word: true
+
+  - trigger: "fara1"
+    replace: "farà"
+    word: true
+
+  - trigger: "faàr"
+    replace: "farà"
+    word: true
+
+  - trigger: "fraà"
+    replace: "farà"
+    word: true
+
+  - trigger: "afrò"
+    replace: "farò"
+    word: true
+
+  - trigger: "faro"
+    replace: "farò"
+    word: true
+
+  - trigger: "faro'"
+    replace: "farò"
+    word: true
+
+  - trigger: "faro1"
+    replace: "farò"
+    word: true
+
+  - trigger: "faòr"
+    replace: "farò"
+    word: true
+
+  - trigger: "fraò"
+    replace: "farò"
+    word: true
+
+  - trigger: "fiché"
+    replace: "finché"
+    word: true
+
+  - trigger: "ficnhé"
+    replace: "finché"
+    word: true
+
+  - trigger: "finche"
+    replace: "finché"
+    word: true
+
+  - trigger: "finche'"
+    replace: "finché"
+    word: true
+
+  - trigger: "finche1"
+    replace: "finché"
+    word: true
+
+  - trigger: "fincé"
+    replace: "finché"
+    word: true
+
+  - trigger: "fincéh"
+    replace: "finché"
+    word: true
+
+  - trigger: "finhcé"
+    replace: "finché"
+    word: true
+
+  - trigger: "finhé"
+    replace: "finché"
+    word: true
+
+  - trigger: "fnché"
+    replace: "finché"
+    word: true
+
+  - trigger: "fniché"
+    replace: "finché"
+    word: true
+
+  - trigger: "ifnché"
+    replace: "finché"
+    word: true
+
+  - trigger: "fiinrai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiirai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiari"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiri"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiria"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finrai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "finriai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniirai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnirai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifnirai"
+    replace: "finirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiinranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiiranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finianno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiarnno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finirano"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiranon"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finirnano"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finirnno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "finrianno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniiranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifniranno"
+    replace: "finiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiinremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiiremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiemo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finiermo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finireo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finireom"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finirmeo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finirmo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "finriemo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniiremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifniremo"
+    replace: "finiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiinrà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "fiirà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finira"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finira'"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finira1"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finià"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finiàr"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finrià"
+    replace: "finirà"
+    word: true
+
+  - trigger: "finrà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "fniirà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "fnirà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "ifnirà"
+    replace: "finirà"
+    word: true
+
+  - trigger: "fiinrò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "fiirò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finiro"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finiro'"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finiro1"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finiò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finiòr"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finriò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "finrò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "fniirò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "fnirò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "ifnirò"
+    replace: "finirò"
+    word: true
+
+  - trigger: "gacché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "gaicché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giacche"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giacche'"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giacche1"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giaccé"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giaccéh"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giachcé"
+    replace: "giacché"
+    word: true
+
+  - trigger: "giaché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "gicaché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "gicché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "igacché"
+    replace: "giacché"
+    word: true
+
+  - trigger: "gioedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "gioevdì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "giovdeì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "giovdì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "giovedi"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "giovedi'"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "giovedi1"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "gioveì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "gioveìd"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "givedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "givoedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "goivedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "govedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "igovedì"
+    replace: "giovedì"
+    word: true
+
+  - trigger: "gia"
+    replace: "già"
+    word: true
+
+  - trigger: "gia'"
+    replace: "già"
+    word: true
+
+  - trigger: "gia1"
+    replace: "già"
+    word: true
+
+  - trigger: "gài"
+    replace: "già"
+    word: true
+
+  - trigger: "igà"
+    replace: "già"
+    word: true
+
+  - trigger: "giu"
+    replace: "giù"
+    word: true
+
+  - trigger: "giu'"
+    replace: "giù"
+    word: true
+
+  - trigger: "giu1"
+    replace: "giù"
+    word: true
+
+  - trigger: "gùi"
+    replace: "giù"
+    word: true
+
+  - trigger: "igù"
+    replace: "giù"
+    word: true
+
+  - trigger: "dientità"
+    replace: "identità"
+    word: true
+
+  - trigger: "idenittà"
+    replace: "identità"
+    word: true
+
+  - trigger: "idenità"
+    replace: "identità"
+    word: true
+
+  - trigger: "identita"
+    replace: "identità"
+    word: true
+
+  - trigger: "identita'"
+    replace: "identità"
+    word: true
+
+  - trigger: "identita1"
+    replace: "identità"
+    word: true
+
+  - trigger: "identià"
+    replace: "identità"
+    word: true
+
+  - trigger: "identiàt"
+    replace: "identità"
+    word: true
+
+  - trigger: "identtià"
+    replace: "identità"
+    word: true
+
+  - trigger: "identtà"
+    replace: "identità"
+    word: true
+
+  - trigger: "idetità"
+    replace: "identità"
+    word: true
+
+  - trigger: "idetnità"
+    replace: "identità"
+    word: true
+
+  - trigger: "idnetità"
+    replace: "identità"
+    word: true
+
+  - trigger: "idntità"
+    replace: "identità"
+    word: true
+
+  - trigger: "iedntità"
+    replace: "identità"
+    word: true
+
+  - trigger: "ientità"
+    replace: "identità"
+    word: true
+
+  - trigger: "imlementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlpementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "impelmenterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "impementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleemnterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleenterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemenerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemenetrai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeari"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeri"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeria"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementrai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementreai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemeterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemetnerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemneterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemnterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmeenterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmenterai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iplementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmlementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "miplementerai"
+    replace: "implementerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlpementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "impelmenteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "impementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleemnteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleenteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemeneranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemenetranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeanno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementearnno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementerano"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeranon"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementernano"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementernno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementreanno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemeteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemetneranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemneteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemnteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmeenteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmenteranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iplementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmlementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "miplementeranno"
+    replace: "implementeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlpementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "impelmenteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "impementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleemnteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleenteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemeneremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemenetremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeemo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementeermo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementereo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementereom"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementermeo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementermo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementreemo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implementremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemeteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemetneremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemneteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemnteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmeenteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmenteremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iplementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmlementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "miplementeremo"
+    replace: "implementeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "imlpementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "impelmenterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "impementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "impleemnterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "impleenterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemenerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemenetrà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementera"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementera'"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementera1"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementeà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementeàr"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementreà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implementrà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemeterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemetnerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemneterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implemnterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implmeenterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "implmenterà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "iplementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "ipmlementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "miplementerà"
+    replace: "implementerà"
+    word: true
+
+  - trigger: "imlementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "imlpementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "impelmenterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "impementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "impleemnterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "impleenterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemenerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemenetrò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementero"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementero'"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementero1"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementeò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementeòr"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementreò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implementrò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemeterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemetnerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemneterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implemnterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implmeenterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "implmenterò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "iplementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "ipmlementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "miplementerò"
+    replace: "implementerò"
+    word: true
+
+  - trigger: "iinzierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iizierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniizerai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizeirai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizerai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieari"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieri"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieria"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizirai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizireai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inzierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inziierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "niizierai"
+    replace: "inizierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iinzieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iizieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniizeranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizeiranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizeranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieanno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziearnno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizierano"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieranon"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziernano"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziernno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizireanno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inzieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inziieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "niizieranno"
+    replace: "inizieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iinzieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iizieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniizeremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizeiremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizeremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieemo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizieermo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziereo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziereom"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziermeo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziermo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizireemo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inzieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inziieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "niizieremo"
+    replace: "inizieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iinzierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iizierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iniierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iniizerà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizeirà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizerà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iniziera"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iniziera'"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iniziera1"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizieà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizieàr"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizireà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inizirà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inzierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "inziierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "niizierà"
+    replace: "inizierà"
+    word: true
+
+  - trigger: "iinzierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iizierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iniierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iniizerò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizeirò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizerò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iniziero"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iniziero'"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "iniziero1"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizieò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizieòr"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizireò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inizirò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inzierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inziierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "niizierò"
+    replace: "inizierò"
+    word: true
+
+  - trigger: "inerirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inesrirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseirrai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriari"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriri"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriria"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserrai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserriai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "insreirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "insrirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iserirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "isnerirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "niserirai"
+    replace: "inserirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ineriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inesriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseiranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseirranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserianno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriarnno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserirano"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriranon"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserirnano"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserirnno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserrianno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "insreiranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "insriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iseriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "isneriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "niseriranno"
+    replace: "inseriranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ineriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inesriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseiremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseirremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriemo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseriermo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserireo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserireom"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserirmeo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserirmo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inserriemo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "insreiremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "insriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iseriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "isneriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "niseriremo"
+    replace: "inseriremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inerirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inesrirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inseirrà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inseirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserira"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserira'"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserira1"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserià"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inseriàr"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserrià"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inserrà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "insreirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "insrirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "iserirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "isnerirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "niserirà"
+    replace: "inserirà"
+    word: true
+
+  - trigger: "inerirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inesrirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseirrò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseriro"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseriro'"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseriro1"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseriò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inseriòr"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inserriò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inserrò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "insreirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "insrirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "iserirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "isnerirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "niserirò"
+    replace: "inserirò"
+    word: true
+
+  - trigger: "inierai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniverai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inveirai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inverai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieari"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieri"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieria"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invirai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "invireai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivierai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivnierai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "nivierai"
+    replace: "invierai"
+    propagate_case: true
+    word: true
+
+  - trigger: "inieranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniveranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inveiranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inveranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieanno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviearnno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "invierano"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieranon"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviernano"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviernno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "invireanno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivieranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivnieranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nivieranno"
+    replace: "invieranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "inieremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniveremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inveiremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inveremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieemo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "invieermo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviereo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviereom"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviermeo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviermo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "invireemo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inviremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivieremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivnieremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nivieremo"
+    replace: "invieremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "inierà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "iniverà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inveirà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inverà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inviera"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inviera'"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inviera1"
+    replace: "invierà"
+    word: true
+
+  - trigger: "invieà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "invieàr"
+    replace: "invierà"
+    word: true
+
+  - trigger: "invireà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "invirà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "ivierà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "ivnierà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "nivierà"
+    replace: "invierà"
+    word: true
+
+  - trigger: "inierò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "iniverò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "inveirò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "inverò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "inviero"
+    replace: "invierò"
+    word: true
+
+  - trigger: "inviero'"
+    replace: "invierò"
+    word: true
+
+  - trigger: "inviero1"
+    replace: "invierò"
+    word: true
+
+  - trigger: "invieò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "invieòr"
+    replace: "invierò"
+    word: true
+
+  - trigger: "invireò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "invirò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "ivierò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "ivnierò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "nivierò"
+    replace: "invierò"
+    word: true
+
+  - trigger: "alvorerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "laorerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "laovrerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoerrai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreari"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreri"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreria"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorrai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorreai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavrerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavroerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvaorerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvorerai"
+    replace: "lavorerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "alvoreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "laoreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "laovreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoeranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoerranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreanno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorearnno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorerano"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreranon"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorernano"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorernno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorreanno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavroeranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvaoreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvoreranno"
+    replace: "lavoreranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "alvoreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "laoreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "laovreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoeremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoerremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreemo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoreermo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorereo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorereom"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorermeo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorermo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorreemo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavroeremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvaoreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvoreremo"
+    replace: "lavoreremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "alvorerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "laorerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "laovrerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavoerrà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavoerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavorera"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavorera'"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavorera1"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavoreà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavoreàr"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavorreà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavorrà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavrerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lavroerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lvaorerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "lvorerà"
+    replace: "lavorerà"
+    word: true
+
+  - trigger: "alvorerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "laorerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "laovrerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavoerrò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavoerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavorero"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavorero'"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavorero1"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavoreò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavoreòr"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavorreò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavorrò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavrerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lavroerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lvaorerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "lvorerò"
+    replace: "lavorerò"
+    word: true
+
+  - trigger: "elggerai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "legegrai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "legerai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeari"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeri"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeria"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggrai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggreai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lgegerai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "lggerai"
+    replace: "leggerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "elggeranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "legegranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "legeranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeanno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggearnno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggerano"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeranon"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggernano"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggernno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggreanno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lgegeranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lggeranno"
+    replace: "leggeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "elggeremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "legegremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "legeremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeemo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeermo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggereo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggereom"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggermeo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggermo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggreemo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lgegeremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lggeremo"
+    replace: "leggeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "elggerà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "legegrà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "legerà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggera"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggera'"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggera1"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggeà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggeàr"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggreà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "leggrà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "lgegerà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "lggerà"
+    replace: "leggerà"
+    word: true
+
+  - trigger: "elggerò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "legegrò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "legerò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggero"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggero'"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggero1"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggeò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggeòr"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggreò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "leggrò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "lgegerò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "lggerò"
+    replace: "leggerò"
+    word: true
+
+  - trigger: "ilbertà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "lbertà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "lbiertà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liberta"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liberta'"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liberta1"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liberà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liberàt"
+    replace: "libertà"
+    word: true
+
+  - trigger: "libetrà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "libetà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "libretà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "librtà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liebrtà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "liertà"
+    replace: "libertà"
+    word: true
+
+  - trigger: "lnedì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lnuedì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "luedì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "luendì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lundeì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lundì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lunedi"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lunedi'"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "lunedi1"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "luneì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "luneìd"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "ulnedì"
+    replace: "lunedì"
+    word: true
+
+  - trigger: "amnderai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "maderai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "madnerai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandeai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandeari"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "manderi"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "manderia"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandrai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandreai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "manedrai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "manerai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnaderai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnderai"
+    replace: "manderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "amnderanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "maderanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "madneranno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandeanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandearnno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "manderano"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "manderanon"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandernano"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandernno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandranno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandreanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "manedranno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "maneranno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnaderanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnderanno"
+    replace: "manderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "amnderemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "maderemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "madneremo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandeemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandeermo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandereo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandereom"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandermeo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandermo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandreemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mandremo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "manedremo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "maneremo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnaderemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnderemo"
+    replace: "manderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "amnderà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "maderà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "madnerà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandera"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandera'"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandera1"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandeà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandeàr"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandreà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mandrà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "manedrà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "manerà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mnaderà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "mnderà"
+    replace: "manderà"
+    word: true
+
+  - trigger: "amnderò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "maderò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "madnerò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandero"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandero'"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandero1"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandeò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandeòr"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandreò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mandrò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "manedrò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "manerò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mnaderò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "mnderò"
+    replace: "manderò"
+    word: true
+
+  - trigger: "amngerai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "magerai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "magnerai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "manegrai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeari"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeri"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeria"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangrai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangreai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnagerai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mngerai"
+    replace: "mangerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "amngeranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mageranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "magneranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "manegranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeanno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangearnno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangerano"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeranon"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangernano"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangernno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangreanno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnageranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mngeranno"
+    replace: "mangeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "amngeremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mageremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "magneremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "manegremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeemo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangeermo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangereo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangereom"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangermeo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangermo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangreemo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnageremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mngeremo"
+    replace: "mangeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "amngerà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "magerà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "magnerà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "manegrà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangera"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangera'"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangera1"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangeà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangeàr"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangreà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mangrà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mnagerà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "mngerà"
+    replace: "mangerà"
+    word: true
+
+  - trigger: "amngerò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "magerò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "magnerò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "manegrò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangero"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangero'"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangero1"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangeò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangeòr"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangreò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mangrò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mnagerò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "mngerò"
+    replace: "mangerò"
+    word: true
+
+  - trigger: "amrtedì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "maredì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "maretdì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "martdeì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "martdì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "martedi"
+    replace: "martedì"
+    word: true
+
+  - trigger: "martedi'"
+    replace: "martedì"
+    word: true
+
+  - trigger: "martedi1"
+    replace: "martedì"
+    word: true
+
+  - trigger: "marteì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "marteìd"
+    replace: "martedì"
+    word: true
+
+  - trigger: "matedì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "matredì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "mratedì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "mrtedì"
+    replace: "martedì"
+    word: true
+
+  - trigger: "emrcoledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mecoledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mecroledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercloedì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoedì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoeldì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoldeì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoldì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoledi"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoledi'"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoledi1"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoleì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mercoleìd"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "merocledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "meroledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mrcoledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "mrecoledì"
+    replace: "mercoledì"
+    word: true
+
+  - trigger: "emtterai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "meterai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "metetrai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteari"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteri"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteria"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettrai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettreai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mteterai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtterai"
+    replace: "metterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "emtteranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "meteranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metetranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteanno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettearnno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metterano"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteranon"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metternano"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "metternno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettreanno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mteteranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtteranno"
+    replace: "metteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "emtteremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "meteremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "metetremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteemo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteermo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettereo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettereom"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettermeo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettermo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettreemo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mteteremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtteremo"
+    replace: "metteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "emtterà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "meterà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "metetrà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mettera"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mettera'"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mettera1"
+    replace: "metterà"
+    word: true
+
+  - trigger: "metteà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "metteàr"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mettreà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mettrà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mteterà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "mtterà"
+    replace: "metterà"
+    word: true
+
+  - trigger: "emtterò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "meterò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "metetrò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mettero"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mettero'"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mettero1"
+    replace: "metterò"
+    word: true
+
+  - trigger: "metteò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "metteòr"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mettreò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mettrò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mteterò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "mtterò"
+    replace: "metterò"
+    word: true
+
+  - trigger: "encessità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "nceessità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "ncessità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necesistà"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necesità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necessita'"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necessita1"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necessià"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necessiàt"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necesstià"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necesstà"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necsesità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "necssità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "neecssità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "neessità"
+    replace: "necessità"
+    word: true
+
+  - trigger: "oganizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogranizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "oragnizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "oranizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgainzzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgaizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizezrai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeari"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeri"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeria"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzrai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzreai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzizerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnaizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "roganizzerai"
+    replace: "organizzerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "oganizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogranizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oragnizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oranizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgainzzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgaizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizezranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeanno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzearnno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzerano"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeranon"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzernano"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzernno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzreanno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzizeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnaizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "roganizzeranno"
+    replace: "organizzeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oganizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogranizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "oragnizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "oranizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgainzzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgaizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizezremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeemo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzeermo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzereo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzereom"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzermeo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzermo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzreemo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzizeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnaizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "roganizzeremo"
+    replace: "organizzeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "oganizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "ogranizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "oragnizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "oranizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "orgainzzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "orgaizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizezrà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzera"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzera'"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzera1"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzeà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzeàr"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzreà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organizzrà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organzizerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "organzzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "orgnaizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "orgnizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "roganizzerà"
+    replace: "organizzerà"
+    word: true
+
+  - trigger: "oganizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "ogranizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "oragnizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "oranizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "orgainzzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "orgaizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizezrò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzero"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzero'"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzero1"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzeò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzeòr"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzreò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organizzrò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organzizerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "organzzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "orgnaizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "orgnizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "roganizzerò"
+    replace: "organizzerò"
+    word: true
+
+  - trigger: "aprlerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "palerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "palrerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parelrai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleari"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleri"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleria"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlrai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlreai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pralerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prlerai"
+    replace: "parlerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprleranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "paleranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "palreranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parelranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pareranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleanno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlearnno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlerano"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleranon"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlernano"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlernno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlreanno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "praleranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prleranno"
+    replace: "parleranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprleremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "paleremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "palreremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parelremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pareremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleemo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parleermo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlereo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlereom"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlermeo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlermo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlreemo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "praleremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prleremo"
+    replace: "parleremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprlerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "palerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "palrerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parelrà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parlera"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parlera'"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parlera1"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parleà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parleàr"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parlreà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "parlrà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "pralerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "prlerà"
+    replace: "parlerà"
+    word: true
+
+  - trigger: "aprlerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "palerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "palrerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parelrò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parlero"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parlero'"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parlero1"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parleò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parleòr"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parlreò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "parlrò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "pralerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "prlerò"
+    replace: "parlerò"
+    word: true
+
+  - trigger: "apsserai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "paserai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pasesrai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeari"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeri"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeria"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passrai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "passreai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "psaserai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "psserai"
+    replace: "passerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsseranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "paseranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pasesranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeanno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passearnno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passerano"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeranon"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passernano"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passernno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "passreanno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "psaseranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "psseranno"
+    replace: "passeranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsseremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "paseremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pasesremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeemo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passeermo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passereo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passereom"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passermeo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passermo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passreemo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "passremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psaseremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psseremo"
+    replace: "passeremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsserà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "paserà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "pasesrà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passera"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passera'"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passera1"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passeà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passeàr"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passreà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "passrà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "psaserà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "psserà"
+    replace: "passerà"
+    word: true
+
+  - trigger: "apsserò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "paserò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "pasesrò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passero"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passero'"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passero1"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passeò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passeòr"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passreò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "passrò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "psaserò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "psserò"
+    replace: "passerò"
+    word: true
+
+  - trigger: "eprché"
+    replace: "perché"
+    word: true
+
+  - trigger: "peché"
+    replace: "perché"
+    word: true
+
+  - trigger: "pecrhé"
+    replace: "perché"
+    word: true
+
+  - trigger: "perche"
+    replace: "perché"
+    word: true
+
+  - trigger: "perche'"
+    replace: "perché"
+    word: true
+
+  - trigger: "perche1"
+    replace: "perché"
+    word: true
+
+  - trigger: "percé"
+    replace: "perché"
+    word: true
+
+  - trigger: "percéh"
+    replace: "perché"
+    word: true
+
+  - trigger: "perhcé"
+    replace: "perché"
+    word: true
+
+  - trigger: "perhé"
+    replace: "perché"
+    word: true
+
+  - trigger: "prché"
+    replace: "perché"
+    word: true
+
+  - trigger: "preché"
+    replace: "perché"
+    word: true
+
+  - trigger: "eprciò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "peciò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "pecriò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "percio"
+    replace: "perciò"
+    word: true
+
+  - trigger: "percio'"
+    replace: "perciò"
+    word: true
+
+  - trigger: "percio1"
+    replace: "perciò"
+    word: true
+
+  - trigger: "percò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "percòi"
+    replace: "perciò"
+    word: true
+
+  - trigger: "pericò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "periò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "prciò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "preciò"
+    replace: "perciò"
+    word: true
+
+  - trigger: "eprò"
+    replace: "però"
+    word: true
+
+  - trigger: "pero"
+    replace: "però"
+    word: true
+
+  - trigger: "pero'"
+    replace: "però"
+    word: true
+
+  - trigger: "pero1"
+    replace: "però"
+    word: true
+
+  - trigger: "peòr"
+    replace: "però"
+    word: true
+
+  - trigger: "preò"
+    replace: "però"
+    word: true
+
+  - trigger: "ipaceranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "paceranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "paiceranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piaceanno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacearnno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacerano"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piaceranon"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacernano"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacernno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piacreanno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piaecranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piaeranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "picaeranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "piceranno"
+    replace: "piaceranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipacerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "pacerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "paicerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piacera"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piacera'"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piacera1"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piaceà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piaceàr"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piacreà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piacrà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piaecrà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "piaerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "picaerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "picerà"
+    replace: "piacerà"
+    word: true
+
+  - trigger: "ipacerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "pacerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "paicerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piacero"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piacero'"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piacero1"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piaceò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piaceòr"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piacreò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piacrò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piaecrò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "piaerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "picaerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "picerò"
+    replace: "piacerò"
+    word: true
+
+  - trigger: "ipù"
+    replace: "più"
+    word: true
+
+  - trigger: "piu"
+    replace: "più"
+    word: true
+
+  - trigger: "piu'"
+    replace: "più"
+    word: true
+
+  - trigger: "piu1"
+    replace: "più"
+    word: true
+
+  - trigger: "pùi"
+    replace: "più"
+    word: true
+
+  - trigger: "opiché"
+    replace: "poiché"
+    word: true
+
+  - trigger: "piché"
+    replace: "poiché"
+    word: true
+
+  - trigger: "pioché"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poché"
+    replace: "poiché"
+    word: true
+
+  - trigger: "pocihé"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poiche"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poiche'"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poiche1"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poicé"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poicéh"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poihcé"
+    replace: "poiché"
+    word: true
+
+  - trigger: "poihé"
+    replace: "poiché"
+    word: true
+
+  - trigger: "opssibilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "posibilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "posisbilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possbiilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possbilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibiiltà"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibiità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibilita"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibilita'"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibilita1"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibilià"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibiliàt"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibiltià"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibiltà"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possibliità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possiblità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possiiblità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "possiilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "psosibilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "pssibilità"
+    replace: "possibilità"
+    word: true
+
+  - trigger: "optrai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "porai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "portai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "potai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "potari"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "potri"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "potria"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptorai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptrai"
+    replace: "potrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "optranno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "poranno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "portanno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potanno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potarnno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrano"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potranon"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrnano"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrnno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptoranno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptranno"
+    replace: "potranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "optremo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "poremo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "portemo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potemo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potermo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potreo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potreom"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrmeo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrmo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptoremo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptremo"
+    replace: "potremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "optrà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "portà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "porà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "potra"
+    replace: "potrà"
+    word: true
+
+  - trigger: "potra'"
+    replace: "potrà"
+    word: true
+
+  - trigger: "potra1"
+    replace: "potrà"
+    word: true
+
+  - trigger: "potà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "potàr"
+    replace: "potrà"
+    word: true
+
+  - trigger: "ptorà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "ptrà"
+    replace: "potrà"
+    word: true
+
+  - trigger: "optrò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "portò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "porò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "potro"
+    replace: "potrò"
+    word: true
+
+  - trigger: "potro'"
+    replace: "potrò"
+    word: true
+
+  - trigger: "potro1"
+    replace: "potrò"
+    word: true
+
+  - trigger: "potò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "potòr"
+    replace: "potrò"
+    word: true
+
+  - trigger: "ptorò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "ptrò"
+    replace: "potrò"
+    word: true
+
+  - trigger: "penderai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pernderai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prederai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prednerai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeari"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenderi"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenderia"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendrai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendreai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenedrai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenerai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnderai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnederai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpenderai"
+    replace: "prenderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "penderanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pernderanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prederanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "predneranno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendearnno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenderano"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenderanon"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendernano"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendernno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendranno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendreanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenedranno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preneranno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnderanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnederanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpenderanno"
+    replace: "prenderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "penderemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pernderemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prederemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "predneremo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeermo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendereo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendereom"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendermeo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendermo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendreemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendremo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenedremo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preneremo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnderemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnederemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpenderemo"
+    replace: "prenderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "penderà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "pernderà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prederà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prednerà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendera"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendera'"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendera1"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendeà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendeàr"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendreà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prendrà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prenedrà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prenerà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prnderà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "prnederà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "rpenderà"
+    replace: "prenderà"
+    word: true
+
+  - trigger: "penderò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "pernderò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prederò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prednerò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendero"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendero'"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendero1"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendeò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendeòr"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendreò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prendrò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prenedrò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prenerò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prnderò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "prnederò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "rpenderò"
+    replace: "prenderò"
+    word: true
+
+  - trigger: "peparerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "perparerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "preaprerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prearerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaerrai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareari"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareri"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareria"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparrai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparreai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepraerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "preprerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prparerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prpearerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpeparerai"
+    replace: "preparerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pepareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "perpareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preapreranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaeranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaerranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareanno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparearnno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparerano"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareranon"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparernano"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparernno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparreanno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepraeranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepreranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prpareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prpeareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpepareranno"
+    replace: "prepareranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pepareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "perpareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preapreremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaeremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepaerremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareemo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepareermo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparereo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparereom"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparermeo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparermo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparreemo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "preparremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepraeremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prepreremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prpareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prpeareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpepareremo"
+    replace: "prepareremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "peparerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "perparerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preaprerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prearerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prepaerrà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prepaerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preparera"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preparera'"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preparera1"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prepareà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prepareàr"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preparreà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preparrà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prepraerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "preprerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prparerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "prpearerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "rpeparerà"
+    replace: "preparerà"
+    word: true
+
+  - trigger: "peparerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "perparerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preaprerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prearerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prepaerrò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prepaerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preparero"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preparero'"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preparero1"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prepareò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prepareòr"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preparreò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preparrò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prepraerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "preprerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prparerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "prpearerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "rpeparerò"
+    replace: "preparerò"
+    word: true
+
+  - trigger: "porverai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "poverai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proerai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proevrai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveari"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveri"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveria"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "provrai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "provreai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prverai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "prvoerai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoverai"
+    replace: "proverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "porveranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "poveranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "proeranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "proevranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveanno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "provearnno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "proverano"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveranon"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "provernano"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "provernno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "provranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "provreanno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prveranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "prvoeranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoveranno"
+    replace: "proveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "porveremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "poveremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proeremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proevremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveemo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proveermo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provereo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provereom"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provermeo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provermo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provreemo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "provremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prveremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prvoeremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoveremo"
+    replace: "proveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "porverà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "poverà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "proerà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "proevrà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "provera"
+    replace: "proverà"
+    word: true
+
+  - trigger: "provera'"
+    replace: "proverà"
+    word: true
+
+  - trigger: "provera1"
+    replace: "proverà"
+    word: true
+
+  - trigger: "proveà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "proveàr"
+    replace: "proverà"
+    word: true
+
+  - trigger: "provreà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "provrà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "prverà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "prvoerà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "rpoverà"
+    replace: "proverà"
+    word: true
+
+  - trigger: "porverò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "poverò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "proerò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "proevrò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "provero"
+    replace: "proverò"
+    word: true
+
+  - trigger: "provero'"
+    replace: "proverò"
+    word: true
+
+  - trigger: "provero1"
+    replace: "proverò"
+    word: true
+
+  - trigger: "proveò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "proveòr"
+    replace: "proverò"
+    word: true
+
+  - trigger: "provreò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "provrò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "prverò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "prvoerò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "rpoverò"
+    replace: "proverò"
+    word: true
+
+  - trigger: "pbblicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbublicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbilcherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblcherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblciherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicehrai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicerai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheari"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheri"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheria"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichrai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichreai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblihcerai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbliherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "publbicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "publicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "upbblicherai"
+    replace: "pubblicherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbblicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbublicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbilcheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblcheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblciheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicehranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbliceranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheanno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichearnno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicherano"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheranon"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichernano"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichernno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichreanno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblihceranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbliheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "publbicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "publicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "upbblicheranno"
+    replace: "pubblicheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbblicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbublicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbilcheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblcheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblciheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicehremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbliceremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheemo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblicheermo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichereo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichereom"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichermeo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichermo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichreemo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblichremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubblihceremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pubbliheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "publbicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "publicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "upbblicheremo"
+    replace: "pubblicheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pbblicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pbublicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubbicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubbilcherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblcherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblciherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblicehrà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblicerà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblichera"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblichera'"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblichera1"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblicheà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblicheàr"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblichreà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblichrà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubblihcerà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pubbliherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "publbicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "publicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "upbblicherà"
+    replace: "pubblicherà"
+    word: true
+
+  - trigger: "pbblicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pbublicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubbicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubbilcherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblcherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblciherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblicehrò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblicerò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblichero"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblichero'"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblichero1"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblicheò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblicheòr"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblichreò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblichrò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubblihcerò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pubbliherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "publbicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "publicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "upbblicherò"
+    replace: "pubblicherò"
+    word: true
+
+  - trigger: "pruché"
+    replace: "purché"
+    word: true
+
+  - trigger: "puché"
+    replace: "purché"
+    word: true
+
+  - trigger: "pucrhé"
+    replace: "purché"
+    word: true
+
+  - trigger: "purche"
+    replace: "purché"
+    word: true
+
+  - trigger: "purche'"
+    replace: "purché"
+    word: true
+
+  - trigger: "purche1"
+    replace: "purché"
+    word: true
+
+  - trigger: "purcé"
+    replace: "purché"
+    word: true
+
+  - trigger: "purcéh"
+    replace: "purché"
+    word: true
+
+  - trigger: "purhcé"
+    replace: "purché"
+    word: true
+
+  - trigger: "purhé"
+    replace: "purché"
+    word: true
+
+  - trigger: "uprché"
+    replace: "purché"
+    word: true
+
+  - trigger: "puo"
+    replace: "può"
+    word: true
+
+  - trigger: "puo'"
+    replace: "può"
+    word: true
+
+  - trigger: "puo1"
+    replace: "può"
+    word: true
+
+  - trigger: "pòu"
+    replace: "può"
+    word: true
+
+  - trigger: "upò"
+    replace: "può"
+    word: true
+
+  - trigger: "qalità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qaulità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "quailtà"
+    replace: "qualità"
+    word: true
+
+  - trigger: "quaità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualita"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualita'"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualita1"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualià"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualiàt"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualtià"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qualtà"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qulaità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qulità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "uqalità"
+    replace: "qualità"
+    word: true
+
+  - trigger: "qantità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "qauntità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quanittà"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quanità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quantita"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quantita'"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quantita1"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quantià"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quantiàt"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quanttià"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quanttà"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quatità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quatnità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "qunatità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "quntità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "uqantità"
+    replace: "quantità"
+    word: true
+
+  - trigger: "eraltà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "raeltà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "raltà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "realta"
+    replace: "realtà"
+    word: true
+
+  - trigger: "realta'"
+    replace: "realtà"
+    word: true
+
+  - trigger: "realta1"
+    replace: "realtà"
+    word: true
+
+  - trigger: "realà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "realàt"
+    replace: "realtà"
+    word: true
+
+  - trigger: "reatlà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "reatà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "relatà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "reltà"
+    replace: "realtà"
+    word: true
+
+  - trigger: "ersponsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "reponsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "repsonsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "resonsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "resopnsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "respnosabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "respnsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responasbilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabiiltà"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabiità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabilita"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabilita'"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabilita1"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabilià"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabiliàt"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabiltià"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabiltà"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsabliità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsablità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsaiblità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsailità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsbailità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "responsbilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "resposabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "resposnabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "rseponsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "rsponsabilità"
+    replace: "responsabilità"
+    word: true
+
+  - trigger: "ersterai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "reserai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "resetrai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteari"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteri"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteria"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "restrai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "restreai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "reterai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "retserai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseterai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsterai"
+    replace: "resterai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersteranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "reseranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resetranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteanno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "restearnno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resterano"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteranon"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resternano"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "resternno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "restranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "restreanno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "reteranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "retseranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseteranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsteranno"
+    replace: "resteranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersteremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "reseremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "resetremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteemo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "resteermo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restereo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restereom"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restermeo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restermo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restreemo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "restremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "reteremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "retseremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseteremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsteremo"
+    replace: "resteremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersterà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "reserà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "resetrà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "restera"
+    replace: "resterà"
+    word: true
+
+  - trigger: "restera'"
+    replace: "resterà"
+    word: true
+
+  - trigger: "restera1"
+    replace: "resterà"
+    word: true
+
+  - trigger: "resteà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "resteàr"
+    replace: "resterà"
+    word: true
+
+  - trigger: "restreà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "restrà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "reterà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "retserà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "rseterà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "rsterà"
+    replace: "resterà"
+    word: true
+
+  - trigger: "ersterò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "reserò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "resetrò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "restero"
+    replace: "resterò"
+    word: true
+
+  - trigger: "restero'"
+    replace: "resterò"
+    word: true
+
+  - trigger: "restero1"
+    replace: "resterò"
+    word: true
+
+  - trigger: "resteò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "resteòr"
+    replace: "resterò"
+    word: true
+
+  - trigger: "restreò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "restrò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "reterò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "retserò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "rseterò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "rsterò"
+    replace: "resterò"
+    word: true
+
+  - trigger: "irceverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcieverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceerai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceevrai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveari"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveri"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveria"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevrai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevreai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricveerai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riecverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rieverai"
+    replace: "riceverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "irceveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcieveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceeranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceevranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveanno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevearnno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceverano"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveranon"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevernano"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevernno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevreanno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricveeranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riecveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rieveranno"
+    replace: "riceveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "irceveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcieveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceeremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceevremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveemo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riceveermo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevereo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevereom"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevermeo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevermo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevreemo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricevremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricveeremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ricveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riecveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rieveremo"
+    replace: "riceveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "irceverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "rceverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "rcieverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "riceerà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "riceevrà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricevera"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricevera'"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricevera1"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "riceveà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "riceveàr"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricevreà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricevrà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricveerà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "ricverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "riecverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "rieverà"
+    replace: "riceverà"
+    word: true
+
+  - trigger: "irceverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "rceverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "rcieverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "riceerò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "riceevrò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricevero"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricevero'"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricevero1"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "riceveò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "riceveòr"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricevreò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricevrò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricveerò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "ricverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "riecverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "rieverò"
+    replace: "riceverò"
+    word: true
+
+  - trigger: "irmarrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riamrrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riarrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarari"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarri"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarria"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimrarai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimrrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmarrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmiarrai"
+    replace: "rimarrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "irmarranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riamrranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riarranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimaranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimararnno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarrano"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarranon"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarrnano"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarrnno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimraranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimrranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmarranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmiarranno"
+    replace: "rimarranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "irmarremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riamrremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riarremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimaremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarermo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarreo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarreom"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarrmeo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimarrmo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimraremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rimrremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmarremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmiarremo"
+    replace: "rimarremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "irmarrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "riamrrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "riarrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimarra"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimarra'"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimarra1"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimarà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimaràr"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimrarà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rimrrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rmarrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "rmiarrà"
+    replace: "rimarrà"
+    word: true
+
+  - trigger: "irmarrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "riamrrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "riarrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimarro"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimarro'"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimarro1"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimarò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimaròr"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimrarò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rimrrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rmarrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "rmiarrò"
+    replace: "rimarrò"
+    word: true
+
+  - trigger: "irsolverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riolverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rioslverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risloverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rislverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolerai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolevrai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveari"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveri"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveria"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvrai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvreai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risoverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risovlerai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiolverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsolverai"
+    replace: "risolverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsolveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riolveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rioslveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risloveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rislveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risoleranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolevranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveanno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvearnno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolverano"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveranon"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvernano"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvernno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvreanno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risoveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risovleranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiolveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsolveranno"
+    replace: "risolveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsolveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riolveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rioslveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risloveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rislveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risoleremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolevremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveemo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolveermo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvereo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvereom"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvermeo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvermo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvreemo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risolvremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risoveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risovleremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiolveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsolveremo"
+    replace: "risolveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsolverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "riolverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "rioslverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risloverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "rislverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolerà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolevrà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolvera"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolvera'"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolvera1"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolveà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolveàr"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolvreà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risolvrà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risoverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "risovlerà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "rsiolverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "rsolverà"
+    replace: "risolverà"
+    word: true
+
+  - trigger: "irsolverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "riolverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "rioslverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risloverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "rislverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolerò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolevrò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolvero"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolvero'"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolvero1"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolveò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolveòr"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolvreò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risolvrò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risoverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "risovlerò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "rsiolverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "rsolverò"
+    replace: "risolverò"
+    word: true
+
+  - trigger: "irsponderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "riponderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ripsonderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risonderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risopnderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnoderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispoderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispodnerai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondeai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondeari"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponderi"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponderia"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondrai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondreai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponedrai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponerai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiponderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsponderai"
+    replace: "risponderai"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsponderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "riponderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ripsonderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risonderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risopnderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnoderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispoderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispodneranno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondeanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondearnno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponderano"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponderanon"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondernano"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondernno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondranno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondreanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponedranno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponeranno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiponderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsponderanno"
+    replace: "risponderanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsponderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "riponderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ripsonderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risonderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risopnderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispnoderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispoderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispodneremo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondeemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondeermo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondereo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondereom"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondermeo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondermo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondreemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispondremo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponedremo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "risponeremo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiponderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsponderemo"
+    replace: "risponderemo"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsponderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "riponderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "ripsonderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "risonderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "risopnderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispnderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispnoderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispoderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispodnerà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondera"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondera'"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondera1"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondeà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondeàr"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondreà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rispondrà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "risponedrà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "risponerà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rsiponderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "rsponderà"
+    replace: "risponderà"
+    word: true
+
+  - trigger: "irsponderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "riponderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "ripsonderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "risonderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "risopnderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispnderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispnoderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispoderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispodnerò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondero"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondero'"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondero1"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondeò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondeòr"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondreò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rispondrò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "risponedrò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "risponerò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rsiponderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "rsponderò"
+    replace: "risponderò"
+    word: true
+
+  - trigger: "asprai"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapai"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapari"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapri"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapria"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarpai"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sparai"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sprai"
+    replace: "saprai"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspranno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapanno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saparnno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saprano"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapranon"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saprnano"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saprnno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarpanno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sparanno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spranno"
+    replace: "sapranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspremo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapemo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapermo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapreo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapreom"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "saprmeo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "saprmo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarpemo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sparemo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spremo"
+    replace: "sapremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "asprà"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sapra"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sapra'"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sapra1"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sapà"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sapàr"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sarpà"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sparà"
+    replace: "saprà"
+    word: true
+
+  - trigger: "sprà"
+    replace: "saprà"
+    word: true
+
+  - trigger: "asprò"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sapro"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sapro'"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sapro1"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sapò"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sapòr"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sarpò"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sparò"
+    replace: "saprò"
+    word: true
+
+  - trigger: "sprò"
+    replace: "saprò"
+    word: true
+
+  - trigger: "asrai"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "saai"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "saari"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sari"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "saria"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sraai"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "srai"
+    replace: "sarai"
+    propagate_case: true
+    word: true
+
+  - trigger: "asranno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saanno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saarnno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarano"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "saranon"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarnano"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarnno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sraanno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sranno"
+    replace: "saranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "asremo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "saemo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "saermo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sareo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sareom"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarmeo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarmo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sraemo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sremo"
+    replace: "saremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "asrà"
+    replace: "sarà"
+    word: true
+
+  - trigger: "sara"
+    replace: "sarà"
+    word: true
+
+  - trigger: "sara'"
+    replace: "sarà"
+    word: true
+
+  - trigger: "sara1"
+    replace: "sarà"
+    word: true
+
+  - trigger: "saàr"
+    replace: "sarà"
+    word: true
+
+  - trigger: "sraà"
+    replace: "sarà"
+    word: true
+
+  - trigger: "asrò"
+    replace: "sarò"
+    word: true
+
+  - trigger: "saro"
+    replace: "sarò"
+    word: true
+
+  - trigger: "saro'"
+    replace: "sarò"
+    word: true
+
+  - trigger: "saro1"
+    replace: "sarò"
+    word: true
+
+  - trigger: "saòr"
+    replace: "sarò"
+    word: true
+
+  - trigger: "sraò"
+    replace: "sarò"
+    word: true
+
+  - trigger: "csriverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scirverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sciverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrierai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrievrai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveari"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveri"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveria"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivrai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivreai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrvierai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "srciverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sriverai"
+    replace: "scriverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "csriveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scirveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sciveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrieranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrievranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveanno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivearnno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriverano"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveranon"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivernano"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivernno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivreanno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrvieranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "srciveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sriveranno"
+    replace: "scriveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "csriveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scirveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sciveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrieremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrievremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveemo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveermo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivereo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivereom"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivermeo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivermo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivreemo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrvieremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "srciveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sriveremo"
+    replace: "scriveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "csriverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scirverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "sciverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrierà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrievrà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrivera"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrivera'"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrivera1"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scriveà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scriveàr"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrivreà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrivrà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "scrvierà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "srciverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "sriverà"
+    replace: "scriverà"
+    word: true
+
+  - trigger: "csriverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scirverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "sciverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrierò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrievrò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrivero"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrivero'"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrivero1"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scriveò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scriveòr"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrivreò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrivrò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "scrvierò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "srciverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "sriverò"
+    replace: "scriverò"
+    word: true
+
+  - trigger: "esnsibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "senibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "senisbilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensbiilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensbilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibiiltà"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibiità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibilita"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibilita'"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibilita1"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibilià"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibiliàt"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibiltià"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibiltà"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensibliità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensiblità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensiiblità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sensiilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sesibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "sesnibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "snesibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "snsibilità"
+    replace: "sensibilità"
+    word: true
+
+  - trigger: "esntirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "senirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "senitrai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiari"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiri"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiria"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentrai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentriai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "setirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "setnirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "snetirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sntirai"
+    replace: "sentirai"
+    propagate_case: true
+    word: true
+
+  - trigger: "esntiranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "seniranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "senitranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentianno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiarnno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentirano"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiranon"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentirnano"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentirnno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentrianno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "setiranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "setniranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "snetiranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sntiranno"
+    replace: "sentiranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "esntiremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "seniremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "senitremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiemo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentiermo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentireo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentireom"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentirmeo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentirmo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentriemo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "setiremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "setniremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "snetiremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sntiremo"
+    replace: "sentiremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "esntirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "senirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "senitrà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentira"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentira'"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentira1"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentià"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentiàr"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentrià"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sentrà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "setirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "setnirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "snetirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "sntirà"
+    replace: "sentirà"
+    word: true
+
+  - trigger: "esntirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "senirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "senitrò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentiro"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentiro'"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentiro1"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentiò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentiòr"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentriò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sentrò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "setirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "setnirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "snetirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "sntirò"
+    replace: "sentirò"
+    word: true
+
+  - trigger: "psiegherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "siegherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sipegherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spegherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "speigherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegehrai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegerai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheari"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheri"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheria"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghrai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghreai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiehgerai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigeherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigherai"
+    replace: "spiegherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "psiegheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "siegheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sipegheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spegheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "speigheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegehranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegeranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheanno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghearnno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegherano"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheranon"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghernano"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghernno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghreanno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiehgeranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigeheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigheranno"
+    replace: "spiegheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "psiegheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "siegheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sipegheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spegheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "speigheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegehremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegeremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheemo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiegheermo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghereo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghereom"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghermeo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghermo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghreemo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieghremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spieheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiehgeremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigeheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "spigheremo"
+    replace: "spiegheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psiegherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "siegherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "sipegherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spegherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "speigherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spiegehrà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spiegerà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieghera"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieghera'"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieghera1"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spiegheà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spiegheàr"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieghreà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieghrà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spieherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spiehgerà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spigeherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "spigherà"
+    replace: "spiegherà"
+    word: true
+
+  - trigger: "psiegherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "siegherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "sipegherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spegherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "speigherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spiegehrò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spiegerò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieghero"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieghero'"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieghero1"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spiegheò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spiegheòr"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieghreò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieghrò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spieherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spiehgerò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spigeherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "spigherò"
+    replace: "spiegherò"
+    word: true
+
+  - trigger: "satrai"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "staai"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "staari"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "stari"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "staria"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "straai"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "strai"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsarai"
+    replace: "starai"
+    propagate_case: true
+    word: true
+
+  - trigger: "satranno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "staanno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "staarnno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "starano"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "staranon"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "starnano"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "starnno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "straanno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "stranno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsaranno"
+    replace: "staranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "satremo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "staemo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "staermo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "stareo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "stareom"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "starmeo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "starmo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "straemo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "stremo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsaremo"
+    replace: "staremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "satrà"
+    replace: "starà"
+    word: true
+
+  - trigger: "stara"
+    replace: "starà"
+    word: true
+
+  - trigger: "stara'"
+    replace: "starà"
+    word: true
+
+  - trigger: "stara1"
+    replace: "starà"
+    word: true
+
+  - trigger: "staà"
+    replace: "starà"
+    word: true
+
+  - trigger: "staàr"
+    replace: "starà"
+    word: true
+
+  - trigger: "straà"
+    replace: "starà"
+    word: true
+
+  - trigger: "strà"
+    replace: "starà"
+    word: true
+
+  - trigger: "tsarà"
+    replace: "starà"
+    word: true
+
+  - trigger: "satrò"
+    replace: "starò"
+    word: true
+
+  - trigger: "staro"
+    replace: "starò"
+    word: true
+
+  - trigger: "staro'"
+    replace: "starò"
+    word: true
+
+  - trigger: "staro1"
+    replace: "starò"
+    word: true
+
+  - trigger: "staò"
+    replace: "starò"
+    word: true
+
+  - trigger: "staòr"
+    replace: "starò"
+    word: true
+
+  - trigger: "straò"
+    replace: "starò"
+    word: true
+
+  - trigger: "strò"
+    replace: "starò"
+    word: true
+
+  - trigger: "tsarò"
+    replace: "starò"
+    word: true
+
+  - trigger: "etrrai"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "terai"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "terari"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "terri"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "terria"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trerai"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trrai"
+    replace: "terrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrranno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "teranno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "terarnno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrano"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "terranon"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrnano"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrnno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "treranno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trranno"
+    replace: "terranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrremo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "teremo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "terermo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "terreo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "terreom"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrmeo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrmo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "treremo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trremo"
+    replace: "terremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrrà"
+    replace: "terrà"
+    word: true
+
+  - trigger: "terra"
+    replace: "terrà"
+    word: true
+
+  - trigger: "terra'"
+    replace: "terrà"
+    word: true
+
+  - trigger: "terra1"
+    replace: "terrà"
+    word: true
+
+  - trigger: "terà"
+    replace: "terrà"
+    word: true
+
+  - trigger: "teràr"
+    replace: "terrà"
+    word: true
+
+  - trigger: "trerà"
+    replace: "terrà"
+    word: true
+
+  - trigger: "trrà"
+    replace: "terrà"
+    word: true
+
+  - trigger: "etrrò"
+    replace: "terrò"
+    word: true
+
+  - trigger: "terro"
+    replace: "terrò"
+    word: true
+
+  - trigger: "terro'"
+    replace: "terrò"
+    word: true
+
+  - trigger: "terro1"
+    replace: "terrò"
+    word: true
+
+  - trigger: "terò"
+    replace: "terrò"
+    word: true
+
+  - trigger: "teròr"
+    replace: "terrò"
+    word: true
+
+  - trigger: "trerò"
+    replace: "terrò"
+    word: true
+
+  - trigger: "trrò"
+    replace: "terrò"
+    word: true
+
+  - trigger: "otrnerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonrerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torenrai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneari"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneri"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneria"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornrai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornreai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "tronerai"
+    replace: "tornerai"
+    propagate_case: true
+    word: true
+
+  - trigger: "otrneranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "toneranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonreranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "torenranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "toreranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneanno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornearnno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornerano"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneranon"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornernano"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornernno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornreanno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trneranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troneranno"
+    replace: "torneranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "otrneremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "toneremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonreremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "torenremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "toreremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneemo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "torneermo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornereo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornereom"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornermeo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornermo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornreemo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trneremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "troneremo"
+    replace: "torneremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "otrnerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tonerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tonrerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "torenrà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "torerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tornera"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tornera'"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tornera1"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "torneà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "torneàr"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tornreà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tornrà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "trnerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "tronerà"
+    replace: "tornerà"
+    word: true
+
+  - trigger: "otrnerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tonerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tonrerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "torenrò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "torerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tornero"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tornero'"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tornero1"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "torneò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "torneòr"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tornreò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tornrò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "trnerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "tronerò"
+    replace: "tornerò"
+    word: true
+
+  - trigger: "rtoverai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "torverai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "toverai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troerai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troevrai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveari"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveri"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveria"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovrai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovreai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trverai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "trvoerai"
+    replace: "troverai"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtoveranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "torveranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "toveranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troeranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troevranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveanno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovearnno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troverano"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveranon"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovernano"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovernno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovreanno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trveranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "trvoeranno"
+    replace: "troveranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtoveremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "torveremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "toveremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "troeremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "troevremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveemo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "troveermo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovereo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovereom"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovermeo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovermo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovreemo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trveremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trvoeremo"
+    replace: "troveremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtoverà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "torverà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "toverà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "troerà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "troevrà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trovera"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trovera'"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trovera1"
+    replace: "troverà"
+    word: true
+
+  - trigger: "troveà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "troveàr"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trovreà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trovrà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trverà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "trvoerà"
+    replace: "troverà"
+    word: true
+
+  - trigger: "rtoverò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "torverò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "toverò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "troerò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "troevrò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trovero"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trovero'"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trovero1"
+    replace: "troverò"
+    word: true
+
+  - trigger: "troveò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "troveòr"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trovreò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trovrò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trverò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "trvoerò"
+    replace: "troverò"
+    word: true
+
+  - trigger: "nuiversità"
+    replace: "università"
+    word: true
+
+  - trigger: "uinversità"
+    replace: "università"
+    word: true
+
+  - trigger: "uiversità"
+    replace: "università"
+    word: true
+
+  - trigger: "uniersità"
+    replace: "università"
+    word: true
+
+  - trigger: "unievrsità"
+    replace: "università"
+    word: true
+
+  - trigger: "univeristà"
+    replace: "università"
+    word: true
+
+  - trigger: "univerità"
+    replace: "università"
+    word: true
+
+  - trigger: "universita"
+    replace: "università"
+    word: true
+
+  - trigger: "universita'"
+    replace: "università"
+    word: true
+
+  - trigger: "universita1"
+    replace: "università"
+    word: true
+
+  - trigger: "universià"
+    replace: "università"
+    word: true
+
+  - trigger: "universiàt"
+    replace: "università"
+    word: true
+
+  - trigger: "universtià"
+    replace: "università"
+    word: true
+
+  - trigger: "universtà"
+    replace: "università"
+    word: true
+
+  - trigger: "univesità"
+    replace: "università"
+    word: true
+
+  - trigger: "univesrità"
+    replace: "università"
+    word: true
+
+  - trigger: "univresità"
+    replace: "università"
+    word: true
+
+  - trigger: "univrsità"
+    replace: "università"
+    word: true
+
+  - trigger: "unversità"
+    replace: "università"
+    word: true
+
+  - trigger: "unviersità"
+    replace: "università"
+    word: true
+
+  - trigger: "suerai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "uerai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "uesrai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "useai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "useari"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "useri"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "useria"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "usrai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "usreai"
+    replace: "userai"
+    propagate_case: true
+    word: true
+
+  - trigger: "sueranno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ueranno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "uesranno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "useanno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "usearnno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "userano"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "useranon"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "usernano"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "usernno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "usranno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "usreanno"
+    replace: "useranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "sueremo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ueremo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "uesremo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "useemo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "useermo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usereo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usereom"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usermeo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usermo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usreemo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "usremo"
+    replace: "useremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "suerà"
+    replace: "userà"
+    word: true
+
+  - trigger: "uerà"
+    replace: "userà"
+    word: true
+
+  - trigger: "uesrà"
+    replace: "userà"
+    word: true
+
+  - trigger: "usera"
+    replace: "userà"
+    word: true
+
+  - trigger: "usera'"
+    replace: "userà"
+    word: true
+
+  - trigger: "usera1"
+    replace: "userà"
+    word: true
+
+  - trigger: "useà"
+    replace: "userà"
+    word: true
+
+  - trigger: "useàr"
+    replace: "userà"
+    word: true
+
+  - trigger: "usreà"
+    replace: "userà"
+    word: true
+
+  - trigger: "usrà"
+    replace: "userà"
+    word: true
+
+  - trigger: "suerò"
+    replace: "userò"
+    word: true
+
+  - trigger: "uerò"
+    replace: "userò"
+    word: true
+
+  - trigger: "uesrò"
+    replace: "userò"
+    word: true
+
+  - trigger: "usero"
+    replace: "userò"
+    word: true
+
+  - trigger: "usero'"
+    replace: "userò"
+    word: true
+
+  - trigger: "usero1"
+    replace: "userò"
+    word: true
+
+  - trigger: "useò"
+    replace: "userò"
+    word: true
+
+  - trigger: "useòr"
+    replace: "userò"
+    word: true
+
+  - trigger: "usreò"
+    replace: "userò"
+    word: true
+
+  - trigger: "usrò"
+    replace: "userò"
+    word: true
+
+  - trigger: "tuilità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "uilità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "uitlità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utiiltà"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utiità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utilita"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utilita'"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utilita1"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utilià"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utiliàt"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utiltià"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utiltà"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utliità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "utlità"
+    replace: "utilità"
+    word: true
+
+  - trigger: "evdrai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vderai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdrai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedari"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedri"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedria"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verdai"
+    replace: "vedrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "evdranno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vderanno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdranno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedanno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedarnno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedrano"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedranon"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedrnano"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedrnno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "veranno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verdanno"
+    replace: "vedranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "evdremo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vderemo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdremo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedemo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedermo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedreo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedreom"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedrmeo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedrmo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verdemo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "veremo"
+    replace: "vedremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "evdrà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vderà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vdrà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vedra"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vedra'"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vedra1"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vedà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "vedàr"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "verdà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "verà"
+    replace: "vedrà"
+    word: true
+
+  - trigger: "evdrò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vderò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vdrò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vedro"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vedro'"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vedro1"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vedò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "vedòr"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "verdò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "verò"
+    replace: "vedrò"
+    word: true
+
+  - trigger: "evnerdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "veenrdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "veerdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venedrì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venedì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venerdi"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venerdi'"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venerdi1"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venerì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venerìd"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venrdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "venredì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "vneerdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "vnerdì"
+    replace: "venerdì"
+    word: true
+
+  - trigger: "evrificherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "veificherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "veirficherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verficherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verfiicherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifcherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifciherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificehrai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificerai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheari"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheri"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheria"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichrai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichreai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifihcerai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifiherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriicherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriifcherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreificherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrificherai"
+    replace: "verificherai"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrificheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "veificheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "veirficheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verficheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verfiicheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifcheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifciheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificehranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificeranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheanno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichearnno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificherano"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheranon"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichernano"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichernno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichreanno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifihceranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifiheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriicheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriifcheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreificheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrificheranno"
+    replace: "verificheranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrificheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "veificheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "veirficheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verficheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verfiicheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifcheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifciheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificehremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificeremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheemo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verificheermo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichereo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichereom"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichermeo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichermo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichreemo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifichremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifihceremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verifiheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriicheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "veriifcheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreificheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrificheremo"
+    replace: "verificheremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrificherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "veificherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "veirficherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verficherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verfiicherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifcherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifciherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verificehrà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verificerà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifichera"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifichera'"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifichera1"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verificheà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verificheàr"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifichreà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifichrà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifihcerà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "verifiherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "veriicherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "veriifcherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "vreificherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "vrificherà"
+    replace: "verificherà"
+    word: true
+
+  - trigger: "evrificherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "veificherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "veirficherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verficherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verfiicherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifcherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifciherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verificehrò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verificerò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifichero"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifichero'"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifichero1"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verificheò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verificheòr"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifichreò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifichrò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifihcerò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "verifiherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "veriicherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "veriifcherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "vreificherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "vrificherò"
+    replace: "verificherò"
+    word: true
+
+  - trigger: "evrrai"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verari"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verri"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "verria"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrerai"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrrai"
+    replace: "verrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrranno"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verarnno"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verrano"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verranon"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verrnano"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "verrnno"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreranno"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrranno"
+    replace: "verranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrremo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verermo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verreo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verreom"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verrmeo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "verrmo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreremo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrremo"
+    replace: "verremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrrà"
+    replace: "verrà"
+    word: true
+
+  - trigger: "verra"
+    replace: "verrà"
+    word: true
+
+  - trigger: "verra'"
+    replace: "verrà"
+    word: true
+
+  - trigger: "verra1"
+    replace: "verrà"
+    word: true
+
+  - trigger: "veràr"
+    replace: "verrà"
+    word: true
+
+  - trigger: "vrerà"
+    replace: "verrà"
+    word: true
+
+  - trigger: "vrrà"
+    replace: "verrà"
+    word: true
+
+  - trigger: "evrrò"
+    replace: "verrò"
+    word: true
+
+  - trigger: "verro"
+    replace: "verrò"
+    word: true
+
+  - trigger: "verro'"
+    replace: "verrò"
+    word: true
+
+  - trigger: "verro1"
+    replace: "verrò"
+    word: true
+
+  - trigger: "veròr"
+    replace: "verrò"
+    word: true
+
+  - trigger: "vrerò"
+    replace: "verrò"
+    word: true
+
+  - trigger: "vrrò"
+    replace: "verrò"
+    word: true
+
+  - trigger: "ovrrai"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorai"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorari"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorri"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorria"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrorai"
+    replace: "vorrai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovrranno"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "voranno"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorarnno"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorrano"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorranon"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorrnano"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorrnno"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vroranno"
+    replace: "vorranno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovrremo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "voremo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorermo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorreo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorreom"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorrmeo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vorrmo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vroremo"
+    replace: "vorremo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovrrà"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "vorra"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "vorra'"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "vorra1"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "vorà"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "voràr"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "vrorà"
+    replace: "vorrà"
+    word: true
+
+  - trigger: "ovrrò"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "vorro"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "vorro'"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "vorro1"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "vorò"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "voròr"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "vrorò"
+    replace: "vorrò"
+    word: true
+
+  - trigger: "uvlnerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vlnerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vlunerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulenrabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulneabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnearbilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabiiltà"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabiità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabilita"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabilita'"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabilita1"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabilià"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabiliàt"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabiltià"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabiltà"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerabliità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerablità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulneraiblità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerailità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerbailità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnerbilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnrabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vulnreabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vunerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  - trigger: "vunlerabilità"
+    replace: "vulnerabilità"
+    word: true
+
+  # Short accented words (too short for the auto-generator)
+  - trigger: "e'"
+    replace: "è"
+    word: true
+
+  - trigger: "e1"
+    replace: "è"
+    word: true
+
+  - trigger: "si'"
+    replace: "sì"
+    word: true
+
+  - trigger: "si1"
+    replace: "sì"
+    word: true
+
+  - trigger: "la'"
+    replace: "là"
+    word: true
+
+  - trigger: "la1"
+    replace: "là"
+    word: true
+
+  - trigger: "li'"
+    replace: "lì"
+    word: true
+
+  - trigger: "li1"
+    replace: "lì"
+    word: true

--- a/packages/refuos-accenti/0.1.0/package.yml
+++ b/packages/refuos-accenti/0.1.0/package.yml
@@ -2205,7 +2205,6 @@ matches:
     - "afrai"
     - "faai"
     - "faari"
-    - "fari"
     - "faria"
     - "fraai"
     - "frai"
@@ -2253,7 +2252,6 @@ matches:
 
   - triggers:
     - "afrò"
-    - "faro"
     - "faro'"
     - "faro1"
     - "faòr"
@@ -3763,7 +3761,6 @@ matches:
 
   - triggers:
     - "eprò"
-    - "pero"
     - "pero'"
     - "pero1"
     - "peòr"
@@ -5127,7 +5124,6 @@ matches:
 
   - triggers:
     - "asrà"
-    - "sara"
     - "sara'"
     - "sara1"
     - "saàr"

--- a/packages/refuos-accenti/0.1.0/package.yml
+++ b/packages/refuos-accenti/0.1.0/package.yml
@@ -5,21645 +5,6316 @@
 
 matches:
 
-  - trigger: "affiché"
+  - triggers:
+    - "affiché"
+    - "afficnhé"
+    - "affinche"
+    - "affinche'"
+    - "affinche1"
+    - "affincé"
+    - "affincéh"
+    - "affinhcé"
+    - "affinhé"
+    - "affnché"
+    - "affniché"
+    - "afifnché"
+    - "afinché"
+    - "fafinché"
     replace: "affinché"
     word: true
 
-  - trigger: "afficnhé"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affinche"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affinche'"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affinche1"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affincé"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affincéh"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affinhcé"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affinhé"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affnché"
-    replace: "affinché"
-    word: true
-
-  - trigger: "affniché"
-    replace: "affinché"
-    word: true
-
-  - trigger: "afifnché"
-    replace: "affinché"
-    word: true
-
-  - trigger: "afinché"
-    replace: "affinché"
-    word: true
-
-  - trigger: "fafinché"
-    replace: "affinché"
-    word: true
-
-  - trigger: "aggionerai"
+  - triggers:
+    - "aggionerai"
+    - "aggionrerai"
+    - "aggiorenrai"
+    - "aggiorerai"
+    - "aggiorneai"
+    - "aggiorneari"
+    - "aggiorneri"
+    - "aggiorneria"
+    - "aggiornrai"
+    - "aggiornreai"
+    - "aggirnerai"
+    - "aggironerai"
+    - "aggoirnerai"
+    - "aggornerai"
+    - "agigornerai"
+    - "agiornerai"
+    - "gagiornerai"
     replace: "aggiornerai"
     propagate_case: true
     word: true
 
-  - trigger: "aggionrerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorenrai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneari"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneri"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneria"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornrai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornreai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggirnerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggironerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggoirnerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggornerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigornerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiornerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiornerai"
-    replace: "aggiornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioneranno"
+  - triggers:
+    - "aggioneranno"
+    - "aggionreranno"
+    - "aggiorenranno"
+    - "aggioreranno"
+    - "aggiorneanno"
+    - "aggiornearnno"
+    - "aggiornerano"
+    - "aggiorneranon"
+    - "aggiornernano"
+    - "aggiornernno"
+    - "aggiornranno"
+    - "aggiornreanno"
+    - "aggirneranno"
+    - "aggironeranno"
+    - "aggoirneranno"
+    - "aggorneranno"
+    - "agigorneranno"
+    - "agiorneranno"
+    - "gagiorneranno"
     replace: "aggiorneranno"
     propagate_case: true
     word: true
 
-  - trigger: "aggionreranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorenranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioreranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneanno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornearnno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornerano"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneranon"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornernano"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornernno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornreanno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggirneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggironeranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggoirneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggorneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigorneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiorneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiorneranno"
-    replace: "aggiorneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioneremo"
+  - triggers:
+    - "aggioneremo"
+    - "aggionreremo"
+    - "aggiorenremo"
+    - "aggioreremo"
+    - "aggiorneemo"
+    - "aggiorneermo"
+    - "aggiornereo"
+    - "aggiornereom"
+    - "aggiornermeo"
+    - "aggiornermo"
+    - "aggiornreemo"
+    - "aggiornremo"
+    - "aggirneremo"
+    - "aggironeremo"
+    - "aggoirneremo"
+    - "aggorneremo"
+    - "agigorneremo"
+    - "agiorneremo"
+    - "gagiorneremo"
     replace: "aggiorneremo"
     propagate_case: true
     word: true
 
-  - trigger: "aggionreremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorenremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioreremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneemo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiorneermo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornereo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornereom"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornermeo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornermo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornreemo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggirneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggironeremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggoirneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggorneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigorneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiorneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiorneremo"
-    replace: "aggiorneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggionerà"
+  - triggers:
+    - "aggionerà"
+    - "aggionrerà"
+    - "aggiorenrà"
+    - "aggiorerà"
+    - "aggiornera"
+    - "aggiornera'"
+    - "aggiornera1"
+    - "aggiorneà"
+    - "aggiorneàr"
+    - "aggiornreà"
+    - "aggiornrà"
+    - "aggirnerà"
+    - "aggironerà"
+    - "aggoirnerà"
+    - "aggornerà"
+    - "agigornerà"
+    - "agiornerà"
+    - "gagiornerà"
     replace: "aggiornerà"
     word: true
 
-  - trigger: "aggionrerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiorenrà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiorerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiornera"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiornera'"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiornera1"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiorneà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiorneàr"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiornreà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggiornrà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggirnerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggironerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggoirnerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggornerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "agigornerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "agiornerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "gagiornerà"
-    replace: "aggiornerà"
-    word: true
-
-  - trigger: "aggionerò"
+  - triggers:
+    - "aggionerò"
+    - "aggionrerò"
+    - "aggiorenrò"
+    - "aggiorerò"
+    - "aggiornero"
+    - "aggiornero'"
+    - "aggiornero1"
+    - "aggiorneò"
+    - "aggiorneòr"
+    - "aggiornreò"
+    - "aggiornrò"
+    - "aggirnerò"
+    - "aggironerò"
+    - "aggoirnerò"
+    - "aggornerò"
+    - "agigornerò"
+    - "agiornerò"
+    - "gagiornerò"
     replace: "aggiornerò"
     word: true
 
-  - trigger: "aggionrerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiorenrò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiorerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiornero"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiornero'"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiornero1"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiorneò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiorneòr"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiornreò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggiornrò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggirnerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggironerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggoirnerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggornerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "agigornerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "agiornerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "gagiornerò"
-    replace: "aggiornerò"
-    word: true
-
-  - trigger: "aggingerai"
+  - triggers:
+    - "aggingerai"
+    - "agginugerai"
+    - "aggiugerai"
+    - "aggiugnerai"
+    - "aggiunegrai"
+    - "aggiunerai"
+    - "aggiungeai"
+    - "aggiungeari"
+    - "aggiungeri"
+    - "aggiungeria"
+    - "aggiungrai"
+    - "aggiungreai"
+    - "agguingerai"
+    - "aggungerai"
+    - "agigungerai"
+    - "agiungerai"
+    - "gagiungerai"
     replace: "aggiungerai"
     propagate_case: true
     word: true
 
-  - trigger: "agginugerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugnerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiunegrai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiunerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeari"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeri"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeria"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungrai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungreai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "agguingerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggungerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigungerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiungerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiungerai"
-    replace: "aggiungerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggingeranno"
+  - triggers:
+    - "aggingeranno"
+    - "agginugeranno"
+    - "aggiugeranno"
+    - "aggiugneranno"
+    - "aggiunegranno"
+    - "aggiuneranno"
+    - "aggiungeanno"
+    - "aggiungearnno"
+    - "aggiungerano"
+    - "aggiungeranon"
+    - "aggiungernano"
+    - "aggiungernno"
+    - "aggiungranno"
+    - "aggiungreanno"
+    - "agguingeranno"
+    - "aggungeranno"
+    - "agigungeranno"
+    - "agiungeranno"
+    - "gagiungeranno"
     replace: "aggiungeranno"
     propagate_case: true
     word: true
 
-  - trigger: "agginugeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugneranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiunegranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiuneranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeanno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungearnno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungerano"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeranon"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungernano"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungernno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungreanno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "agguingeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggungeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigungeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiungeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiungeranno"
-    replace: "aggiungeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggingeremo"
+  - triggers:
+    - "aggingeremo"
+    - "agginugeremo"
+    - "aggiugeremo"
+    - "aggiugneremo"
+    - "aggiunegremo"
+    - "aggiuneremo"
+    - "aggiungeemo"
+    - "aggiungeermo"
+    - "aggiungereo"
+    - "aggiungereom"
+    - "aggiungermeo"
+    - "aggiungermo"
+    - "aggiungreemo"
+    - "aggiungremo"
+    - "agguingeremo"
+    - "aggungeremo"
+    - "agigungeremo"
+    - "agiungeremo"
+    - "gagiungeremo"
     replace: "aggiungeremo"
     propagate_case: true
     word: true
 
-  - trigger: "agginugeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiugneremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiunegremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiuneremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeemo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungeermo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungereo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungereom"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungermeo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungermo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungreemo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiungremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "agguingeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggungeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigungeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiungeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiungeremo"
-    replace: "aggiungeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggingerà"
+  - triggers:
+    - "aggingerà"
+    - "agginugerà"
+    - "aggiugerà"
+    - "aggiugnerà"
+    - "aggiunegrà"
+    - "aggiunerà"
+    - "aggiungera"
+    - "aggiungera'"
+    - "aggiungera1"
+    - "aggiungeà"
+    - "aggiungeàr"
+    - "aggiungreà"
+    - "aggiungrà"
+    - "agguingerà"
+    - "aggungerà"
+    - "agigungerà"
+    - "agiungerà"
+    - "gagiungerà"
     replace: "aggiungerà"
     word: true
 
-  - trigger: "agginugerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiugerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiugnerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiunegrà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiunerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungera"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungera'"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungera1"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungeà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungeàr"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungreà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggiungrà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "agguingerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggungerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "agigungerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "agiungerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "gagiungerà"
-    replace: "aggiungerà"
-    word: true
-
-  - trigger: "aggingerò"
+  - triggers:
+    - "aggingerò"
+    - "agginugerò"
+    - "aggiugerò"
+    - "aggiugnerò"
+    - "aggiunegrò"
+    - "aggiunerò"
+    - "aggiungero"
+    - "aggiungero'"
+    - "aggiungero1"
+    - "aggiungeò"
+    - "aggiungeòr"
+    - "aggiungreò"
+    - "aggiungrò"
+    - "agguingerò"
+    - "aggungerò"
+    - "agigungerò"
+    - "agiungerò"
+    - "gagiungerò"
     replace: "aggiungerò"
     word: true
 
-  - trigger: "agginugerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiugerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiugnerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiunegrò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiunerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungero"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungero'"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungero1"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungeò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungeòr"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungreò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggiungrò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "agguingerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aggungerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "agigungerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "agiungerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "gagiungerò"
-    replace: "aggiungerò"
-    word: true
-
-  - trigger: "aiterai"
+  - triggers:
+    - "aiterai"
+    - "aituerai"
+    - "aiuerai"
+    - "aiuetrai"
+    - "aiuteai"
+    - "aiuteari"
+    - "aiuteri"
+    - "aiuteria"
+    - "aiutrai"
+    - "aiutreai"
+    - "auiterai"
+    - "auterai"
+    - "iauterai"
     replace: "aiuterai"
     propagate_case: true
     word: true
 
-  - trigger: "aituerai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuerai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuetrai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteari"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteri"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteria"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutrai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutreai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "auiterai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "auterai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iauterai"
-    replace: "aiuterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiteranno"
+  - triggers:
+    - "aiteranno"
+    - "aitueranno"
+    - "aiueranno"
+    - "aiuetranno"
+    - "aiuteanno"
+    - "aiutearnno"
+    - "aiuterano"
+    - "aiuteranon"
+    - "aiuternano"
+    - "aiuternno"
+    - "aiutranno"
+    - "aiutreanno"
+    - "auiteranno"
+    - "auteranno"
+    - "iauteranno"
     replace: "aiuteranno"
     propagate_case: true
     word: true
 
-  - trigger: "aitueranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiueranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuetranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteanno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutearnno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuterano"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteranon"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuternano"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuternno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutreanno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "auiteranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "auteranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iauteranno"
-    replace: "aiuteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiteremo"
+  - triggers:
+    - "aiteremo"
+    - "aitueremo"
+    - "aiueremo"
+    - "aiuetremo"
+    - "aiuteemo"
+    - "aiuteermo"
+    - "aiutereo"
+    - "aiutereom"
+    - "aiutermeo"
+    - "aiutermo"
+    - "aiutreemo"
+    - "aiutremo"
+    - "auiteremo"
+    - "auteremo"
+    - "iauteremo"
     replace: "aiuteremo"
     propagate_case: true
     word: true
 
-  - trigger: "aitueremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiueremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuetremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteemo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuteermo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutereo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutereom"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutermeo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutermo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutreemo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "auiteremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "auteremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iauteremo"
-    replace: "aiuteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiterà"
+  - triggers:
+    - "aiterà"
+    - "aituerà"
+    - "aiuerà"
+    - "aiuetrà"
+    - "aiutera"
+    - "aiutera'"
+    - "aiutera1"
+    - "aiuteà"
+    - "aiuteàr"
+    - "aiutreà"
+    - "aiutrà"
+    - "auiterà"
+    - "auterà"
+    - "iauterà"
     replace: "aiuterà"
     word: true
 
-  - trigger: "aituerà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiuerà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiuetrà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiutera"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiutera'"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiutera1"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiuteà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiuteàr"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiutreà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiutrà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "auiterà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "auterà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "iauterà"
-    replace: "aiuterà"
-    word: true
-
-  - trigger: "aiterò"
+  - triggers:
+    - "aiterò"
+    - "aituerò"
+    - "aiuerò"
+    - "aiuetrò"
+    - "aiutero"
+    - "aiutero'"
+    - "aiutero1"
+    - "aiuteò"
+    - "aiuteòr"
+    - "aiutreò"
+    - "aiutrò"
+    - "auiterò"
+    - "auterò"
+    - "iauterò"
     replace: "aiuterò"
     word: true
 
-  - trigger: "aituerò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiuerò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiuetrò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiutero"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiutero'"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiutero1"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiuteò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiuteòr"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiutreò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "aiutrò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "auiterò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "auterò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "iauterò"
-    replace: "aiuterò"
-    word: true
-
-  - trigger: "alloché"
+  - triggers:
+    - "alloché"
+    - "allocrhé"
+    - "allorche"
+    - "allorche'"
+    - "allorche1"
+    - "allorcé"
+    - "allorcéh"
+    - "allorhcé"
+    - "allorhé"
+    - "allrché"
+    - "allroché"
+    - "alolrché"
+    - "alorché"
+    - "lalorché"
     replace: "allorché"
     word: true
 
-  - trigger: "allocrhé"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorche"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorche'"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorche1"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorcé"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorcéh"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorhcé"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allorhé"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allrché"
-    replace: "allorché"
-    word: true
-
-  - trigger: "allroché"
-    replace: "allorché"
-    word: true
-
-  - trigger: "alolrché"
-    replace: "allorché"
-    word: true
-
-  - trigger: "alorché"
-    replace: "allorché"
-    word: true
-
-  - trigger: "lalorché"
-    replace: "allorché"
-    word: true
-
-  - trigger: "adnrai"
+  - triggers:
+    - "adnrai"
+    - "adrai"
+    - "andai"
+    - "andari"
+    - "andri"
+    - "andria"
+    - "anrai"
+    - "anrdai"
+    - "nadrai"
     replace: "andrai"
     propagate_case: true
     word: true
 
-  - trigger: "adrai"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "andai"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "andari"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "andri"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "andria"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "anrai"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "anrdai"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadrai"
-    replace: "andrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "adnranno"
+  - triggers:
+    - "adnranno"
+    - "adranno"
+    - "andanno"
+    - "andarnno"
+    - "andrano"
+    - "andranon"
+    - "andrnano"
+    - "andrnno"
+    - "anranno"
+    - "anrdanno"
+    - "nadranno"
     replace: "andranno"
     propagate_case: true
     word: true
 
-  - trigger: "adranno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andanno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andarnno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrano"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andranon"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrnano"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrnno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "anranno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "anrdanno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadranno"
-    replace: "andranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "adnremo"
+  - triggers:
+    - "adnremo"
+    - "adremo"
+    - "andemo"
+    - "andermo"
+    - "andreo"
+    - "andreom"
+    - "andrmeo"
+    - "andrmo"
+    - "anrdemo"
+    - "anremo"
+    - "nadremo"
     replace: "andremo"
     propagate_case: true
     word: true
 
-  - trigger: "adremo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andemo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andermo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andreo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andreom"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrmeo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrmo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "anrdemo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "anremo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadremo"
-    replace: "andremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "adnrà"
+  - triggers:
+    - "adnrà"
+    - "adrà"
+    - "andra"
+    - "andra'"
+    - "andra1"
+    - "andà"
+    - "andàr"
+    - "anrdà"
+    - "anrà"
+    - "nadrà"
     replace: "andrà"
     word: true
 
-  - trigger: "adrà"
-    replace: "andrà"
-    word: true
-
-  - trigger: "andra"
-    replace: "andrà"
-    word: true
-
-  - trigger: "andra'"
-    replace: "andrà"
-    word: true
-
-  - trigger: "andra1"
-    replace: "andrà"
-    word: true
-
-  - trigger: "andà"
-    replace: "andrà"
-    word: true
-
-  - trigger: "andàr"
-    replace: "andrà"
-    word: true
-
-  - trigger: "anrdà"
-    replace: "andrà"
-    word: true
-
-  - trigger: "anrà"
-    replace: "andrà"
-    word: true
-
-  - trigger: "nadrà"
-    replace: "andrà"
-    word: true
-
-  - trigger: "adnrò"
+  - triggers:
+    - "adnrò"
+    - "adrò"
+    - "andro"
+    - "andro'"
+    - "andro1"
+    - "andò"
+    - "andòr"
+    - "anrdò"
+    - "anrò"
+    - "nadrò"
     replace: "andrò"
     word: true
 
-  - trigger: "adrò"
-    replace: "andrò"
-    word: true
-
-  - trigger: "andro"
-    replace: "andrò"
-    word: true
-
-  - trigger: "andro'"
-    replace: "andrò"
-    word: true
-
-  - trigger: "andro1"
-    replace: "andrò"
-    word: true
-
-  - trigger: "andò"
-    replace: "andrò"
-    word: true
-
-  - trigger: "andòr"
-    replace: "andrò"
-    word: true
-
-  - trigger: "anrdò"
-    replace: "andrò"
-    word: true
-
-  - trigger: "anrò"
-    replace: "andrò"
-    word: true
-
-  - trigger: "nadrò"
-    replace: "andrò"
-    word: true
-
-  - trigger: "arirverai"
+  - triggers:
+    - "arirverai"
+    - "ariverai"
+    - "arrierai"
+    - "arrievrai"
+    - "arriveai"
+    - "arriveari"
+    - "arriveri"
+    - "arriveria"
+    - "arrivrai"
+    - "arrivreai"
+    - "arrverai"
+    - "arrvierai"
+    - "rariverai"
     replace: "arriverai"
     propagate_case: true
     word: true
 
-  - trigger: "ariverai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrierai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrievrai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveari"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveri"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveria"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivrai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivreai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrverai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrvierai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rariverai"
-    replace: "arriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "arirveranno"
+  - triggers:
+    - "arirveranno"
+    - "ariveranno"
+    - "arrieranno"
+    - "arrievranno"
+    - "arriveanno"
+    - "arrivearnno"
+    - "arriverano"
+    - "arriveranon"
+    - "arrivernano"
+    - "arrivernno"
+    - "arrivranno"
+    - "arrivreanno"
+    - "arrveranno"
+    - "arrvieranno"
+    - "rariveranno"
     replace: "arriveranno"
     propagate_case: true
     word: true
 
-  - trigger: "ariveranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrieranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrievranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveanno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivearnno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriverano"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveranon"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivernano"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivernno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivreanno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrveranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrvieranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rariveranno"
-    replace: "arriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "arirveremo"
+  - triggers:
+    - "arirveremo"
+    - "ariveremo"
+    - "arrieremo"
+    - "arrievremo"
+    - "arriveemo"
+    - "arriveermo"
+    - "arrivereo"
+    - "arrivereom"
+    - "arrivermeo"
+    - "arrivermo"
+    - "arrivreemo"
+    - "arrivremo"
+    - "arrveremo"
+    - "arrvieremo"
+    - "rariveremo"
     replace: "arriveremo"
     propagate_case: true
     word: true
 
-  - trigger: "ariveremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrieremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrievremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveemo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveermo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivereo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivereom"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivermeo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivermo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivreemo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrveremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrvieremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rariveremo"
-    replace: "arriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arirverà"
+  - triggers:
+    - "arirverà"
+    - "ariverà"
+    - "arrierà"
+    - "arrievrà"
+    - "arrivera"
+    - "arrivera'"
+    - "arrivera1"
+    - "arriveà"
+    - "arriveàr"
+    - "arrivreà"
+    - "arrivrà"
+    - "arrverà"
+    - "arrvierà"
+    - "rariverà"
     replace: "arriverà"
     word: true
 
-  - trigger: "ariverà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrierà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrievrà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrivera"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrivera'"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrivera1"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arriveà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arriveàr"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrivreà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrivrà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrverà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arrvierà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "rariverà"
-    replace: "arriverà"
-    word: true
-
-  - trigger: "arirverò"
+  - triggers:
+    - "arirverò"
+    - "ariverò"
+    - "arrierò"
+    - "arrievrò"
+    - "arrivero"
+    - "arrivero'"
+    - "arrivero1"
+    - "arriveò"
+    - "arriveòr"
+    - "arrivreò"
+    - "arrivrò"
+    - "arrverò"
+    - "arrvierò"
+    - "rariverò"
     replace: "arriverò"
     word: true
 
-  - trigger: "ariverò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrierò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrievrò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrivero"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrivero'"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrivero1"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arriveò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arriveòr"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrivreò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrivrò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrverò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "arrvierò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "rariverò"
-    replace: "arriverò"
-    word: true
-
-  - trigger: "apetterai"
+  - triggers:
+    - "apetterai"
+    - "apsetterai"
+    - "aseptterai"
+    - "asetterai"
+    - "aspeterai"
+    - "aspetetrai"
+    - "aspetteai"
+    - "aspetteari"
+    - "aspetteri"
+    - "aspetteria"
+    - "aspettrai"
+    - "aspettreai"
+    - "aspteterai"
+    - "asptterai"
+    - "sapetterai"
     replace: "aspetterai"
     propagate_case: true
     word: true
 
-  - trigger: "apsetterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aseptterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "asetterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspeterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetetrai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteari"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteri"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteria"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettrai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettreai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspteterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "asptterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapetterai"
-    replace: "aspetterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "apetteranno"
+  - triggers:
+    - "apetteranno"
+    - "apsetteranno"
+    - "aseptteranno"
+    - "asetteranno"
+    - "aspeteranno"
+    - "aspetetranno"
+    - "aspetteanno"
+    - "aspettearnno"
+    - "aspetterano"
+    - "aspetteranon"
+    - "aspetternano"
+    - "aspetternno"
+    - "aspettranno"
+    - "aspettreanno"
+    - "aspteteranno"
+    - "asptteranno"
+    - "sapetteranno"
     replace: "aspetteranno"
     propagate_case: true
     word: true
 
-  - trigger: "apsetteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aseptteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "asetteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspeteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetetranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteanno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettearnno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetterano"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteranon"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetternano"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetternno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettreanno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspteteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "asptteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapetteranno"
-    replace: "aspetteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "apetteremo"
+  - triggers:
+    - "apetteremo"
+    - "apsetteremo"
+    - "aseptteremo"
+    - "asetteremo"
+    - "aspeteremo"
+    - "aspetetremo"
+    - "aspetteemo"
+    - "aspetteermo"
+    - "aspettereo"
+    - "aspettereom"
+    - "aspettermeo"
+    - "aspettermo"
+    - "aspettreemo"
+    - "aspettremo"
+    - "aspteteremo"
+    - "asptteremo"
+    - "sapetteremo"
     replace: "aspetteremo"
     propagate_case: true
     word: true
 
-  - trigger: "apsetteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aseptteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "asetteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspeteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetetremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteemo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetteermo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettereo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettereom"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettermeo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettermo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettreemo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspteteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "asptteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapetteremo"
-    replace: "aspetteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "apetterà"
+  - triggers:
+    - "apetterà"
+    - "apsetterà"
+    - "aseptterà"
+    - "asetterà"
+    - "aspeterà"
+    - "aspetetrà"
+    - "aspettera"
+    - "aspettera'"
+    - "aspettera1"
+    - "aspetteà"
+    - "aspetteàr"
+    - "aspettreà"
+    - "aspettrà"
+    - "aspteterà"
+    - "asptterà"
+    - "sapetterà"
     replace: "aspetterà"
     word: true
 
-  - trigger: "apsetterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aseptterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "asetterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspeterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspetetrà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspettera"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspettera'"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspettera1"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspetteà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspetteàr"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspettreà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspettrà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "aspteterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "asptterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "sapetterà"
-    replace: "aspetterà"
-    word: true
-
-  - trigger: "apetterò"
+  - triggers:
+    - "apetterò"
+    - "apsetterò"
+    - "aseptterò"
+    - "asetterò"
+    - "aspeterò"
+    - "aspetetrò"
+    - "aspettero"
+    - "aspettero'"
+    - "aspettero1"
+    - "aspetteò"
+    - "aspetteòr"
+    - "aspettreò"
+    - "aspettrò"
+    - "aspteterò"
+    - "asptterò"
+    - "sapetterò"
     replace: "aspetterò"
     word: true
 
-  - trigger: "apsetterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aseptterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "asetterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspeterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspetetrò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspettero"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspettero'"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspettero1"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspetteò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspetteòr"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspettreò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspettrò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "aspteterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "asptterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "sapetterò"
-    replace: "aspetterò"
-    word: true
-
-  - trigger: "atitvità"
+  - triggers:
+    - "atitvità"
+    - "atività"
+    - "attiità"
+    - "attiivtà"
+    - "attivita"
+    - "attivita'"
+    - "attivita1"
+    - "attivià"
+    - "attiviàt"
+    - "attivtià"
+    - "attivtà"
+    - "attviità"
+    - "attvità"
+    - "tatività"
     replace: "attività"
     word: true
 
-  - trigger: "atività"
-    replace: "attività"
-    word: true
-
-  - trigger: "attiità"
-    replace: "attività"
-    word: true
-
-  - trigger: "attiivtà"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivita"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivita'"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivita1"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivià"
-    replace: "attività"
-    word: true
-
-  - trigger: "attiviàt"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivtià"
-    replace: "attività"
-    word: true
-
-  - trigger: "attivtà"
-    replace: "attività"
-    word: true
-
-  - trigger: "attviità"
-    replace: "attività"
-    word: true
-
-  - trigger: "attvità"
-    replace: "attività"
-    word: true
-
-  - trigger: "tatività"
-    replace: "attività"
-    word: true
-
-  - trigger: "arai"
+  - triggers:
+    - "arai"
+    - "arvai"
+    - "avai"
+    - "avari"
+    - "avri"
+    - "avria"
+    - "varai"
     replace: "avrai"
     propagate_case: true
     word: true
 
-  - trigger: "arvai"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "avai"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "avari"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "avri"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "avria"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "varai"
-    replace: "avrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aranno"
+  - triggers:
+    - "aranno"
+    - "arvanno"
+    - "avanno"
+    - "avarnno"
+    - "avrano"
+    - "avranon"
+    - "avrnano"
+    - "avrnno"
+    - "varanno"
     replace: "avranno"
     propagate_case: true
     word: true
 
-  - trigger: "arvanno"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avanno"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avarnno"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avrano"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avranon"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avrnano"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "avrnno"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "varanno"
-    replace: "avranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aremo"
+  - triggers:
+    - "aremo"
+    - "arvemo"
+    - "avemo"
+    - "avermo"
+    - "avreo"
+    - "avreom"
+    - "avrmeo"
+    - "avrmo"
+    - "varemo"
     replace: "avremo"
     propagate_case: true
     word: true
 
-  - trigger: "arvemo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avemo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avermo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avreo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avreom"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avrmeo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "avrmo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "varemo"
-    replace: "avremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "arvà"
+  - triggers:
+    - "arvà"
+    - "avra"
+    - "avra'"
+    - "avra1"
+    - "avàr"
+    - "varà"
     replace: "avrà"
     word: true
 
-  - trigger: "avra"
-    replace: "avrà"
-    word: true
-
-  - trigger: "avra'"
-    replace: "avrà"
-    word: true
-
-  - trigger: "avra1"
-    replace: "avrà"
-    word: true
-
-  - trigger: "avàr"
-    replace: "avrà"
-    word: true
-
-  - trigger: "varà"
-    replace: "avrà"
-    word: true
-
-  - trigger: "arvò"
+  - triggers:
+    - "arvò"
+    - "avro"
+    - "avro'"
+    - "avro1"
+    - "avòr"
+    - "varò"
     replace: "avrò"
     word: true
 
-  - trigger: "avro"
-    replace: "avrò"
-    word: true
-
-  - trigger: "avro'"
-    replace: "avrò"
-    word: true
-
-  - trigger: "avro1"
-    replace: "avrò"
-    word: true
-
-  - trigger: "avòr"
-    replace: "avrò"
-    word: true
-
-  - trigger: "varò"
-    replace: "avrò"
-    word: true
-
-  - trigger: "beché"
+  - triggers:
+    - "beché"
+    - "becnhé"
+    - "benche"
+    - "benche'"
+    - "benche1"
+    - "bencé"
+    - "bencéh"
+    - "benhcé"
+    - "benhé"
+    - "bnché"
+    - "bneché"
+    - "ebnché"
     replace: "benché"
     word: true
 
-  - trigger: "becnhé"
-    replace: "benché"
-    word: true
-
-  - trigger: "benche"
-    replace: "benché"
-    word: true
-
-  - trigger: "benche'"
-    replace: "benché"
-    word: true
-
-  - trigger: "benche1"
-    replace: "benché"
-    word: true
-
-  - trigger: "bencé"
-    replace: "benché"
-    word: true
-
-  - trigger: "bencéh"
-    replace: "benché"
-    word: true
-
-  - trigger: "benhcé"
-    replace: "benché"
-    word: true
-
-  - trigger: "benhé"
-    replace: "benché"
-    word: true
-
-  - trigger: "bnché"
-    replace: "benché"
-    word: true
-
-  - trigger: "bneché"
-    replace: "benché"
-    word: true
-
-  - trigger: "ebnché"
-    replace: "benché"
-    word: true
-
-  - trigger: "acmbierai"
+  - triggers:
+    - "acmbierai"
+    - "cabierai"
+    - "cabmierai"
+    - "cambeirai"
+    - "camberai"
+    - "cambieai"
+    - "cambieari"
+    - "cambieri"
+    - "cambieria"
+    - "cambirai"
+    - "cambireai"
+    - "camiberai"
+    - "camierai"
+    - "cmabierai"
+    - "cmbierai"
     replace: "cambierai"
     propagate_case: true
     word: true
 
-  - trigger: "cabierai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cabmierai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambeirai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "camberai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieari"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieri"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieria"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambirai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambireai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "camiberai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "camierai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmabierai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmbierai"
-    replace: "cambierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "acmbieranno"
+  - triggers:
+    - "acmbieranno"
+    - "cabieranno"
+    - "cabmieranno"
+    - "cambeiranno"
+    - "camberanno"
+    - "cambieanno"
+    - "cambiearnno"
+    - "cambierano"
+    - "cambieranon"
+    - "cambiernano"
+    - "cambiernno"
+    - "cambiranno"
+    - "cambireanno"
+    - "camiberanno"
+    - "camieranno"
+    - "cmabieranno"
+    - "cmbieranno"
     replace: "cambieranno"
     propagate_case: true
     word: true
 
-  - trigger: "cabieranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cabmieranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambeiranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "camberanno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieanno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiearnno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambierano"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieranon"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiernano"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiernno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambireanno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "camiberanno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "camieranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmabieranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmbieranno"
-    replace: "cambieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "acmbieremo"
+  - triggers:
+    - "acmbieremo"
+    - "cabieremo"
+    - "cabmieremo"
+    - "cambeiremo"
+    - "camberemo"
+    - "cambieemo"
+    - "cambieermo"
+    - "cambiereo"
+    - "cambiereom"
+    - "cambiermeo"
+    - "cambiermo"
+    - "cambireemo"
+    - "cambiremo"
+    - "camiberemo"
+    - "camieremo"
+    - "cmabieremo"
+    - "cmbieremo"
     replace: "cambieremo"
     propagate_case: true
     word: true
 
-  - trigger: "cabieremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cabmieremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambeiremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "camberemo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieemo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambieermo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiereo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiereom"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiermeo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiermo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambireemo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "camiberemo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "camieremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmabieremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmbieremo"
-    replace: "cambieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "acmbierà"
+  - triggers:
+    - "acmbierà"
+    - "cabierà"
+    - "cabmierà"
+    - "cambeirà"
+    - "camberà"
+    - "cambiera"
+    - "cambiera'"
+    - "cambiera1"
+    - "cambieà"
+    - "cambieàr"
+    - "cambireà"
+    - "cambirà"
+    - "camiberà"
+    - "camierà"
+    - "cmabierà"
+    - "cmbierà"
     replace: "cambierà"
     word: true
 
-  - trigger: "cabierà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cabmierà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambeirà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "camberà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambiera"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambiera'"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambiera1"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambieà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambieàr"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambireà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cambirà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "camiberà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "camierà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cmabierà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "cmbierà"
-    replace: "cambierà"
-    word: true
-
-  - trigger: "acmbierò"
+  - triggers:
+    - "acmbierò"
+    - "cabierò"
+    - "cabmierò"
+    - "cambeirò"
+    - "camberò"
+    - "cambiero"
+    - "cambiero'"
+    - "cambiero1"
+    - "cambieò"
+    - "cambieòr"
+    - "cambireò"
+    - "cambirò"
+    - "camiberò"
+    - "camierò"
+    - "cmabierò"
+    - "cmbierò"
     replace: "cambierò"
     word: true
 
-  - trigger: "cabierò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cabmierò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambeirò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "camberò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambiero"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambiero'"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambiero1"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambieò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambieòr"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambireò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cambirò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "camiberò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "camierò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cmabierò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "cmbierò"
-    replace: "cambierò"
-    word: true
-
-  - trigger: "acpacità"
+  - triggers:
+    - "acpacità"
+    - "caacità"
+    - "caapcità"
+    - "capacita"
+    - "capacita'"
+    - "capacita1"
+    - "capacià"
+    - "capaciàt"
+    - "capactià"
+    - "capactà"
+    - "capaictà"
+    - "capaità"
+    - "capcaità"
+    - "capcità"
+    - "cpaacità"
+    - "cpacità"
     replace: "capacità"
     word: true
 
-  - trigger: "caacità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "caapcità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capacita"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capacita'"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capacita1"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capacià"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capaciàt"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capactià"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capactà"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capaictà"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capaità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capcaità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "capcità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "cpaacità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "cpacità"
-    replace: "capacità"
-    word: true
-
-  - trigger: "acpirai"
+  - triggers:
+    - "acpirai"
+    - "caiprai"
+    - "cairai"
+    - "capiai"
+    - "capiari"
+    - "capiri"
+    - "capiria"
+    - "caprai"
+    - "capriai"
+    - "cpairai"
+    - "cpirai"
     replace: "capirai"
     propagate_case: true
     word: true
 
-  - trigger: "caiprai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cairai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiari"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiri"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiria"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "caprai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "capriai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpairai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpirai"
-    replace: "capirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "acpiranno"
+  - triggers:
+    - "acpiranno"
+    - "caipranno"
+    - "cairanno"
+    - "capianno"
+    - "capiarnno"
+    - "capirano"
+    - "capiranon"
+    - "capirnano"
+    - "capirnno"
+    - "capranno"
+    - "caprianno"
+    - "cpairanno"
+    - "cpiranno"
     replace: "capiranno"
     propagate_case: true
     word: true
 
-  - trigger: "caipranno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cairanno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capianno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiarnno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capirano"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiranon"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capirnano"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capirnno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "capranno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "caprianno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpairanno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpiranno"
-    replace: "capiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "acpiremo"
+  - triggers:
+    - "acpiremo"
+    - "caipremo"
+    - "cairemo"
+    - "capiemo"
+    - "capiermo"
+    - "capireo"
+    - "capireom"
+    - "capirmeo"
+    - "capirmo"
+    - "capremo"
+    - "capriemo"
+    - "cpairemo"
+    - "cpiremo"
     replace: "capiremo"
     propagate_case: true
     word: true
 
-  - trigger: "caipremo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cairemo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiemo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capiermo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capireo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capireom"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capirmeo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capirmo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capremo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "capriemo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpairemo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpiremo"
-    replace: "capiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "acpirà"
+  - triggers:
+    - "acpirà"
+    - "caiprà"
+    - "cairà"
+    - "capira"
+    - "capira'"
+    - "capira1"
+    - "capià"
+    - "capiàr"
+    - "caprià"
+    - "caprà"
+    - "cpairà"
+    - "cpirà"
     replace: "capirà"
     word: true
 
-  - trigger: "caiprà"
-    replace: "capirà"
-    word: true
-
-  - trigger: "cairà"
-    replace: "capirà"
-    word: true
-
-  - trigger: "capira"
-    replace: "capirà"
-    word: true
-
-  - trigger: "capira'"
-    replace: "capirà"
-    word: true
-
-  - trigger: "capira1"
-    replace: "capirà"
-    word: true
-
-  - trigger: "capià"
-    replace: "capirà"
-    word: true
-
-  - trigger: "capiàr"
-    replace: "capirà"
-    word: true
-
-  - trigger: "caprià"
-    replace: "capirà"
-    word: true
-
-  - trigger: "caprà"
-    replace: "capirà"
-    word: true
-
-  - trigger: "cpairà"
-    replace: "capirà"
-    word: true
-
-  - trigger: "cpirà"
-    replace: "capirà"
-    word: true
-
-  - trigger: "acpirò"
+  - triggers:
+    - "acpirò"
+    - "caiprò"
+    - "cairò"
+    - "capiro"
+    - "capiro'"
+    - "capiro1"
+    - "capiò"
+    - "capiòr"
+    - "capriò"
+    - "caprò"
+    - "cpairò"
+    - "cpirò"
     replace: "capirò"
     word: true
 
-  - trigger: "caiprò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "cairò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capiro"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capiro'"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capiro1"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capiò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capiòr"
-    replace: "capirò"
-    word: true
-
-  - trigger: "capriò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "caprò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "cpairò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "cpirò"
-    replace: "capirò"
-    word: true
-
-  - trigger: "chaimerai"
+  - triggers:
+    - "chaimerai"
+    - "chamerai"
+    - "chiaemrai"
+    - "chiaerai"
+    - "chiameai"
+    - "chiameari"
+    - "chiameri"
+    - "chiameria"
+    - "chiamrai"
+    - "chiamreai"
+    - "chimaerai"
+    - "chimerai"
+    - "ciamerai"
+    - "cihamerai"
+    - "hciamerai"
     replace: "chiamerai"
     propagate_case: true
     word: true
 
-  - trigger: "chamerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaemrai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameari"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameri"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameria"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamrai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamreai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimaerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciamerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihamerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciamerai"
-    replace: "chiamerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chaimeranno"
+  - triggers:
+    - "chaimeranno"
+    - "chameranno"
+    - "chiaemranno"
+    - "chiaeranno"
+    - "chiameanno"
+    - "chiamearnno"
+    - "chiamerano"
+    - "chiameranon"
+    - "chiamernano"
+    - "chiamernno"
+    - "chiamranno"
+    - "chiamreanno"
+    - "chimaeranno"
+    - "chimeranno"
+    - "ciameranno"
+    - "cihameranno"
+    - "hciameranno"
     replace: "chiameranno"
     propagate_case: true
     word: true
 
-  - trigger: "chameranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaemranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaeranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameanno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamearnno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamerano"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameranon"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamernano"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamernno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamreanno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimaeranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimeranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciameranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihameranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciameranno"
-    replace: "chiameranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chaimeremo"
+  - triggers:
+    - "chaimeremo"
+    - "chameremo"
+    - "chiaemremo"
+    - "chiaeremo"
+    - "chiameemo"
+    - "chiameermo"
+    - "chiamereo"
+    - "chiamereom"
+    - "chiamermeo"
+    - "chiamermo"
+    - "chiamreemo"
+    - "chiamremo"
+    - "chimaeremo"
+    - "chimeremo"
+    - "ciameremo"
+    - "cihameremo"
+    - "hciameremo"
     replace: "chiameremo"
     propagate_case: true
     word: true
 
-  - trigger: "chameremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaemremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaeremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameemo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiameermo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamereo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamereom"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamermeo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamermo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamreemo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimaeremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimeremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciameremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihameremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciameremo"
-    replace: "chiameremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chaimerà"
+  - triggers:
+    - "chaimerà"
+    - "chamerà"
+    - "chiaemrà"
+    - "chiaerà"
+    - "chiamera"
+    - "chiamera'"
+    - "chiamera1"
+    - "chiameà"
+    - "chiameàr"
+    - "chiamreà"
+    - "chiamrà"
+    - "chimaerà"
+    - "chimerà"
+    - "ciamerà"
+    - "cihamerà"
+    - "hciamerà"
     replace: "chiamerà"
     word: true
 
-  - trigger: "chamerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiaemrà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiaerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiamera"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiamera'"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiamera1"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiameà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiameàr"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiamreà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chiamrà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chimaerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chimerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "ciamerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "cihamerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "hciamerà"
-    replace: "chiamerà"
-    word: true
-
-  - trigger: "chaimerò"
+  - triggers:
+    - "chaimerò"
+    - "chamerò"
+    - "chiaemrò"
+    - "chiaerò"
+    - "chiamero"
+    - "chiamero'"
+    - "chiamero1"
+    - "chiameò"
+    - "chiameòr"
+    - "chiamreò"
+    - "chiamrò"
+    - "chimaerò"
+    - "chimerò"
+    - "ciamerò"
+    - "cihamerò"
+    - "hciamerò"
     replace: "chiamerò"
     word: true
 
-  - trigger: "chamerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiaemrò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiaerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiamero"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiamero'"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiamero1"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiameò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiameòr"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiamreò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chiamrò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chimaerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chimerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "ciamerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "cihamerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "hciamerò"
-    replace: "chiamerò"
-    word: true
-
-  - trigger: "chederai"
+  - triggers:
+    - "chederai"
+    - "cheiderai"
+    - "chideerai"
+    - "chiderai"
+    - "chiedeai"
+    - "chiedeari"
+    - "chiederi"
+    - "chiederia"
+    - "chiedrai"
+    - "chiedreai"
+    - "chieedrai"
+    - "chieerai"
+    - "ciederai"
+    - "cihederai"
+    - "hciederai"
     replace: "chiederai"
     propagate_case: true
     word: true
 
-  - trigger: "cheiderai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chideerai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiderai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedeai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedeari"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiederi"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiederia"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedrai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedreai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieedrai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieerai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciederai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihederai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciederai"
-    replace: "chiederai"
-    propagate_case: true
-    word: true
-
-  - trigger: "chederanno"
+  - triggers:
+    - "chederanno"
+    - "cheideranno"
+    - "chideeranno"
+    - "chideranno"
+    - "chiedeanno"
+    - "chiedearnno"
+    - "chiederano"
+    - "chiederanon"
+    - "chiedernano"
+    - "chiedernno"
+    - "chiedranno"
+    - "chiedreanno"
+    - "chieedranno"
+    - "chieeranno"
+    - "ciederanno"
+    - "cihederanno"
+    - "hciederanno"
     replace: "chiederanno"
     propagate_case: true
     word: true
 
-  - trigger: "cheideranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chideeranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chideranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedeanno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedearnno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiederano"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiederanon"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedernano"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedernno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedreanno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieedranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieeranno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciederanno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihederanno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciederanno"
-    replace: "chiederanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "chederemo"
+  - triggers:
+    - "chederemo"
+    - "cheideremo"
+    - "chideeremo"
+    - "chideremo"
+    - "chiedeemo"
+    - "chiedeermo"
+    - "chiedereo"
+    - "chiedereom"
+    - "chiedermeo"
+    - "chiedermo"
+    - "chiedreemo"
+    - "chiedremo"
+    - "chieedremo"
+    - "chieeremo"
+    - "ciederemo"
+    - "cihederemo"
+    - "hciederemo"
     replace: "chiederemo"
     propagate_case: true
     word: true
 
-  - trigger: "cheideremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chideeremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chideremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedeemo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedeermo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedereo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedereom"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedermeo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedermo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedreemo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiedremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieedremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chieeremo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciederemo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihederemo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciederemo"
-    replace: "chiederemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "chederà"
+  - triggers:
+    - "chederà"
+    - "cheiderà"
+    - "chideerà"
+    - "chiderà"
+    - "chiedera"
+    - "chiedera'"
+    - "chiedera1"
+    - "chiedeà"
+    - "chiedeàr"
+    - "chiedreà"
+    - "chiedrà"
+    - "chieedrà"
+    - "chieerà"
+    - "ciederà"
+    - "cihederà"
+    - "hciederà"
     replace: "chiederà"
     word: true
 
-  - trigger: "cheiderà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chideerà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiderà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedera"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedera'"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedera1"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedeà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedeàr"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedreà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chiedrà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chieedrà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chieerà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "ciederà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "cihederà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "hciederà"
-    replace: "chiederà"
-    word: true
-
-  - trigger: "chederò"
+  - triggers:
+    - "chederò"
+    - "cheiderò"
+    - "chideerò"
+    - "chiderò"
+    - "chiedero"
+    - "chiedero'"
+    - "chiedero1"
+    - "chiedeò"
+    - "chiedeòr"
+    - "chiedreò"
+    - "chiedrò"
+    - "chieedrò"
+    - "chieerò"
+    - "ciederò"
+    - "cihederò"
+    - "hciederò"
     replace: "chiederò"
     word: true
 
-  - trigger: "cheiderò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chideerò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiderò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedero"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedero'"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedero1"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedeò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedeòr"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedreò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chiedrò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chieedrò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "chieerò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "ciederò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "cihederò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "hciederò"
-    replace: "chiederò"
-    word: true
-
-  - trigger: "cioe"
+  - triggers:
+    - "cioe"
+    - "cioe'"
+    - "cioe1"
+    - "cièo"
+    - "coiè"
+    - "icoè"
     replace: "cioè"
     word: true
 
-  - trigger: "cioe'"
-    replace: "cioè"
-    word: true
-
-  - trigger: "cioe1"
-    replace: "cioè"
-    word: true
-
-  - trigger: "cièo"
-    replace: "cioè"
-    word: true
-
-  - trigger: "coiè"
-    replace: "cioè"
-    word: true
-
-  - trigger: "icoè"
-    replace: "cioè"
-    word: true
-
-  - trigger: "citta"
+  - triggers:
+    - "citta"
+    - "citta'"
+    - "citta1"
+    - "cità"
+    - "citàt"
+    - "ctità"
+    - "cttà"
+    - "icttà"
     replace: "città"
     word: true
 
-  - trigger: "citta'"
-    replace: "città"
-    word: true
-
-  - trigger: "citta1"
-    replace: "città"
-    word: true
-
-  - trigger: "cità"
-    replace: "città"
-    word: true
-
-  - trigger: "citàt"
-    replace: "città"
-    word: true
-
-  - trigger: "ctità"
-    replace: "città"
-    word: true
-
-  - trigger: "cttà"
-    replace: "città"
-    word: true
-
-  - trigger: "icttà"
-    replace: "città"
-    word: true
-
-  - trigger: "cio"
+  - triggers:
+    - "cio"
+    - "cio'"
+    - "cio1"
+    - "còi"
+    - "icò"
     replace: "ciò"
     word: true
 
-  - trigger: "cio'"
-    replace: "ciò"
-    word: true
-
-  - trigger: "cio1"
-    replace: "ciò"
-    word: true
-
-  - trigger: "còi"
-    replace: "ciò"
-    word: true
-
-  - trigger: "icò"
-    replace: "ciò"
-    word: true
-
-  - trigger: "cmopleterai"
+  - triggers:
+    - "cmopleterai"
+    - "cmpleterai"
+    - "comleterai"
+    - "comlpeterai"
+    - "compelterai"
+    - "competerai"
+    - "compleerai"
+    - "compleetrai"
+    - "completeai"
+    - "completeari"
+    - "completeri"
+    - "completeria"
+    - "completrai"
+    - "completreai"
+    - "complteerai"
+    - "complterai"
+    - "copleterai"
+    - "copmleterai"
+    - "ocmpleterai"
     replace: "completerai"
     propagate_case: true
     word: true
 
-  - trigger: "cmpleterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comleterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comlpeterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "compelterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "competerai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleerai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleetrai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeari"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeri"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeria"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completrai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "completreai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "complteerai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "complterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "copleterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "copmleterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmpleterai"
-    replace: "completerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmopleteranno"
+  - triggers:
+    - "cmopleteranno"
+    - "cmpleteranno"
+    - "comleteranno"
+    - "comlpeteranno"
+    - "compelteranno"
+    - "competeranno"
+    - "compleeranno"
+    - "compleetranno"
+    - "completeanno"
+    - "completearnno"
+    - "completerano"
+    - "completeranon"
+    - "completernano"
+    - "completernno"
+    - "completranno"
+    - "completreanno"
+    - "complteeranno"
+    - "complteranno"
+    - "copleteranno"
+    - "copmleteranno"
+    - "ocmpleteranno"
     replace: "completeranno"
     propagate_case: true
     word: true
 
-  - trigger: "cmpleteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comleteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comlpeteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "compelteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "competeranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleeranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleetranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeanno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completearnno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completerano"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeranon"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completernano"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completernno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "completreanno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "complteeranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "complteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "copleteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "copmleteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmpleteranno"
-    replace: "completeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmopleteremo"
+  - triggers:
+    - "cmopleteremo"
+    - "cmpleteremo"
+    - "comleteremo"
+    - "comlpeteremo"
+    - "compelteremo"
+    - "competeremo"
+    - "compleeremo"
+    - "compleetremo"
+    - "completeemo"
+    - "completeermo"
+    - "completereo"
+    - "completereom"
+    - "completermeo"
+    - "completermo"
+    - "completreemo"
+    - "completremo"
+    - "complteeremo"
+    - "complteremo"
+    - "copleteremo"
+    - "copmleteremo"
+    - "ocmpleteremo"
     replace: "completeremo"
     propagate_case: true
     word: true
 
-  - trigger: "cmpleteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comleteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comlpeteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "compelteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "competeremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleeremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "compleetremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeemo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completeermo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completereo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completereom"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completermeo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completermo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completreemo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "completremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "complteeremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "complteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "copleteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "copmleteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmpleteremo"
-    replace: "completeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmopleterà"
+  - triggers:
+    - "cmopleterà"
+    - "cmpleterà"
+    - "comleterà"
+    - "comlpeterà"
+    - "compelterà"
+    - "competerà"
+    - "compleerà"
+    - "compleetrà"
+    - "completera"
+    - "completera'"
+    - "completera1"
+    - "completeà"
+    - "completeàr"
+    - "completreà"
+    - "completrà"
+    - "complteerà"
+    - "complterà"
+    - "copleterà"
+    - "copmleterà"
+    - "ocmpleterà"
     replace: "completerà"
     word: true
 
-  - trigger: "cmpleterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "comleterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "comlpeterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "compelterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "competerà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "compleerà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "compleetrà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completera"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completera'"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completera1"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completeà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completeàr"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completreà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "completrà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "complteerà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "complterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "copleterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "copmleterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "ocmpleterà"
-    replace: "completerà"
-    word: true
-
-  - trigger: "cmopleterò"
+  - triggers:
+    - "cmopleterò"
+    - "cmpleterò"
+    - "comleterò"
+    - "comlpeterò"
+    - "compelterò"
+    - "competerò"
+    - "compleerò"
+    - "compleetrò"
+    - "completero"
+    - "completero'"
+    - "completero1"
+    - "completeò"
+    - "completeòr"
+    - "completreò"
+    - "completrò"
+    - "complteerò"
+    - "complterò"
+    - "copleterò"
+    - "copmleterò"
+    - "ocmpleterò"
     replace: "completerò"
     word: true
 
-  - trigger: "cmpleterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "comleterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "comlpeterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "compelterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "competerò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "compleerò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "compleetrò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completero"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completero'"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completero1"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completeò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completeòr"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completreò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "completrò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "complteerò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "complterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "copleterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "copmleterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "ocmpleterò"
-    replace: "completerò"
-    word: true
-
-  - trigger: "cmounicherai"
+  - triggers:
+    - "cmounicherai"
+    - "cmunicherai"
+    - "comnicherai"
+    - "comnuicherai"
+    - "comuicherai"
+    - "comuincherai"
+    - "comuncherai"
+    - "comunciherai"
+    - "comunicehrai"
+    - "comunicerai"
+    - "comunicheai"
+    - "comunicheari"
+    - "comunicheri"
+    - "comunicheria"
+    - "comunichrai"
+    - "comunichreai"
+    - "comunihcerai"
+    - "comuniherai"
+    - "coumnicherai"
+    - "counicherai"
+    - "ocmunicherai"
     replace: "comunicherai"
     propagate_case: true
     word: true
 
-  - trigger: "cmunicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnuicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuincherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuncherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunciherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicehrai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicerai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheari"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheri"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheria"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichrai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichreai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunihcerai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "coumnicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "counicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmunicherai"
-    replace: "comunicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmounicheranno"
+  - triggers:
+    - "cmounicheranno"
+    - "cmunicheranno"
+    - "comnicheranno"
+    - "comnuicheranno"
+    - "comuicheranno"
+    - "comuincheranno"
+    - "comuncheranno"
+    - "comunciheranno"
+    - "comunicehranno"
+    - "comuniceranno"
+    - "comunicheanno"
+    - "comunichearnno"
+    - "comunicherano"
+    - "comunicheranon"
+    - "comunichernano"
+    - "comunichernno"
+    - "comunichranno"
+    - "comunichreanno"
+    - "comunihceranno"
+    - "comuniheranno"
+    - "coumnicheranno"
+    - "counicheranno"
+    - "ocmunicheranno"
     replace: "comunicheranno"
     propagate_case: true
     word: true
 
-  - trigger: "cmunicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnuicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuincheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuncheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunciheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicehranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniceranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheanno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichearnno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicherano"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheranon"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichernano"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichernno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichreanno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunihceranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "coumnicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "counicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmunicheranno"
-    replace: "comunicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmounicheremo"
+  - triggers:
+    - "cmounicheremo"
+    - "cmunicheremo"
+    - "comnicheremo"
+    - "comnuicheremo"
+    - "comuicheremo"
+    - "comuincheremo"
+    - "comuncheremo"
+    - "comunciheremo"
+    - "comunicehremo"
+    - "comuniceremo"
+    - "comunicheemo"
+    - "comunicheermo"
+    - "comunichereo"
+    - "comunichereom"
+    - "comunichermeo"
+    - "comunichermo"
+    - "comunichreemo"
+    - "comunichremo"
+    - "comunihceremo"
+    - "comuniheremo"
+    - "coumnicheremo"
+    - "counicheremo"
+    - "ocmunicheremo"
     replace: "comunicheremo"
     propagate_case: true
     word: true
 
-  - trigger: "cmunicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnuicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuincheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuncheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunciheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicehremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniceremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheemo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicheermo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichereo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichereom"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichermeo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichermo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichreemo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunichremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunihceremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "coumnicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "counicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmunicheremo"
-    replace: "comunicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmounicherà"
+  - triggers:
+    - "cmounicherà"
+    - "cmunicherà"
+    - "comnicherà"
+    - "comnuicherà"
+    - "comuicherà"
+    - "comuincherà"
+    - "comuncherà"
+    - "comunciherà"
+    - "comunicehrà"
+    - "comunicerà"
+    - "comunichera"
+    - "comunichera'"
+    - "comunichera1"
+    - "comunicheà"
+    - "comunicheàr"
+    - "comunichreà"
+    - "comunichrà"
+    - "comunihcerà"
+    - "comuniherà"
+    - "coumnicherà"
+    - "counicherà"
+    - "ocmunicherà"
     replace: "comunicherà"
     word: true
 
-  - trigger: "cmunicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comnicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comnuicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comuicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comuincherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comuncherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunciherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunicehrà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunicerà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunichera"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunichera'"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunichera1"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunicheà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunicheàr"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunichreà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunichrà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comunihcerà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "comuniherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "coumnicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "counicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "ocmunicherà"
-    replace: "comunicherà"
-    word: true
-
-  - trigger: "cmounicherò"
+  - triggers:
+    - "cmounicherò"
+    - "cmunicherò"
+    - "comnicherò"
+    - "comnuicherò"
+    - "comuicherò"
+    - "comuincherò"
+    - "comuncherò"
+    - "comunciherò"
+    - "comunicehrò"
+    - "comunicerò"
+    - "comunichero"
+    - "comunichero'"
+    - "comunichero1"
+    - "comunicheò"
+    - "comunicheòr"
+    - "comunichreò"
+    - "comunichrò"
+    - "comunihcerò"
+    - "comuniherò"
+    - "coumnicherò"
+    - "counicherò"
+    - "ocmunicherò"
     replace: "comunicherò"
     word: true
 
-  - trigger: "cmunicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comnicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comnuicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comuicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comuincherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comuncherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunciherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunicehrò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunicerò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunichero"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunichero'"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunichero1"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunicheò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunicheòr"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunichreò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunichrò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comunihcerò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "comuniherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "coumnicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "counicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "ocmunicherò"
-    replace: "comunicherò"
-    word: true
-
-  - trigger: "cndividerai"
+  - triggers:
+    - "cndividerai"
+    - "cnodividerai"
+    - "codividerai"
+    - "codnividerai"
+    - "condiiderai"
+    - "condiivderai"
+    - "condivderai"
+    - "condivdierai"
+    - "condivideai"
+    - "condivideari"
+    - "condivideri"
+    - "condivideria"
+    - "condividrai"
+    - "condividreai"
+    - "condiviedrai"
+    - "condivierai"
+    - "condviderai"
+    - "condviiderai"
+    - "conidviderai"
+    - "conividerai"
+    - "ocndividerai"
     replace: "condividerai"
     propagate_case: true
     word: true
 
-  - trigger: "cnodividerai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "codividerai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "codnividerai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiiderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiivderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivdierai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideari"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideri"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideria"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividrai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividreai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiviedrai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivierai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condviderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "condviiderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "conidviderai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "conividerai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocndividerai"
-    replace: "condividerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cndivideranno"
+  - triggers:
+    - "cndivideranno"
+    - "cnodivideranno"
+    - "codivideranno"
+    - "codnivideranno"
+    - "condiideranno"
+    - "condiivderanno"
+    - "condivderanno"
+    - "condivdieranno"
+    - "condivideanno"
+    - "condividearnno"
+    - "condividerano"
+    - "condivideranon"
+    - "condividernano"
+    - "condividernno"
+    - "condividranno"
+    - "condividreanno"
+    - "condiviedranno"
+    - "condivieranno"
+    - "condvideranno"
+    - "condviideranno"
+    - "conidvideranno"
+    - "conivideranno"
+    - "ocndivideranno"
     replace: "condivideranno"
     propagate_case: true
     word: true
 
-  - trigger: "cnodivideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "codivideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "codnivideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiivderanno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivderanno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivdieranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideanno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividearnno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividerano"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideranon"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividernano"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividernno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividreanno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiviedranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivieranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condvideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "condviideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "conidvideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "conivideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocndivideranno"
-    replace: "condivideranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cndivideremo"
+  - triggers:
+    - "cndivideremo"
+    - "cnodivideremo"
+    - "codivideremo"
+    - "codnivideremo"
+    - "condiideremo"
+    - "condiivderemo"
+    - "condivderemo"
+    - "condivdieremo"
+    - "condivideemo"
+    - "condivideermo"
+    - "condividereo"
+    - "condividereom"
+    - "condividermeo"
+    - "condividermo"
+    - "condividreemo"
+    - "condividremo"
+    - "condiviedremo"
+    - "condivieremo"
+    - "condvideremo"
+    - "condviideremo"
+    - "conidvideremo"
+    - "conivideremo"
+    - "ocndivideremo"
     replace: "condivideremo"
     propagate_case: true
     word: true
 
-  - trigger: "cnodivideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "codivideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "codnivideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiivderemo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivderemo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivdieremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideemo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivideermo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividereo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividereom"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividermeo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividermo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividreemo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condividremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiviedremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condivieremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condvideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "condviideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "conidvideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "conivideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocndivideremo"
-    replace: "condivideremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cndividerà"
+  - triggers:
+    - "cndividerà"
+    - "cnodividerà"
+    - "codividerà"
+    - "codnividerà"
+    - "condiiderà"
+    - "condiivderà"
+    - "condivderà"
+    - "condivdierà"
+    - "condividera"
+    - "condividera'"
+    - "condividera1"
+    - "condivideà"
+    - "condivideàr"
+    - "condividreà"
+    - "condividrà"
+    - "condiviedrà"
+    - "condivierà"
+    - "condviderà"
+    - "condviiderà"
+    - "conidviderà"
+    - "conividerà"
+    - "ocndividerà"
     replace: "condividerà"
     word: true
 
-  - trigger: "cnodividerà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "codividerà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "codnividerà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condiiderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condiivderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condivderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condivdierà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condividera"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condividera'"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condividera1"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condivideà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condivideàr"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condividreà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condividrà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condiviedrà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condivierà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condviderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "condviiderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "conidviderà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "conividerà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "ocndividerà"
-    replace: "condividerà"
-    word: true
-
-  - trigger: "cndividerò"
+  - triggers:
+    - "cndividerò"
+    - "cnodividerò"
+    - "codividerò"
+    - "codnividerò"
+    - "condiiderò"
+    - "condiivderò"
+    - "condivderò"
+    - "condivdierò"
+    - "condividero"
+    - "condividero'"
+    - "condividero1"
+    - "condivideò"
+    - "condivideòr"
+    - "condividreò"
+    - "condividrò"
+    - "condiviedrò"
+    - "condivierò"
+    - "condviderò"
+    - "condviiderò"
+    - "conidviderò"
+    - "conividerò"
+    - "ocndividerò"
     replace: "condividerò"
     word: true
 
-  - trigger: "cnodividerò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "codividerò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "codnividerò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condiiderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condiivderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condivderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condivdierò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condividero"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condividero'"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condividero1"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condivideò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condivideòr"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condividreò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condividrò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condiviedrò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condivierò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condviderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "condviiderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "conidviderò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "conividerò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "ocndividerò"
-    replace: "condividerò"
-    word: true
-
-  - trigger: "cnfermerai"
+  - triggers:
+    - "cnfermerai"
+    - "cnofermerai"
+    - "cofermerai"
+    - "cofnermerai"
+    - "conefrmerai"
+    - "conermerai"
+    - "confemerai"
+    - "confemrerai"
+    - "conferemrai"
+    - "confererai"
+    - "confermeai"
+    - "confermeari"
+    - "confermeri"
+    - "confermeria"
+    - "confermrai"
+    - "confermreai"
+    - "confremerai"
+    - "confrmerai"
+    - "ocnfermerai"
     replace: "confermerai"
     propagate_case: true
     word: true
 
-  - trigger: "cnofermerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofermerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofnermerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "conefrmerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "conermerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemrerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "conferemrai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confererai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeari"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeri"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeria"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermrai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermreai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confremerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "confrmerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnfermerai"
-    replace: "confermerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnfermeranno"
+  - triggers:
+    - "cnfermeranno"
+    - "cnofermeranno"
+    - "cofermeranno"
+    - "cofnermeranno"
+    - "conefrmeranno"
+    - "conermeranno"
+    - "confemeranno"
+    - "confemreranno"
+    - "conferemranno"
+    - "confereranno"
+    - "confermeanno"
+    - "confermearnno"
+    - "confermerano"
+    - "confermeranon"
+    - "confermernano"
+    - "confermernno"
+    - "confermranno"
+    - "confermreanno"
+    - "confremeranno"
+    - "confrmeranno"
+    - "ocnfermeranno"
     replace: "confermeranno"
     propagate_case: true
     word: true
 
-  - trigger: "cnofermeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofermeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofnermeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "conefrmeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "conermeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemreranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "conferemranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confereranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeanno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermearnno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermerano"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeranon"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermernano"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermernno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermreanno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confremeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "confrmeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnfermeranno"
-    replace: "confermeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnfermeremo"
+  - triggers:
+    - "cnfermeremo"
+    - "cnofermeremo"
+    - "cofermeremo"
+    - "cofnermeremo"
+    - "conefrmeremo"
+    - "conermeremo"
+    - "confemeremo"
+    - "confemreremo"
+    - "conferemremo"
+    - "confereremo"
+    - "confermeemo"
+    - "confermeermo"
+    - "confermereo"
+    - "confermereom"
+    - "confermermeo"
+    - "confermermo"
+    - "confermreemo"
+    - "confermremo"
+    - "confremeremo"
+    - "confrmeremo"
+    - "ocnfermeremo"
     replace: "confermeremo"
     propagate_case: true
     word: true
 
-  - trigger: "cnofermeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofermeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofnermeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "conefrmeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "conermeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confemreremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "conferemremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confereremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeemo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermeermo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermereo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermereom"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermermeo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermermo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermreemo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confermremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confremeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "confrmeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnfermeremo"
-    replace: "confermeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnfermerà"
+  - triggers:
+    - "cnfermerà"
+    - "cnofermerà"
+    - "cofermerà"
+    - "cofnermerà"
+    - "conefrmerà"
+    - "conermerà"
+    - "confemerà"
+    - "confemrerà"
+    - "conferemrà"
+    - "confererà"
+    - "confermera"
+    - "confermera'"
+    - "confermera1"
+    - "confermeà"
+    - "confermeàr"
+    - "confermreà"
+    - "confermrà"
+    - "confremerà"
+    - "confrmerà"
+    - "ocnfermerà"
     replace: "confermerà"
     word: true
 
-  - trigger: "cnofermerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "cofermerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "cofnermerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "conefrmerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "conermerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confemerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confemrerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "conferemrà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confererà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermera"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermera'"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermera1"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermeà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermeàr"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermreà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confermrà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confremerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "confrmerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "ocnfermerà"
-    replace: "confermerà"
-    word: true
-
-  - trigger: "cnfermerò"
+  - triggers:
+    - "cnfermerò"
+    - "cnofermerò"
+    - "cofermerò"
+    - "cofnermerò"
+    - "conefrmerò"
+    - "conermerò"
+    - "confemerò"
+    - "confemrerò"
+    - "conferemrò"
+    - "confererò"
+    - "confermero"
+    - "confermero'"
+    - "confermero1"
+    - "confermeò"
+    - "confermeòr"
+    - "confermreò"
+    - "confermrò"
+    - "confremerò"
+    - "confrmerò"
+    - "ocnfermerò"
     replace: "confermerò"
     word: true
 
-  - trigger: "cnofermerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "cofermerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "cofnermerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "conefrmerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "conermerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confemerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confemrerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "conferemrò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confererò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermero"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermero'"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermero1"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermeò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermeòr"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermreò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confermrò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confremerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "confrmerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "ocnfermerò"
-    replace: "confermerò"
-    word: true
-
-  - trigger: "coreggerai"
+  - triggers:
+    - "coreggerai"
+    - "corerggerai"
+    - "corregegrai"
+    - "corregerai"
+    - "correggeai"
+    - "correggeari"
+    - "correggeri"
+    - "correggeria"
+    - "correggrai"
+    - "correggreai"
+    - "corrgegerai"
+    - "corrggerai"
+    - "croreggerai"
+    - "crreggerai"
+    - "ocrreggerai"
     replace: "correggerai"
     propagate_case: true
     word: true
 
-  - trigger: "corerggerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregegrai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeari"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeri"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeria"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggrai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggreai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrgegerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrggerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "croreggerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "crreggerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocrreggerai"
-    replace: "correggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "coreggeranno"
+  - triggers:
+    - "coreggeranno"
+    - "corerggeranno"
+    - "corregegranno"
+    - "corregeranno"
+    - "correggeanno"
+    - "correggearnno"
+    - "correggerano"
+    - "correggeranon"
+    - "correggernano"
+    - "correggernno"
+    - "correggranno"
+    - "correggreanno"
+    - "corrgegeranno"
+    - "corrggeranno"
+    - "croreggeranno"
+    - "crreggeranno"
+    - "ocrreggeranno"
     replace: "correggeranno"
     propagate_case: true
     word: true
 
-  - trigger: "corerggeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregegranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeanno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggearnno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggerano"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeranon"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggernano"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggernno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggreanno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrgegeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrggeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "croreggeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "crreggeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocrreggeranno"
-    replace: "correggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "coreggeremo"
+  - triggers:
+    - "coreggeremo"
+    - "corerggeremo"
+    - "corregegremo"
+    - "corregeremo"
+    - "correggeemo"
+    - "correggeermo"
+    - "correggereo"
+    - "correggereom"
+    - "correggermeo"
+    - "correggermo"
+    - "correggreemo"
+    - "correggremo"
+    - "corrgegeremo"
+    - "corrggeremo"
+    - "croreggeremo"
+    - "crreggeremo"
+    - "ocrreggeremo"
     replace: "correggeremo"
     propagate_case: true
     word: true
 
-  - trigger: "corerggeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregegremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corregeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeemo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggeermo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggereo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggereom"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggermeo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggermo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggreemo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "correggremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrgegeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corrggeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "croreggeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "crreggeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocrreggeremo"
-    replace: "correggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "coreggerà"
+  - triggers:
+    - "coreggerà"
+    - "corerggerà"
+    - "corregegrà"
+    - "corregerà"
+    - "correggera"
+    - "correggera'"
+    - "correggera1"
+    - "correggeà"
+    - "correggeàr"
+    - "correggreà"
+    - "correggrà"
+    - "corrgegerà"
+    - "corrggerà"
+    - "croreggerà"
+    - "crreggerà"
+    - "ocrreggerà"
     replace: "correggerà"
     word: true
 
-  - trigger: "corerggerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "corregegrà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "corregerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggera"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggera'"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggera1"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggeà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggeàr"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggreà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "correggrà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "corrgegerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "corrggerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "croreggerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "crreggerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "ocrreggerà"
-    replace: "correggerà"
-    word: true
-
-  - trigger: "coreggerò"
+  - triggers:
+    - "coreggerò"
+    - "corerggerò"
+    - "corregegrò"
+    - "corregerò"
+    - "correggero"
+    - "correggero'"
+    - "correggero1"
+    - "correggeò"
+    - "correggeòr"
+    - "correggreò"
+    - "correggrò"
+    - "corrgegerò"
+    - "corrggerò"
+    - "croreggerò"
+    - "crreggerò"
+    - "ocrreggerò"
     replace: "correggerò"
     word: true
 
-  - trigger: "corerggerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "corregegrò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "corregerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggero"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggero'"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggero1"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggeò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggeòr"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggreò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "correggrò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "corrgegerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "corrggerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "croreggerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "crreggerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "ocrreggerò"
-    replace: "correggerò"
-    word: true
-
-  - trigger: "coicché"
+  - triggers:
+    - "coicché"
+    - "coiscché"
+    - "coscché"
+    - "cosciché"
+    - "cosicche"
+    - "cosicche'"
+    - "cosicche1"
+    - "cosiccé"
+    - "cosiccéh"
+    - "cosichcé"
+    - "cosiché"
+    - "csicché"
+    - "csoicché"
+    - "ocsicché"
     replace: "cosicché"
     word: true
 
-  - trigger: "coiscché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "coscché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosciché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosicche"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosicche'"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosicche1"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosiccé"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosiccéh"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosichcé"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosiché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "csicché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "csoicché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "ocsicché"
-    replace: "cosicché"
-    word: true
-
-  - trigger: "cosi"
+  - triggers:
+    - "cosi"
+    - "cosi'"
+    - "cosi1"
+    - "coìs"
+    - "csoì"
+    - "ocsì"
     replace: "così"
     word: true
 
-  - trigger: "cosi'"
-    replace: "così"
-    word: true
-
-  - trigger: "cosi1"
-    replace: "così"
-    word: true
-
-  - trigger: "coìs"
-    replace: "così"
-    word: true
-
-  - trigger: "csoì"
-    replace: "così"
-    word: true
-
-  - trigger: "ocsì"
-    replace: "così"
-    word: true
-
-  - trigger: "ceatività"
+  - triggers:
+    - "ceatività"
+    - "ceratività"
+    - "craetività"
+    - "cratività"
+    - "creaitvità"
+    - "creaività"
+    - "creatiità"
+    - "creatiivtà"
+    - "creativita"
+    - "creativita'"
+    - "creativita1"
+    - "creativià"
+    - "creativiàt"
+    - "creativtià"
+    - "creativtà"
+    - "creatviità"
+    - "creatvità"
+    - "cretaività"
+    - "cretività"
+    - "rceatività"
     replace: "creatività"
     word: true
 
-  - trigger: "ceratività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "craetività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "cratività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creaitvità"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creaività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creatiità"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creatiivtà"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativita"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativita'"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativita1"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativià"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativiàt"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativtià"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creativtà"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creatviità"
-    replace: "creatività"
-    word: true
-
-  - trigger: "creatvità"
-    replace: "creatività"
-    word: true
-
-  - trigger: "cretaività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "cretività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "rceatività"
-    replace: "creatività"
-    word: true
-
-  - trigger: "ceerai"
+  - triggers:
+    - "ceerai"
+    - "cererai"
+    - "creeai"
+    - "creeari"
+    - "creeri"
+    - "creeria"
+    - "crerai"
+    - "crereai"
+    - "rceerai"
     replace: "creerai"
     propagate_case: true
     word: true
 
-  - trigger: "cererai"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeai"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeari"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeri"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeria"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "crerai"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "crereai"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rceerai"
-    replace: "creerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceeranno"
+  - triggers:
+    - "ceeranno"
+    - "cereranno"
+    - "creeanno"
+    - "creearnno"
+    - "creerano"
+    - "creeranon"
+    - "creernano"
+    - "creernno"
+    - "creranno"
+    - "crereanno"
+    - "rceeranno"
     replace: "creeranno"
     propagate_case: true
     word: true
 
-  - trigger: "cereranno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeanno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creearnno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creerano"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeranon"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creernano"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creernno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "creranno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "crereanno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rceeranno"
-    replace: "creeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceeremo"
+  - triggers:
+    - "ceeremo"
+    - "cereremo"
+    - "creeemo"
+    - "creeermo"
+    - "creereo"
+    - "creereom"
+    - "creermeo"
+    - "creermo"
+    - "crereemo"
+    - "creremo"
+    - "rceeremo"
     replace: "creeremo"
     propagate_case: true
     word: true
 
-  - trigger: "cereremo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeemo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creeermo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creereo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creereom"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creermeo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creermo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "crereemo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "creremo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rceeremo"
-    replace: "creeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceerà"
+  - triggers:
+    - "ceerà"
+    - "cererà"
+    - "creera"
+    - "creera'"
+    - "creera1"
+    - "creeà"
+    - "creeàr"
+    - "crereà"
+    - "crerà"
+    - "rceerà"
     replace: "creerà"
     word: true
 
-  - trigger: "cererà"
-    replace: "creerà"
-    word: true
-
-  - trigger: "creera"
-    replace: "creerà"
-    word: true
-
-  - trigger: "creera'"
-    replace: "creerà"
-    word: true
-
-  - trigger: "creera1"
-    replace: "creerà"
-    word: true
-
-  - trigger: "creeà"
-    replace: "creerà"
-    word: true
-
-  - trigger: "creeàr"
-    replace: "creerà"
-    word: true
-
-  - trigger: "crereà"
-    replace: "creerà"
-    word: true
-
-  - trigger: "crerà"
-    replace: "creerà"
-    word: true
-
-  - trigger: "rceerà"
-    replace: "creerà"
-    word: true
-
-  - trigger: "ceerò"
+  - triggers:
+    - "ceerò"
+    - "cererò"
+    - "creero"
+    - "creero'"
+    - "creero1"
+    - "creeò"
+    - "creeòr"
+    - "crereò"
+    - "crerò"
+    - "rceerò"
     replace: "creerò"
     word: true
 
-  - trigger: "cererò"
-    replace: "creerò"
-    word: true
-
-  - trigger: "creero"
-    replace: "creerò"
-    word: true
-
-  - trigger: "creero'"
-    replace: "creerò"
-    word: true
-
-  - trigger: "creero1"
-    replace: "creerò"
-    word: true
-
-  - trigger: "creeò"
-    replace: "creerò"
-    word: true
-
-  - trigger: "creeòr"
-    replace: "creerò"
-    word: true
-
-  - trigger: "crereò"
-    replace: "creerò"
-    word: true
-
-  - trigger: "crerò"
-    replace: "creerò"
-    word: true
-
-  - trigger: "rceerò"
-    replace: "creerò"
-    word: true
-
-  - trigger: "criosità"
+  - triggers:
+    - "criosità"
+    - "cruiosità"
+    - "cuiosità"
+    - "cuirosità"
+    - "curioistà"
+    - "curioità"
+    - "curiosita"
+    - "curiosita'"
+    - "curiosita1"
+    - "curiosià"
+    - "curiosiàt"
+    - "curiostià"
+    - "curiostà"
+    - "curisità"
+    - "curisoità"
+    - "curoisità"
+    - "curosità"
+    - "ucriosità"
     replace: "curiosità"
     word: true
 
-  - trigger: "cruiosità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "cuiosità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "cuirosità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curioistà"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curioità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiosita"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiosita'"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiosita1"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiosià"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiosiàt"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiostià"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curiostà"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curisità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curisoità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curoisità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "curosità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "ucriosità"
-    replace: "curiosità"
-    word: true
-
-  - trigger: "daai"
+  - triggers:
+    - "daai"
+    - "daari"
+    - "dari"
+    - "daria"
+    - "draai"
+    - "drai"
     replace: "darai"
     propagate_case: true
     word: true
 
-  - trigger: "daari"
-    replace: "darai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dari"
-    replace: "darai"
-    propagate_case: true
-    word: true
-
-  - trigger: "daria"
-    replace: "darai"
-    propagate_case: true
-    word: true
-
-  - trigger: "draai"
-    replace: "darai"
-    propagate_case: true
-    word: true
-
-  - trigger: "drai"
-    replace: "darai"
-    propagate_case: true
-    word: true
-
-  - trigger: "daanno"
+  - triggers:
+    - "daanno"
+    - "daarnno"
+    - "darano"
+    - "daranon"
+    - "darnano"
+    - "darnno"
+    - "draanno"
+    - "dranno"
     replace: "daranno"
     propagate_case: true
     word: true
 
-  - trigger: "daarnno"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "darano"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "daranon"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "darnano"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "darnno"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "draanno"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dranno"
-    replace: "daranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "daemo"
+  - triggers:
+    - "daemo"
+    - "daermo"
+    - "dareo"
+    - "dareom"
+    - "darmeo"
+    - "darmo"
+    - "draemo"
+    - "dremo"
     replace: "daremo"
     propagate_case: true
     word: true
 
-  - trigger: "daermo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dareo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dareom"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "darmeo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "darmo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "draemo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dremo"
-    replace: "daremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dara"
+  - triggers:
+    - "dara"
+    - "dara'"
+    - "dara1"
+    - "daàr"
+    - "draà"
     replace: "darà"
     word: true
 
-  - trigger: "dara'"
-    replace: "darà"
-    word: true
-
-  - trigger: "dara1"
-    replace: "darà"
-    word: true
-
-  - trigger: "daàr"
-    replace: "darà"
-    word: true
-
-  - trigger: "draà"
-    replace: "darà"
-    word: true
-
-  - trigger: "daro"
+  - triggers:
+    - "daro"
+    - "daro'"
+    - "daro1"
+    - "daòr"
+    - "draò"
     replace: "darò"
     word: true
 
-  - trigger: "daro'"
-    replace: "darò"
-    word: true
-
-  - trigger: "daro1"
-    replace: "darò"
-    word: true
-
-  - trigger: "daòr"
-    replace: "darò"
-    word: true
-
-  - trigger: "draò"
-    replace: "darò"
-    word: true
-
-  - trigger: "dfficoltà"
+  - triggers:
+    - "dfficoltà"
+    - "dfificoltà"
+    - "diffcioltà"
+    - "diffcoltà"
+    - "difficlotà"
+    - "difficltà"
+    - "difficolta"
+    - "difficolta'"
+    - "difficolta1"
+    - "difficolà"
+    - "difficolàt"
+    - "difficotlà"
+    - "difficotà"
+    - "diffiocltà"
+    - "diffioltà"
+    - "dificoltà"
+    - "dififcoltà"
+    - "idfficoltà"
     replace: "difficoltà"
     word: true
 
-  - trigger: "dfificoltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "diffcioltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "diffcoltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficlotà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficolta"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficolta'"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficolta1"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficolà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficolàt"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficotlà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "difficotà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "diffiocltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "diffioltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "dificoltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "dififcoltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "idfficoltà"
-    replace: "difficoltà"
-    word: true
-
-  - trigger: "diai"
+  - triggers:
+    - "diai"
+    - "diari"
+    - "diri"
+    - "diria"
+    - "driai"
+    - "idrai"
     replace: "dirai"
     propagate_case: true
     word: true
 
-  - trigger: "diari"
-    replace: "dirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "diri"
-    replace: "dirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "diria"
-    replace: "dirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "driai"
-    replace: "dirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "idrai"
-    replace: "dirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dianno"
+  - triggers:
+    - "dianno"
+    - "diarnno"
+    - "dirano"
+    - "diranon"
+    - "dirnano"
+    - "dirnno"
+    - "drianno"
+    - "idranno"
     replace: "diranno"
     propagate_case: true
     word: true
 
-  - trigger: "diarnno"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirano"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "diranon"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirnano"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirnno"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "drianno"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "idranno"
-    replace: "diranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "diemo"
+  - triggers:
+    - "diemo"
+    - "diermo"
+    - "direo"
+    - "direom"
+    - "dirmeo"
+    - "dirmo"
+    - "driemo"
+    - "idremo"
     replace: "diremo"
     propagate_case: true
     word: true
 
-  - trigger: "diermo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "direo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "direom"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirmeo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirmo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "driemo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "idremo"
-    replace: "diremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dira"
+  - triggers:
+    - "dira"
+    - "dira'"
+    - "dira1"
+    - "diàr"
+    - "drià"
+    - "idrà"
     replace: "dirà"
     word: true
 
-  - trigger: "dira'"
-    replace: "dirà"
-    word: true
-
-  - trigger: "dira1"
-    replace: "dirà"
-    word: true
-
-  - trigger: "diàr"
-    replace: "dirà"
-    word: true
-
-  - trigger: "drià"
-    replace: "dirà"
-    word: true
-
-  - trigger: "idrà"
-    replace: "dirà"
-    word: true
-
-  - trigger: "diro"
+  - triggers:
+    - "diro"
+    - "diro'"
+    - "diro1"
+    - "diòr"
+    - "driò"
+    - "idrò"
     replace: "dirò"
     word: true
 
-  - trigger: "diro'"
-    replace: "dirò"
-    word: true
-
-  - trigger: "diro1"
-    replace: "dirò"
-    word: true
-
-  - trigger: "diòr"
-    replace: "dirò"
-    word: true
-
-  - trigger: "driò"
-    replace: "dirò"
-    word: true
-
-  - trigger: "idrò"
-    replace: "dirò"
-    word: true
-
-  - trigger: "diponibilità"
+  - triggers:
+    - "diponibilità"
+    - "dipsonibilità"
+    - "disonibilità"
+    - "disopnibilità"
+    - "dispnibilità"
+    - "dispnoibilità"
+    - "dispoibilità"
+    - "dispoinbilità"
+    - "disponbiilità"
+    - "disponbilità"
+    - "disponibiiltà"
+    - "disponibiità"
+    - "disponibilita"
+    - "disponibilita'"
+    - "disponibilita1"
+    - "disponibilià"
+    - "disponibiliàt"
+    - "disponibiltià"
+    - "disponibiltà"
+    - "disponibliità"
+    - "disponiblità"
+    - "disponiiblità"
+    - "disponiilità"
+    - "dsiponibilità"
+    - "dsponibilità"
+    - "idsponibilità"
     replace: "disponibilità"
     word: true
 
-  - trigger: "dipsonibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disonibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disopnibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dispnibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dispnoibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dispoibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dispoinbilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponbiilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponbilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibiiltà"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibiità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibilita"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibilita'"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibilita1"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibilià"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibiliàt"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibiltià"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibiltà"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponibliità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponiblità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponiiblità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "disponiilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dsiponibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dsponibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "idsponibilità"
-    replace: "disponibilità"
-    word: true
-
-  - trigger: "dorai"
+  - triggers:
+    - "dorai"
+    - "dorvai"
+    - "dovai"
+    - "dovari"
+    - "dovri"
+    - "dovria"
+    - "dvorai"
+    - "dvrai"
+    - "odvrai"
     replace: "dovrai"
     propagate_case: true
     word: true
 
-  - trigger: "dorvai"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovai"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovari"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovri"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovria"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvorai"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvrai"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "odvrai"
-    replace: "dovrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "doranno"
+  - triggers:
+    - "doranno"
+    - "dorvanno"
+    - "dovanno"
+    - "dovarnno"
+    - "dovrano"
+    - "dovranon"
+    - "dovrnano"
+    - "dovrnno"
+    - "dvoranno"
+    - "dvranno"
+    - "odvranno"
     replace: "dovranno"
     propagate_case: true
     word: true
 
-  - trigger: "dorvanno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovanno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovarnno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovrano"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovranon"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovrnano"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovrnno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvoranno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvranno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "odvranno"
-    replace: "dovranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "doremo"
+  - triggers:
+    - "doremo"
+    - "dorvemo"
+    - "dovemo"
+    - "dovermo"
+    - "dovreo"
+    - "dovreom"
+    - "dovrmeo"
+    - "dovrmo"
+    - "dvoremo"
+    - "dvremo"
+    - "odvremo"
     replace: "dovremo"
     propagate_case: true
     word: true
 
-  - trigger: "dorvemo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovemo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovermo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovreo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovreom"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovrmeo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovrmo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvoremo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvremo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "odvremo"
-    replace: "dovremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dorvà"
+  - triggers:
+    - "dorvà"
+    - "dorà"
+    - "dovra"
+    - "dovra'"
+    - "dovra1"
+    - "dovà"
+    - "dovàr"
+    - "dvorà"
+    - "dvrà"
+    - "odvrà"
     replace: "dovrà"
     word: true
 
-  - trigger: "dorà"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dovra"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dovra'"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dovra1"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dovà"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dovàr"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dvorà"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dvrà"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "odvrà"
-    replace: "dovrà"
-    word: true
-
-  - trigger: "dorvò"
+  - triggers:
+    - "dorvò"
+    - "dorò"
+    - "dovro"
+    - "dovro'"
+    - "dovro1"
+    - "dovò"
+    - "dovòr"
+    - "dvorò"
+    - "dvrò"
+    - "odvrò"
     replace: "dovrò"
     word: true
 
-  - trigger: "dorò"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dovro"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dovro'"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dovro1"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dovò"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dovòr"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dvorò"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "dvrò"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "odvrò"
-    replace: "dovrò"
-    word: true
-
-  - trigger: "afcilità"
+  - triggers:
+    - "afcilità"
+    - "faciiltà"
+    - "faciità"
+    - "facilita'"
+    - "facilita1"
+    - "facilià"
+    - "faciliàt"
+    - "faciltià"
+    - "faciltà"
+    - "facliità"
+    - "faclità"
+    - "faiclità"
+    - "failità"
+    - "fcailità"
+    - "fcilità"
     replace: "facilità"
     word: true
 
-  - trigger: "faciiltà"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faciità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "facilita'"
-    replace: "facilità"
-    word: true
-
-  - trigger: "facilita1"
-    replace: "facilità"
-    word: true
-
-  - trigger: "facilià"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faciliàt"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faciltià"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faciltà"
-    replace: "facilità"
-    word: true
-
-  - trigger: "facliità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faclità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "faiclità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "failità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "fcailità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "fcilità"
-    replace: "facilità"
-    word: true
-
-  - trigger: "afrai"
+  - triggers:
+    - "afrai"
+    - "faai"
+    - "faari"
+    - "fari"
+    - "faria"
+    - "fraai"
+    - "frai"
     replace: "farai"
     propagate_case: true
     word: true
 
-  - trigger: "faai"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "faari"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "fari"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "faria"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraai"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "frai"
-    replace: "farai"
-    propagate_case: true
-    word: true
-
-  - trigger: "afranno"
+  - triggers:
+    - "afranno"
+    - "faanno"
+    - "faarnno"
+    - "farano"
+    - "faranon"
+    - "farnano"
+    - "farnno"
+    - "fraanno"
+    - "franno"
     replace: "faranno"
     propagate_case: true
     word: true
 
-  - trigger: "faanno"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "faarnno"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "farano"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "faranon"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "farnano"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "farnno"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraanno"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "franno"
-    replace: "faranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "afremo"
+  - triggers:
+    - "afremo"
+    - "faemo"
+    - "faermo"
+    - "fareo"
+    - "fareom"
+    - "farmeo"
+    - "farmo"
+    - "fraemo"
+    - "fremo"
     replace: "faremo"
     propagate_case: true
     word: true
 
-  - trigger: "faemo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "faermo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fareo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fareom"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "farmeo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "farmo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraemo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fremo"
-    replace: "faremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "afrà"
+  - triggers:
+    - "afrà"
+    - "fara"
+    - "fara'"
+    - "fara1"
+    - "faàr"
+    - "fraà"
     replace: "farà"
     word: true
 
-  - trigger: "fara"
-    replace: "farà"
-    word: true
-
-  - trigger: "fara'"
-    replace: "farà"
-    word: true
-
-  - trigger: "fara1"
-    replace: "farà"
-    word: true
-
-  - trigger: "faàr"
-    replace: "farà"
-    word: true
-
-  - trigger: "fraà"
-    replace: "farà"
-    word: true
-
-  - trigger: "afrò"
+  - triggers:
+    - "afrò"
+    - "faro"
+    - "faro'"
+    - "faro1"
+    - "faòr"
+    - "fraò"
     replace: "farò"
     word: true
 
-  - trigger: "faro"
-    replace: "farò"
-    word: true
-
-  - trigger: "faro'"
-    replace: "farò"
-    word: true
-
-  - trigger: "faro1"
-    replace: "farò"
-    word: true
-
-  - trigger: "faòr"
-    replace: "farò"
-    word: true
-
-  - trigger: "fraò"
-    replace: "farò"
-    word: true
-
-  - trigger: "fiché"
+  - triggers:
+    - "fiché"
+    - "ficnhé"
+    - "finche"
+    - "finche'"
+    - "finche1"
+    - "fincé"
+    - "fincéh"
+    - "finhcé"
+    - "finhé"
+    - "fnché"
+    - "fniché"
+    - "ifnché"
     replace: "finché"
     word: true
 
-  - trigger: "ficnhé"
-    replace: "finché"
-    word: true
-
-  - trigger: "finche"
-    replace: "finché"
-    word: true
-
-  - trigger: "finche'"
-    replace: "finché"
-    word: true
-
-  - trigger: "finche1"
-    replace: "finché"
-    word: true
-
-  - trigger: "fincé"
-    replace: "finché"
-    word: true
-
-  - trigger: "fincéh"
-    replace: "finché"
-    word: true
-
-  - trigger: "finhcé"
-    replace: "finché"
-    word: true
-
-  - trigger: "finhé"
-    replace: "finché"
-    word: true
-
-  - trigger: "fnché"
-    replace: "finché"
-    word: true
-
-  - trigger: "fniché"
-    replace: "finché"
-    word: true
-
-  - trigger: "ifnché"
-    replace: "finché"
-    word: true
-
-  - trigger: "fiinrai"
+  - triggers:
+    - "fiinrai"
+    - "fiirai"
+    - "finiai"
+    - "finiari"
+    - "finiri"
+    - "finiria"
+    - "finrai"
+    - "finriai"
+    - "fniirai"
+    - "fnirai"
+    - "ifnirai"
     replace: "finirai"
     propagate_case: true
     word: true
 
-  - trigger: "fiirai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiari"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiri"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiria"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finrai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "finriai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniirai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnirai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifnirai"
-    replace: "finirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiinranno"
+  - triggers:
+    - "fiinranno"
+    - "fiiranno"
+    - "finianno"
+    - "finiarnno"
+    - "finirano"
+    - "finiranon"
+    - "finirnano"
+    - "finirnno"
+    - "finranno"
+    - "finrianno"
+    - "fniiranno"
+    - "fniranno"
+    - "ifniranno"
     replace: "finiranno"
     propagate_case: true
     word: true
 
-  - trigger: "fiiranno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finianno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiarnno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finirano"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiranon"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finirnano"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finirnno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finranno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "finrianno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniiranno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniranno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifniranno"
-    replace: "finiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiinremo"
+  - triggers:
+    - "fiinremo"
+    - "fiiremo"
+    - "finiemo"
+    - "finiermo"
+    - "finireo"
+    - "finireom"
+    - "finirmeo"
+    - "finirmo"
+    - "finremo"
+    - "finriemo"
+    - "fniiremo"
+    - "fniremo"
+    - "ifniremo"
     replace: "finiremo"
     propagate_case: true
     word: true
 
-  - trigger: "fiiremo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiemo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finiermo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finireo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finireom"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finirmeo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finirmo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finremo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "finriemo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniiremo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniremo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifniremo"
-    replace: "finiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiinrà"
+  - triggers:
+    - "fiinrà"
+    - "fiirà"
+    - "finira"
+    - "finira'"
+    - "finira1"
+    - "finià"
+    - "finiàr"
+    - "finrià"
+    - "finrà"
+    - "fniirà"
+    - "fnirà"
+    - "ifnirà"
     replace: "finirà"
     word: true
 
-  - trigger: "fiirà"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finira"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finira'"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finira1"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finià"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finiàr"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finrià"
-    replace: "finirà"
-    word: true
-
-  - trigger: "finrà"
-    replace: "finirà"
-    word: true
-
-  - trigger: "fniirà"
-    replace: "finirà"
-    word: true
-
-  - trigger: "fnirà"
-    replace: "finirà"
-    word: true
-
-  - trigger: "ifnirà"
-    replace: "finirà"
-    word: true
-
-  - trigger: "fiinrò"
+  - triggers:
+    - "fiinrò"
+    - "fiirò"
+    - "finiro"
+    - "finiro'"
+    - "finiro1"
+    - "finiò"
+    - "finiòr"
+    - "finriò"
+    - "finrò"
+    - "fniirò"
+    - "fnirò"
+    - "ifnirò"
     replace: "finirò"
     word: true
 
-  - trigger: "fiirò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finiro"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finiro'"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finiro1"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finiò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finiòr"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finriò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "finrò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "fniirò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "fnirò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "ifnirò"
-    replace: "finirò"
-    word: true
-
-  - trigger: "gacché"
+  - triggers:
+    - "gacché"
+    - "gaicché"
+    - "giacche"
+    - "giacche'"
+    - "giacche1"
+    - "giaccé"
+    - "giaccéh"
+    - "giachcé"
+    - "giaché"
+    - "gicaché"
+    - "gicché"
+    - "igacché"
     replace: "giacché"
     word: true
 
-  - trigger: "gaicché"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giacche"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giacche'"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giacche1"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giaccé"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giaccéh"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giachcé"
-    replace: "giacché"
-    word: true
-
-  - trigger: "giaché"
-    replace: "giacché"
-    word: true
-
-  - trigger: "gicaché"
-    replace: "giacché"
-    word: true
-
-  - trigger: "gicché"
-    replace: "giacché"
-    word: true
-
-  - trigger: "igacché"
-    replace: "giacché"
-    word: true
-
-  - trigger: "gioedì"
+  - triggers:
+    - "gioedì"
+    - "gioevdì"
+    - "giovdeì"
+    - "giovdì"
+    - "giovedi"
+    - "giovedi'"
+    - "giovedi1"
+    - "gioveì"
+    - "gioveìd"
+    - "givedì"
+    - "givoedì"
+    - "goivedì"
+    - "govedì"
+    - "igovedì"
     replace: "giovedì"
     word: true
 
-  - trigger: "gioevdì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "giovdeì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "giovdì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "giovedi"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "giovedi'"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "giovedi1"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "gioveì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "gioveìd"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "givedì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "givoedì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "goivedì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "govedì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "igovedì"
-    replace: "giovedì"
-    word: true
-
-  - trigger: "gia"
+  - triggers:
+    - "gia"
+    - "gia'"
+    - "gia1"
+    - "gài"
+    - "igà"
     replace: "già"
     word: true
 
-  - trigger: "gia'"
-    replace: "già"
-    word: true
-
-  - trigger: "gia1"
-    replace: "già"
-    word: true
-
-  - trigger: "gài"
-    replace: "già"
-    word: true
-
-  - trigger: "igà"
-    replace: "già"
-    word: true
-
-  - trigger: "giu"
+  - triggers:
+    - "giu"
+    - "giu'"
+    - "giu1"
+    - "gùi"
+    - "igù"
     replace: "giù"
     word: true
 
-  - trigger: "giu'"
-    replace: "giù"
-    word: true
-
-  - trigger: "giu1"
-    replace: "giù"
-    word: true
-
-  - trigger: "gùi"
-    replace: "giù"
-    word: true
-
-  - trigger: "igù"
-    replace: "giù"
-    word: true
-
-  - trigger: "dientità"
+  - triggers:
+    - "dientità"
+    - "idenittà"
+    - "idenità"
+    - "identita"
+    - "identita'"
+    - "identita1"
+    - "identià"
+    - "identiàt"
+    - "identtià"
+    - "identtà"
+    - "idetità"
+    - "idetnità"
+    - "idnetità"
+    - "idntità"
+    - "iedntità"
+    - "ientità"
     replace: "identità"
     word: true
 
-  - trigger: "idenittà"
-    replace: "identità"
-    word: true
-
-  - trigger: "idenità"
-    replace: "identità"
-    word: true
-
-  - trigger: "identita"
-    replace: "identità"
-    word: true
-
-  - trigger: "identita'"
-    replace: "identità"
-    word: true
-
-  - trigger: "identita1"
-    replace: "identità"
-    word: true
-
-  - trigger: "identià"
-    replace: "identità"
-    word: true
-
-  - trigger: "identiàt"
-    replace: "identità"
-    word: true
-
-  - trigger: "identtià"
-    replace: "identità"
-    word: true
-
-  - trigger: "identtà"
-    replace: "identità"
-    word: true
-
-  - trigger: "idetità"
-    replace: "identità"
-    word: true
-
-  - trigger: "idetnità"
-    replace: "identità"
-    word: true
-
-  - trigger: "idnetità"
-    replace: "identità"
-    word: true
-
-  - trigger: "idntità"
-    replace: "identità"
-    word: true
-
-  - trigger: "iedntità"
-    replace: "identità"
-    word: true
-
-  - trigger: "ientità"
-    replace: "identità"
-    word: true
-
-  - trigger: "imlementerai"
+  - triggers:
+    - "imlementerai"
+    - "imlpementerai"
+    - "impelmenterai"
+    - "impementerai"
+    - "impleemnterai"
+    - "impleenterai"
+    - "implemenerai"
+    - "implemenetrai"
+    - "implementeai"
+    - "implementeari"
+    - "implementeri"
+    - "implementeria"
+    - "implementrai"
+    - "implementreai"
+    - "implemeterai"
+    - "implemetnerai"
+    - "implemneterai"
+    - "implemnterai"
+    - "implmeenterai"
+    - "implmenterai"
+    - "iplementerai"
+    - "ipmlementerai"
+    - "miplementerai"
     replace: "implementerai"
     propagate_case: true
     word: true
 
-  - trigger: "imlpementerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "impelmenterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "impementerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleemnterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleenterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemenerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemenetrai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeari"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeri"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeria"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementrai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementreai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemeterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemetnerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemneterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemnterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmeenterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmenterai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iplementerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmlementerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "miplementerai"
-    replace: "implementerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "imlementeranno"
+  - triggers:
+    - "imlementeranno"
+    - "imlpementeranno"
+    - "impelmenteranno"
+    - "impementeranno"
+    - "impleemnteranno"
+    - "impleenteranno"
+    - "implemeneranno"
+    - "implemenetranno"
+    - "implementeanno"
+    - "implementearnno"
+    - "implementerano"
+    - "implementeranon"
+    - "implementernano"
+    - "implementernno"
+    - "implementranno"
+    - "implementreanno"
+    - "implemeteranno"
+    - "implemetneranno"
+    - "implemneteranno"
+    - "implemnteranno"
+    - "implmeenteranno"
+    - "implmenteranno"
+    - "iplementeranno"
+    - "ipmlementeranno"
+    - "miplementeranno"
     replace: "implementeranno"
     propagate_case: true
     word: true
 
-  - trigger: "imlpementeranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "impelmenteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "impementeranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleemnteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleenteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemeneranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemenetranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeanno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementearnno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementerano"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeranon"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementernano"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementernno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementreanno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemeteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemetneranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemneteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemnteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmeenteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmenteranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iplementeranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmlementeranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "miplementeranno"
-    replace: "implementeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "imlementeremo"
+  - triggers:
+    - "imlementeremo"
+    - "imlpementeremo"
+    - "impelmenteremo"
+    - "impementeremo"
+    - "impleemnteremo"
+    - "impleenteremo"
+    - "implemeneremo"
+    - "implemenetremo"
+    - "implementeemo"
+    - "implementeermo"
+    - "implementereo"
+    - "implementereom"
+    - "implementermeo"
+    - "implementermo"
+    - "implementreemo"
+    - "implementremo"
+    - "implemeteremo"
+    - "implemetneremo"
+    - "implemneteremo"
+    - "implemnteremo"
+    - "implmeenteremo"
+    - "implmenteremo"
+    - "iplementeremo"
+    - "ipmlementeremo"
+    - "miplementeremo"
     replace: "implementeremo"
     propagate_case: true
     word: true
 
-  - trigger: "imlpementeremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "impelmenteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "impementeremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleemnteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleenteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemeneremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemenetremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeemo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementeermo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementereo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementereom"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementermeo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementermo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementreemo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implementremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemeteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemetneremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemneteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemnteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmeenteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmenteremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iplementeremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmlementeremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "miplementeremo"
-    replace: "implementeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "imlementerà"
+  - triggers:
+    - "imlementerà"
+    - "imlpementerà"
+    - "impelmenterà"
+    - "impementerà"
+    - "impleemnterà"
+    - "impleenterà"
+    - "implemenerà"
+    - "implemenetrà"
+    - "implementera"
+    - "implementera'"
+    - "implementera1"
+    - "implementeà"
+    - "implementeàr"
+    - "implementreà"
+    - "implementrà"
+    - "implemeterà"
+    - "implemetnerà"
+    - "implemneterà"
+    - "implemnterà"
+    - "implmeenterà"
+    - "implmenterà"
+    - "iplementerà"
+    - "ipmlementerà"
+    - "miplementerà"
     replace: "implementerà"
     word: true
 
-  - trigger: "imlpementerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "impelmenterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "impementerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "impleemnterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "impleenterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemenerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemenetrà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementera"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementera'"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementera1"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementeà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementeàr"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementreà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implementrà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemeterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemetnerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemneterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implemnterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implmeenterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "implmenterà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "iplementerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "ipmlementerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "miplementerà"
-    replace: "implementerà"
-    word: true
-
-  - trigger: "imlementerò"
+  - triggers:
+    - "imlementerò"
+    - "imlpementerò"
+    - "impelmenterò"
+    - "impementerò"
+    - "impleemnterò"
+    - "impleenterò"
+    - "implemenerò"
+    - "implemenetrò"
+    - "implementero"
+    - "implementero'"
+    - "implementero1"
+    - "implementeò"
+    - "implementeòr"
+    - "implementreò"
+    - "implementrò"
+    - "implemeterò"
+    - "implemetnerò"
+    - "implemneterò"
+    - "implemnterò"
+    - "implmeenterò"
+    - "implmenterò"
+    - "iplementerò"
+    - "ipmlementerò"
+    - "miplementerò"
     replace: "implementerò"
     word: true
 
-  - trigger: "imlpementerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "impelmenterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "impementerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "impleemnterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "impleenterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemenerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemenetrò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementero"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementero'"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementero1"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementeò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementeòr"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementreò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implementrò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemeterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemetnerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemneterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implemnterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implmeenterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "implmenterò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "iplementerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "ipmlementerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "miplementerò"
-    replace: "implementerò"
-    word: true
-
-  - trigger: "iinzierai"
+  - triggers:
+    - "iinzierai"
+    - "iizierai"
+    - "iniierai"
+    - "iniizerai"
+    - "inizeirai"
+    - "inizerai"
+    - "inizieai"
+    - "inizieari"
+    - "inizieri"
+    - "inizieria"
+    - "inizirai"
+    - "inizireai"
+    - "inzierai"
+    - "inziierai"
+    - "niizierai"
     replace: "inizierai"
     propagate_case: true
     word: true
 
-  - trigger: "iizierai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniierai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniizerai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizeirai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizerai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieari"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieri"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieria"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizirai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizireai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inzierai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inziierai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "niizierai"
-    replace: "inizierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iinzieranno"
+  - triggers:
+    - "iinzieranno"
+    - "iizieranno"
+    - "iniieranno"
+    - "iniizeranno"
+    - "inizeiranno"
+    - "inizeranno"
+    - "inizieanno"
+    - "iniziearnno"
+    - "inizierano"
+    - "inizieranon"
+    - "iniziernano"
+    - "iniziernno"
+    - "iniziranno"
+    - "inizireanno"
+    - "inzieranno"
+    - "inziieranno"
+    - "niizieranno"
     replace: "inizieranno"
     propagate_case: true
     word: true
 
-  - trigger: "iizieranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniieranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniizeranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizeiranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizeranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieanno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziearnno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizierano"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieranon"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziernano"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziernno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizireanno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inzieranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inziieranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "niizieranno"
-    replace: "inizieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iinzieremo"
+  - triggers:
+    - "iinzieremo"
+    - "iizieremo"
+    - "iniieremo"
+    - "iniizeremo"
+    - "inizeiremo"
+    - "inizeremo"
+    - "inizieemo"
+    - "inizieermo"
+    - "iniziereo"
+    - "iniziereom"
+    - "iniziermeo"
+    - "iniziermo"
+    - "inizireemo"
+    - "iniziremo"
+    - "inzieremo"
+    - "inziieremo"
+    - "niizieremo"
     replace: "inizieremo"
     propagate_case: true
     word: true
 
-  - trigger: "iizieremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniieremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniizeremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizeiremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizeremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieemo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizieermo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziereo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziereom"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziermeo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziermo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizireemo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inzieremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inziieremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "niizieremo"
-    replace: "inizieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iinzierà"
+  - triggers:
+    - "iinzierà"
+    - "iizierà"
+    - "iniierà"
+    - "iniizerà"
+    - "inizeirà"
+    - "inizerà"
+    - "iniziera"
+    - "iniziera'"
+    - "iniziera1"
+    - "inizieà"
+    - "inizieàr"
+    - "inizireà"
+    - "inizirà"
+    - "inzierà"
+    - "inziierà"
+    - "niizierà"
     replace: "inizierà"
     word: true
 
-  - trigger: "iizierà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iniierà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iniizerà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizeirà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizerà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iniziera"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iniziera'"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iniziera1"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizieà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizieàr"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizireà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inizirà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inzierà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "inziierà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "niizierà"
-    replace: "inizierà"
-    word: true
-
-  - trigger: "iinzierò"
+  - triggers:
+    - "iinzierò"
+    - "iizierò"
+    - "iniierò"
+    - "iniizerò"
+    - "inizeirò"
+    - "inizerò"
+    - "iniziero"
+    - "iniziero'"
+    - "iniziero1"
+    - "inizieò"
+    - "inizieòr"
+    - "inizireò"
+    - "inizirò"
+    - "inzierò"
+    - "inziierò"
+    - "niizierò"
     replace: "inizierò"
     word: true
 
-  - trigger: "iizierò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "iniierò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "iniizerò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizeirò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizerò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "iniziero"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "iniziero'"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "iniziero1"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizieò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizieòr"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizireò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inizirò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inzierò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inziierò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "niizierò"
-    replace: "inizierò"
-    word: true
-
-  - trigger: "inerirai"
+  - triggers:
+    - "inerirai"
+    - "inesrirai"
+    - "inseirai"
+    - "inseirrai"
+    - "inseriai"
+    - "inseriari"
+    - "inseriri"
+    - "inseriria"
+    - "inserrai"
+    - "inserriai"
+    - "insreirai"
+    - "insrirai"
+    - "iserirai"
+    - "isnerirai"
+    - "niserirai"
     replace: "inserirai"
     propagate_case: true
     word: true
 
-  - trigger: "inesrirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseirrai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriari"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriri"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriria"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserrai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserriai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "insreirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "insrirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "iserirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "isnerirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "niserirai"
-    replace: "inserirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ineriranno"
+  - triggers:
+    - "ineriranno"
+    - "inesriranno"
+    - "inseiranno"
+    - "inseirranno"
+    - "inserianno"
+    - "inseriarnno"
+    - "inserirano"
+    - "inseriranon"
+    - "inserirnano"
+    - "inserirnno"
+    - "inserranno"
+    - "inserrianno"
+    - "insreiranno"
+    - "insriranno"
+    - "iseriranno"
+    - "isneriranno"
+    - "niseriranno"
     replace: "inseriranno"
     propagate_case: true
     word: true
 
-  - trigger: "inesriranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseiranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseirranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserianno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriarnno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserirano"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriranon"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserirnano"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserirnno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserrianno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "insreiranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "insriranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "iseriranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "isneriranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "niseriranno"
-    replace: "inseriranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ineriremo"
+  - triggers:
+    - "ineriremo"
+    - "inesriremo"
+    - "inseiremo"
+    - "inseirremo"
+    - "inseriemo"
+    - "inseriermo"
+    - "inserireo"
+    - "inserireom"
+    - "inserirmeo"
+    - "inserirmo"
+    - "inserremo"
+    - "inserriemo"
+    - "insreiremo"
+    - "insriremo"
+    - "iseriremo"
+    - "isneriremo"
+    - "niseriremo"
     replace: "inseriremo"
     propagate_case: true
     word: true
 
-  - trigger: "inesriremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseiremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseirremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriemo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseriermo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserireo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserireom"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserirmeo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserirmo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inserriemo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "insreiremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "insriremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iseriremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "isneriremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "niseriremo"
-    replace: "inseriremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inerirà"
+  - triggers:
+    - "inerirà"
+    - "inesrirà"
+    - "inseirrà"
+    - "inseirà"
+    - "inserira"
+    - "inserira'"
+    - "inserira1"
+    - "inserià"
+    - "inseriàr"
+    - "inserrià"
+    - "inserrà"
+    - "insreirà"
+    - "insrirà"
+    - "iserirà"
+    - "isnerirà"
+    - "niserirà"
     replace: "inserirà"
     word: true
 
-  - trigger: "inesrirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inseirrà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inseirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserira"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserira'"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserira1"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserià"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inseriàr"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserrià"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inserrà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "insreirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "insrirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "iserirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "isnerirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "niserirà"
-    replace: "inserirà"
-    word: true
-
-  - trigger: "inerirò"
+  - triggers:
+    - "inerirò"
+    - "inesrirò"
+    - "inseirrò"
+    - "inseirò"
+    - "inseriro"
+    - "inseriro'"
+    - "inseriro1"
+    - "inseriò"
+    - "inseriòr"
+    - "inserriò"
+    - "inserrò"
+    - "insreirò"
+    - "insrirò"
+    - "iserirò"
+    - "isnerirò"
+    - "niserirò"
     replace: "inserirò"
     word: true
 
-  - trigger: "inesrirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseirrò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseriro"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseriro'"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseriro1"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseriò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inseriòr"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inserriò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inserrò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "insreirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "insrirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "iserirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "isnerirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "niserirò"
-    replace: "inserirò"
-    word: true
-
-  - trigger: "inierai"
+  - triggers:
+    - "inierai"
+    - "iniverai"
+    - "inveirai"
+    - "inverai"
+    - "invieai"
+    - "invieari"
+    - "invieri"
+    - "invieria"
+    - "invirai"
+    - "invireai"
+    - "ivierai"
+    - "ivnierai"
+    - "nivierai"
     replace: "invierai"
     propagate_case: true
     word: true
 
-  - trigger: "iniverai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inveirai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inverai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieari"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieri"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieria"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invirai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "invireai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivierai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivnierai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "nivierai"
-    replace: "invierai"
-    propagate_case: true
-    word: true
-
-  - trigger: "inieranno"
+  - triggers:
+    - "inieranno"
+    - "iniveranno"
+    - "inveiranno"
+    - "inveranno"
+    - "invieanno"
+    - "inviearnno"
+    - "invierano"
+    - "invieranon"
+    - "inviernano"
+    - "inviernno"
+    - "inviranno"
+    - "invireanno"
+    - "ivieranno"
+    - "ivnieranno"
+    - "nivieranno"
     replace: "invieranno"
     propagate_case: true
     word: true
 
-  - trigger: "iniveranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inveiranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inveranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieanno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviearnno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "invierano"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieranon"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviernano"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviernno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "invireanno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivieranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivnieranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nivieranno"
-    replace: "invieranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "inieremo"
+  - triggers:
+    - "inieremo"
+    - "iniveremo"
+    - "inveiremo"
+    - "inveremo"
+    - "invieemo"
+    - "invieermo"
+    - "inviereo"
+    - "inviereom"
+    - "inviermeo"
+    - "inviermo"
+    - "invireemo"
+    - "inviremo"
+    - "ivieremo"
+    - "ivnieremo"
+    - "nivieremo"
     replace: "invieremo"
     propagate_case: true
     word: true
 
-  - trigger: "iniveremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inveiremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inveremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieemo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "invieermo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviereo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviereom"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviermeo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviermo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "invireemo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inviremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivieremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivnieremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nivieremo"
-    replace: "invieremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "inierà"
+  - triggers:
+    - "inierà"
+    - "iniverà"
+    - "inveirà"
+    - "inverà"
+    - "inviera"
+    - "inviera'"
+    - "inviera1"
+    - "invieà"
+    - "invieàr"
+    - "invireà"
+    - "invirà"
+    - "ivierà"
+    - "ivnierà"
+    - "nivierà"
     replace: "invierà"
     word: true
 
-  - trigger: "iniverà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inveirà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inverà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inviera"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inviera'"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inviera1"
-    replace: "invierà"
-    word: true
-
-  - trigger: "invieà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "invieàr"
-    replace: "invierà"
-    word: true
-
-  - trigger: "invireà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "invirà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "ivierà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "ivnierà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "nivierà"
-    replace: "invierà"
-    word: true
-
-  - trigger: "inierò"
+  - triggers:
+    - "inierò"
+    - "iniverò"
+    - "inveirò"
+    - "inverò"
+    - "inviero"
+    - "inviero'"
+    - "inviero1"
+    - "invieò"
+    - "invieòr"
+    - "invireò"
+    - "invirò"
+    - "ivierò"
+    - "ivnierò"
+    - "nivierò"
     replace: "invierò"
     word: true
 
-  - trigger: "iniverò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "inveirò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "inverò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "inviero"
-    replace: "invierò"
-    word: true
-
-  - trigger: "inviero'"
-    replace: "invierò"
-    word: true
-
-  - trigger: "inviero1"
-    replace: "invierò"
-    word: true
-
-  - trigger: "invieò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "invieòr"
-    replace: "invierò"
-    word: true
-
-  - trigger: "invireò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "invirò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "ivierò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "ivnierò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "nivierò"
-    replace: "invierò"
-    word: true
-
-  - trigger: "alvorerai"
+  - triggers:
+    - "alvorerai"
+    - "laorerai"
+    - "laovrerai"
+    - "lavoerai"
+    - "lavoerrai"
+    - "lavoreai"
+    - "lavoreari"
+    - "lavoreri"
+    - "lavoreria"
+    - "lavorrai"
+    - "lavorreai"
+    - "lavrerai"
+    - "lavroerai"
+    - "lvaorerai"
+    - "lvorerai"
     replace: "lavorerai"
     propagate_case: true
     word: true
 
-  - trigger: "laorerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "laovrerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoerrai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreari"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreri"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreria"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorrai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorreai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavrerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavroerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvaorerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvorerai"
-    replace: "lavorerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "alvoreranno"
+  - triggers:
+    - "alvoreranno"
+    - "laoreranno"
+    - "laovreranno"
+    - "lavoeranno"
+    - "lavoerranno"
+    - "lavoreanno"
+    - "lavorearnno"
+    - "lavorerano"
+    - "lavoreranon"
+    - "lavorernano"
+    - "lavorernno"
+    - "lavorranno"
+    - "lavorreanno"
+    - "lavreranno"
+    - "lavroeranno"
+    - "lvaoreranno"
+    - "lvoreranno"
     replace: "lavoreranno"
     propagate_case: true
     word: true
 
-  - trigger: "laoreranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "laovreranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoeranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoerranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreanno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorearnno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorerano"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreranon"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorernano"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorernno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorreanno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavreranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavroeranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvaoreranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvoreranno"
-    replace: "lavoreranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "alvoreremo"
+  - triggers:
+    - "alvoreremo"
+    - "laoreremo"
+    - "laovreremo"
+    - "lavoeremo"
+    - "lavoerremo"
+    - "lavoreemo"
+    - "lavoreermo"
+    - "lavorereo"
+    - "lavorereom"
+    - "lavorermeo"
+    - "lavorermo"
+    - "lavorreemo"
+    - "lavorremo"
+    - "lavreremo"
+    - "lavroeremo"
+    - "lvaoreremo"
+    - "lvoreremo"
     replace: "lavoreremo"
     propagate_case: true
     word: true
 
-  - trigger: "laoreremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "laovreremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoeremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoerremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreemo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoreermo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorereo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorereom"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorermeo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorermo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorreemo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavreremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavroeremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvaoreremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvoreremo"
-    replace: "lavoreremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "alvorerà"
+  - triggers:
+    - "alvorerà"
+    - "laorerà"
+    - "laovrerà"
+    - "lavoerrà"
+    - "lavoerà"
+    - "lavorera"
+    - "lavorera'"
+    - "lavorera1"
+    - "lavoreà"
+    - "lavoreàr"
+    - "lavorreà"
+    - "lavorrà"
+    - "lavrerà"
+    - "lavroerà"
+    - "lvaorerà"
+    - "lvorerà"
     replace: "lavorerà"
     word: true
 
-  - trigger: "laorerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "laovrerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavoerrà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavoerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavorera"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavorera'"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavorera1"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavoreà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavoreàr"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavorreà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavorrà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavrerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lavroerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lvaorerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "lvorerà"
-    replace: "lavorerà"
-    word: true
-
-  - trigger: "alvorerò"
+  - triggers:
+    - "alvorerò"
+    - "laorerò"
+    - "laovrerò"
+    - "lavoerrò"
+    - "lavoerò"
+    - "lavorero"
+    - "lavorero'"
+    - "lavorero1"
+    - "lavoreò"
+    - "lavoreòr"
+    - "lavorreò"
+    - "lavorrò"
+    - "lavrerò"
+    - "lavroerò"
+    - "lvaorerò"
+    - "lvorerò"
     replace: "lavorerò"
     word: true
 
-  - trigger: "laorerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "laovrerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavoerrò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavoerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavorero"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavorero'"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavorero1"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavoreò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavoreòr"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavorreò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavorrò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavrerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lavroerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lvaorerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "lvorerò"
-    replace: "lavorerò"
-    word: true
-
-  - trigger: "elggerai"
+  - triggers:
+    - "elggerai"
+    - "legegrai"
+    - "legerai"
+    - "leggeai"
+    - "leggeari"
+    - "leggeri"
+    - "leggeria"
+    - "leggrai"
+    - "leggreai"
+    - "lgegerai"
+    - "lggerai"
     replace: "leggerai"
     propagate_case: true
     word: true
 
-  - trigger: "legegrai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "legerai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeari"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeri"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeria"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggrai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggreai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lgegerai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "lggerai"
-    replace: "leggerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "elggeranno"
+  - triggers:
+    - "elggeranno"
+    - "legegranno"
+    - "legeranno"
+    - "leggeanno"
+    - "leggearnno"
+    - "leggerano"
+    - "leggeranon"
+    - "leggernano"
+    - "leggernno"
+    - "leggranno"
+    - "leggreanno"
+    - "lgegeranno"
+    - "lggeranno"
     replace: "leggeranno"
     propagate_case: true
     word: true
 
-  - trigger: "legegranno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "legeranno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeanno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggearnno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggerano"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeranon"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggernano"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggernno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggranno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggreanno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lgegeranno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lggeranno"
-    replace: "leggeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "elggeremo"
+  - triggers:
+    - "elggeremo"
+    - "legegremo"
+    - "legeremo"
+    - "leggeemo"
+    - "leggeermo"
+    - "leggereo"
+    - "leggereom"
+    - "leggermeo"
+    - "leggermo"
+    - "leggreemo"
+    - "leggremo"
+    - "lgegeremo"
+    - "lggeremo"
     replace: "leggeremo"
     propagate_case: true
     word: true
 
-  - trigger: "legegremo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "legeremo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeemo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeermo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggereo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggereom"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggermeo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggermo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggreemo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggremo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lgegeremo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lggeremo"
-    replace: "leggeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "elggerà"
+  - triggers:
+    - "elggerà"
+    - "legegrà"
+    - "legerà"
+    - "leggera"
+    - "leggera'"
+    - "leggera1"
+    - "leggeà"
+    - "leggeàr"
+    - "leggreà"
+    - "leggrà"
+    - "lgegerà"
+    - "lggerà"
     replace: "leggerà"
     word: true
 
-  - trigger: "legegrà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "legerà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggera"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggera'"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggera1"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggeà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggeàr"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggreà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "leggrà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "lgegerà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "lggerà"
-    replace: "leggerà"
-    word: true
-
-  - trigger: "elggerò"
+  - triggers:
+    - "elggerò"
+    - "legegrò"
+    - "legerò"
+    - "leggero"
+    - "leggero'"
+    - "leggero1"
+    - "leggeò"
+    - "leggeòr"
+    - "leggreò"
+    - "leggrò"
+    - "lgegerò"
+    - "lggerò"
     replace: "leggerò"
     word: true
 
-  - trigger: "legegrò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "legerò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggero"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggero'"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggero1"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggeò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggeòr"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggreò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "leggrò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "lgegerò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "lggerò"
-    replace: "leggerò"
-    word: true
-
-  - trigger: "ilbertà"
+  - triggers:
+    - "ilbertà"
+    - "lbertà"
+    - "lbiertà"
+    - "liberta"
+    - "liberta'"
+    - "liberta1"
+    - "liberà"
+    - "liberàt"
+    - "libetrà"
+    - "libetà"
+    - "libretà"
+    - "librtà"
+    - "liebrtà"
+    - "liertà"
     replace: "libertà"
     word: true
 
-  - trigger: "lbertà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "lbiertà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liberta"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liberta'"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liberta1"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liberà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liberàt"
-    replace: "libertà"
-    word: true
-
-  - trigger: "libetrà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "libetà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "libretà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "librtà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liebrtà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "liertà"
-    replace: "libertà"
-    word: true
-
-  - trigger: "lnedì"
+  - triggers:
+    - "lnedì"
+    - "lnuedì"
+    - "luedì"
+    - "luendì"
+    - "lundeì"
+    - "lundì"
+    - "lunedi"
+    - "lunedi'"
+    - "lunedi1"
+    - "luneì"
+    - "luneìd"
+    - "ulnedì"
     replace: "lunedì"
     word: true
 
-  - trigger: "lnuedì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "luedì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "luendì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "lundeì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "lundì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "lunedi"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "lunedi'"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "lunedi1"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "luneì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "luneìd"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "ulnedì"
-    replace: "lunedì"
-    word: true
-
-  - trigger: "amnderai"
+  - triggers:
+    - "amnderai"
+    - "maderai"
+    - "madnerai"
+    - "mandeai"
+    - "mandeari"
+    - "manderi"
+    - "manderia"
+    - "mandrai"
+    - "mandreai"
+    - "manedrai"
+    - "manerai"
+    - "mnaderai"
+    - "mnderai"
     replace: "manderai"
     propagate_case: true
     word: true
 
-  - trigger: "maderai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "madnerai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandeai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandeari"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "manderi"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "manderia"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandrai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandreai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "manedrai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "manerai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnaderai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnderai"
-    replace: "manderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "amnderanno"
+  - triggers:
+    - "amnderanno"
+    - "maderanno"
+    - "madneranno"
+    - "mandeanno"
+    - "mandearnno"
+    - "manderano"
+    - "manderanon"
+    - "mandernano"
+    - "mandernno"
+    - "mandranno"
+    - "mandreanno"
+    - "manedranno"
+    - "maneranno"
+    - "mnaderanno"
+    - "mnderanno"
     replace: "manderanno"
     propagate_case: true
     word: true
 
-  - trigger: "maderanno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "madneranno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandeanno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandearnno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "manderano"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "manderanon"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandernano"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandernno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandranno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandreanno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "manedranno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "maneranno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnaderanno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnderanno"
-    replace: "manderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "amnderemo"
+  - triggers:
+    - "amnderemo"
+    - "maderemo"
+    - "madneremo"
+    - "mandeemo"
+    - "mandeermo"
+    - "mandereo"
+    - "mandereom"
+    - "mandermeo"
+    - "mandermo"
+    - "mandreemo"
+    - "mandremo"
+    - "manedremo"
+    - "maneremo"
+    - "mnaderemo"
+    - "mnderemo"
     replace: "manderemo"
     propagate_case: true
     word: true
 
-  - trigger: "maderemo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "madneremo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandeemo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandeermo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandereo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandereom"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandermeo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandermo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandreemo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mandremo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "manedremo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "maneremo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnaderemo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnderemo"
-    replace: "manderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "amnderà"
+  - triggers:
+    - "amnderà"
+    - "maderà"
+    - "madnerà"
+    - "mandera"
+    - "mandera'"
+    - "mandera1"
+    - "mandeà"
+    - "mandeàr"
+    - "mandreà"
+    - "mandrà"
+    - "manedrà"
+    - "manerà"
+    - "mnaderà"
+    - "mnderà"
     replace: "manderà"
     word: true
 
-  - trigger: "maderà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "madnerà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandera"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandera'"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandera1"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandeà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandeàr"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandreà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mandrà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "manedrà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "manerà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mnaderà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "mnderà"
-    replace: "manderà"
-    word: true
-
-  - trigger: "amnderò"
+  - triggers:
+    - "amnderò"
+    - "maderò"
+    - "madnerò"
+    - "mandero"
+    - "mandero'"
+    - "mandero1"
+    - "mandeò"
+    - "mandeòr"
+    - "mandreò"
+    - "mandrò"
+    - "manedrò"
+    - "manerò"
+    - "mnaderò"
+    - "mnderò"
     replace: "manderò"
     word: true
 
-  - trigger: "maderò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "madnerò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandero"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandero'"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandero1"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandeò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandeòr"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandreò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mandrò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "manedrò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "manerò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mnaderò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "mnderò"
-    replace: "manderò"
-    word: true
-
-  - trigger: "amngerai"
+  - triggers:
+    - "amngerai"
+    - "magerai"
+    - "magnerai"
+    - "manegrai"
+    - "mangeai"
+    - "mangeari"
+    - "mangeri"
+    - "mangeria"
+    - "mangrai"
+    - "mangreai"
+    - "mnagerai"
+    - "mngerai"
     replace: "mangerai"
     propagate_case: true
     word: true
 
-  - trigger: "magerai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "magnerai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "manegrai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeari"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeri"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeria"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangrai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangreai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnagerai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mngerai"
-    replace: "mangerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "amngeranno"
+  - triggers:
+    - "amngeranno"
+    - "mageranno"
+    - "magneranno"
+    - "manegranno"
+    - "mangeanno"
+    - "mangearnno"
+    - "mangerano"
+    - "mangeranon"
+    - "mangernano"
+    - "mangernno"
+    - "mangranno"
+    - "mangreanno"
+    - "mnageranno"
+    - "mngeranno"
     replace: "mangeranno"
     propagate_case: true
     word: true
 
-  - trigger: "mageranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "magneranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "manegranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeanno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangearnno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangerano"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeranon"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangernano"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangernno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangreanno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnageranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mngeranno"
-    replace: "mangeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "amngeremo"
+  - triggers:
+    - "amngeremo"
+    - "mageremo"
+    - "magneremo"
+    - "manegremo"
+    - "mangeemo"
+    - "mangeermo"
+    - "mangereo"
+    - "mangereom"
+    - "mangermeo"
+    - "mangermo"
+    - "mangreemo"
+    - "mangremo"
+    - "mnageremo"
+    - "mngeremo"
     replace: "mangeremo"
     propagate_case: true
     word: true
 
-  - trigger: "mageremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "magneremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "manegremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeemo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangeermo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangereo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangereom"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangermeo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangermo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangreemo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnageremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mngeremo"
-    replace: "mangeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "amngerà"
+  - triggers:
+    - "amngerà"
+    - "magerà"
+    - "magnerà"
+    - "manegrà"
+    - "mangera"
+    - "mangera'"
+    - "mangera1"
+    - "mangeà"
+    - "mangeàr"
+    - "mangreà"
+    - "mangrà"
+    - "mnagerà"
+    - "mngerà"
     replace: "mangerà"
     word: true
 
-  - trigger: "magerà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "magnerà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "manegrà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangera"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangera'"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangera1"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangeà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangeàr"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangreà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mangrà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mnagerà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "mngerà"
-    replace: "mangerà"
-    word: true
-
-  - trigger: "amngerò"
+  - triggers:
+    - "amngerò"
+    - "magerò"
+    - "magnerò"
+    - "manegrò"
+    - "mangero"
+    - "mangero'"
+    - "mangero1"
+    - "mangeò"
+    - "mangeòr"
+    - "mangreò"
+    - "mangrò"
+    - "mnagerò"
+    - "mngerò"
     replace: "mangerò"
     word: true
 
-  - trigger: "magerò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "magnerò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "manegrò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangero"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangero'"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangero1"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangeò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangeòr"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangreò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mangrò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mnagerò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "mngerò"
-    replace: "mangerò"
-    word: true
-
-  - trigger: "amrtedì"
+  - triggers:
+    - "amrtedì"
+    - "maredì"
+    - "maretdì"
+    - "martdeì"
+    - "martdì"
+    - "martedi"
+    - "martedi'"
+    - "martedi1"
+    - "marteì"
+    - "marteìd"
+    - "matedì"
+    - "matredì"
+    - "mratedì"
+    - "mrtedì"
     replace: "martedì"
     word: true
 
-  - trigger: "maredì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "maretdì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "martdeì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "martdì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "martedi"
-    replace: "martedì"
-    word: true
-
-  - trigger: "martedi'"
-    replace: "martedì"
-    word: true
-
-  - trigger: "martedi1"
-    replace: "martedì"
-    word: true
-
-  - trigger: "marteì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "marteìd"
-    replace: "martedì"
-    word: true
-
-  - trigger: "matedì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "matredì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "mratedì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "mrtedì"
-    replace: "martedì"
-    word: true
-
-  - trigger: "emrcoledì"
+  - triggers:
+    - "emrcoledì"
+    - "mecoledì"
+    - "mecroledì"
+    - "mercledì"
+    - "mercloedì"
+    - "mercoedì"
+    - "mercoeldì"
+    - "mercoldeì"
+    - "mercoldì"
+    - "mercoledi"
+    - "mercoledi'"
+    - "mercoledi1"
+    - "mercoleì"
+    - "mercoleìd"
+    - "merocledì"
+    - "meroledì"
+    - "mrcoledì"
+    - "mrecoledì"
     replace: "mercoledì"
     word: true
 
-  - trigger: "mecoledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mecroledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercloedì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoedì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoeldì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoldeì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoldì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoledi"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoledi'"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoledi1"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoleì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mercoleìd"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "merocledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "meroledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mrcoledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "mrecoledì"
-    replace: "mercoledì"
-    word: true
-
-  - trigger: "emtterai"
+  - triggers:
+    - "emtterai"
+    - "meterai"
+    - "metetrai"
+    - "metteai"
+    - "metteari"
+    - "metteri"
+    - "metteria"
+    - "mettrai"
+    - "mettreai"
+    - "mteterai"
+    - "mtterai"
     replace: "metterai"
     propagate_case: true
     word: true
 
-  - trigger: "meterai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "metetrai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteari"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteri"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteria"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettrai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettreai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mteterai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtterai"
-    replace: "metterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "emtteranno"
+  - triggers:
+    - "emtteranno"
+    - "meteranno"
+    - "metetranno"
+    - "metteanno"
+    - "mettearnno"
+    - "metterano"
+    - "metteranon"
+    - "metternano"
+    - "metternno"
+    - "mettranno"
+    - "mettreanno"
+    - "mteteranno"
+    - "mtteranno"
     replace: "metteranno"
     propagate_case: true
     word: true
 
-  - trigger: "meteranno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metetranno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteanno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettearnno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metterano"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteranon"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metternano"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "metternno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettranno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettreanno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mteteranno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtteranno"
-    replace: "metteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "emtteremo"
+  - triggers:
+    - "emtteremo"
+    - "meteremo"
+    - "metetremo"
+    - "metteemo"
+    - "metteermo"
+    - "mettereo"
+    - "mettereom"
+    - "mettermeo"
+    - "mettermo"
+    - "mettreemo"
+    - "mettremo"
+    - "mteteremo"
+    - "mtteremo"
     replace: "metteremo"
     propagate_case: true
     word: true
 
-  - trigger: "meteremo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "metetremo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteemo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteermo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettereo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettereom"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettermeo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettermo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettreemo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettremo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mteteremo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtteremo"
-    replace: "metteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "emtterà"
+  - triggers:
+    - "emtterà"
+    - "meterà"
+    - "metetrà"
+    - "mettera"
+    - "mettera'"
+    - "mettera1"
+    - "metteà"
+    - "metteàr"
+    - "mettreà"
+    - "mettrà"
+    - "mteterà"
+    - "mtterà"
     replace: "metterà"
     word: true
 
-  - trigger: "meterà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "metetrà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mettera"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mettera'"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mettera1"
-    replace: "metterà"
-    word: true
-
-  - trigger: "metteà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "metteàr"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mettreà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mettrà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mteterà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "mtterà"
-    replace: "metterà"
-    word: true
-
-  - trigger: "emtterò"
+  - triggers:
+    - "emtterò"
+    - "meterò"
+    - "metetrò"
+    - "mettero"
+    - "mettero'"
+    - "mettero1"
+    - "metteò"
+    - "metteòr"
+    - "mettreò"
+    - "mettrò"
+    - "mteterò"
+    - "mtterò"
     replace: "metterò"
     word: true
 
-  - trigger: "meterò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "metetrò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mettero"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mettero'"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mettero1"
-    replace: "metterò"
-    word: true
-
-  - trigger: "metteò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "metteòr"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mettreò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mettrò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mteterò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "mtterò"
-    replace: "metterò"
-    word: true
-
-  - trigger: "encessità"
+  - triggers:
+    - "encessità"
+    - "nceessità"
+    - "ncessità"
+    - "necesistà"
+    - "necesità"
+    - "necessita'"
+    - "necessita1"
+    - "necessià"
+    - "necessiàt"
+    - "necesstià"
+    - "necesstà"
+    - "necsesità"
+    - "necssità"
+    - "neecssità"
+    - "neessità"
     replace: "necessità"
     word: true
 
-  - trigger: "nceessità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "ncessità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necesistà"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necesità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necessita'"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necessita1"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necessià"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necessiàt"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necesstià"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necesstà"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necsesità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "necssità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "neecssità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "neessità"
-    replace: "necessità"
-    word: true
-
-  - trigger: "oganizzerai"
+  - triggers:
+    - "oganizzerai"
+    - "ogranizzerai"
+    - "oragnizzerai"
+    - "oranizzerai"
+    - "orgainzzerai"
+    - "orgaizzerai"
+    - "organizerai"
+    - "organizezrai"
+    - "organizzeai"
+    - "organizzeari"
+    - "organizzeri"
+    - "organizzeria"
+    - "organizzrai"
+    - "organizzreai"
+    - "organzizerai"
+    - "organzzerai"
+    - "orgnaizzerai"
+    - "orgnizzerai"
+    - "roganizzerai"
     replace: "organizzerai"
     propagate_case: true
     word: true
 
-  - trigger: "ogranizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "oragnizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "oranizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgainzzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgaizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizezrai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeari"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeri"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeria"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzrai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzreai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzizerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnaizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "roganizzerai"
-    replace: "organizzerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "oganizzeranno"
+  - triggers:
+    - "oganizzeranno"
+    - "ogranizzeranno"
+    - "oragnizzeranno"
+    - "oranizzeranno"
+    - "orgainzzeranno"
+    - "orgaizzeranno"
+    - "organizeranno"
+    - "organizezranno"
+    - "organizzeanno"
+    - "organizzearnno"
+    - "organizzerano"
+    - "organizzeranon"
+    - "organizzernano"
+    - "organizzernno"
+    - "organizzranno"
+    - "organizzreanno"
+    - "organzizeranno"
+    - "organzzeranno"
+    - "orgnaizzeranno"
+    - "orgnizzeranno"
+    - "roganizzeranno"
     replace: "organizzeranno"
     propagate_case: true
     word: true
 
-  - trigger: "ogranizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oragnizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oranizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgainzzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgaizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizezranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeanno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzearnno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzerano"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeranon"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzernano"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzernno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzreanno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzizeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnaizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "roganizzeranno"
-    replace: "organizzeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oganizzeremo"
+  - triggers:
+    - "oganizzeremo"
+    - "ogranizzeremo"
+    - "oragnizzeremo"
+    - "oranizzeremo"
+    - "orgainzzeremo"
+    - "orgaizzeremo"
+    - "organizeremo"
+    - "organizezremo"
+    - "organizzeemo"
+    - "organizzeermo"
+    - "organizzereo"
+    - "organizzereom"
+    - "organizzermeo"
+    - "organizzermo"
+    - "organizzreemo"
+    - "organizzremo"
+    - "organzizeremo"
+    - "organzzeremo"
+    - "orgnaizzeremo"
+    - "orgnizzeremo"
+    - "roganizzeremo"
     replace: "organizzeremo"
     propagate_case: true
     word: true
 
-  - trigger: "ogranizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "oragnizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "oranizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgainzzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgaizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizezremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeemo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzeermo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzereo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzereom"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzermeo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzermo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzreemo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzizeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnaizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "roganizzeremo"
-    replace: "organizzeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "oganizzerà"
+  - triggers:
+    - "oganizzerà"
+    - "ogranizzerà"
+    - "oragnizzerà"
+    - "oranizzerà"
+    - "orgainzzerà"
+    - "orgaizzerà"
+    - "organizerà"
+    - "organizezrà"
+    - "organizzera"
+    - "organizzera'"
+    - "organizzera1"
+    - "organizzeà"
+    - "organizzeàr"
+    - "organizzreà"
+    - "organizzrà"
+    - "organzizerà"
+    - "organzzerà"
+    - "orgnaizzerà"
+    - "orgnizzerà"
+    - "roganizzerà"
     replace: "organizzerà"
     word: true
 
-  - trigger: "ogranizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "oragnizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "oranizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "orgainzzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "orgaizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizezrà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzera"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzera'"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzera1"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzeà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzeàr"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzreà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organizzrà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organzizerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "organzzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "orgnaizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "orgnizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "roganizzerà"
-    replace: "organizzerà"
-    word: true
-
-  - trigger: "oganizzerò"
+  - triggers:
+    - "oganizzerò"
+    - "ogranizzerò"
+    - "oragnizzerò"
+    - "oranizzerò"
+    - "orgainzzerò"
+    - "orgaizzerò"
+    - "organizerò"
+    - "organizezrò"
+    - "organizzero"
+    - "organizzero'"
+    - "organizzero1"
+    - "organizzeò"
+    - "organizzeòr"
+    - "organizzreò"
+    - "organizzrò"
+    - "organzizerò"
+    - "organzzerò"
+    - "orgnaizzerò"
+    - "orgnizzerò"
+    - "roganizzerò"
     replace: "organizzerò"
     word: true
 
-  - trigger: "ogranizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "oragnizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "oranizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "orgainzzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "orgaizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizezrò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzero"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzero'"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzero1"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzeò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzeòr"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzreò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organizzrò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organzizerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "organzzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "orgnaizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "orgnizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "roganizzerò"
-    replace: "organizzerò"
-    word: true
-
-  - trigger: "aprlerai"
+  - triggers:
+    - "aprlerai"
+    - "palerai"
+    - "palrerai"
+    - "parelrai"
+    - "parerai"
+    - "parleai"
+    - "parleari"
+    - "parleri"
+    - "parleria"
+    - "parlrai"
+    - "parlreai"
+    - "pralerai"
+    - "prlerai"
     replace: "parlerai"
     propagate_case: true
     word: true
 
-  - trigger: "palerai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "palrerai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parelrai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parerai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleari"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleri"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleria"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlrai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlreai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pralerai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prlerai"
-    replace: "parlerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprleranno"
+  - triggers:
+    - "aprleranno"
+    - "paleranno"
+    - "palreranno"
+    - "parelranno"
+    - "pareranno"
+    - "parleanno"
+    - "parlearnno"
+    - "parlerano"
+    - "parleranon"
+    - "parlernano"
+    - "parlernno"
+    - "parlranno"
+    - "parlreanno"
+    - "praleranno"
+    - "prleranno"
     replace: "parleranno"
     propagate_case: true
     word: true
 
-  - trigger: "paleranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "palreranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parelranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pareranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleanno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlearnno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlerano"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleranon"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlernano"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlernno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlreanno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "praleranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prleranno"
-    replace: "parleranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprleremo"
+  - triggers:
+    - "aprleremo"
+    - "paleremo"
+    - "palreremo"
+    - "parelremo"
+    - "pareremo"
+    - "parleemo"
+    - "parleermo"
+    - "parlereo"
+    - "parlereom"
+    - "parlermeo"
+    - "parlermo"
+    - "parlreemo"
+    - "parlremo"
+    - "praleremo"
+    - "prleremo"
     replace: "parleremo"
     propagate_case: true
     word: true
 
-  - trigger: "paleremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "palreremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parelremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pareremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleemo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parleermo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlereo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlereom"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlermeo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlermo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlreemo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "praleremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prleremo"
-    replace: "parleremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprlerà"
+  - triggers:
+    - "aprlerà"
+    - "palerà"
+    - "palrerà"
+    - "parelrà"
+    - "parerà"
+    - "parlera"
+    - "parlera'"
+    - "parlera1"
+    - "parleà"
+    - "parleàr"
+    - "parlreà"
+    - "parlrà"
+    - "pralerà"
+    - "prlerà"
     replace: "parlerà"
     word: true
 
-  - trigger: "palerà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "palrerà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parelrà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parerà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parlera"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parlera'"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parlera1"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parleà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parleàr"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parlreà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "parlrà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "pralerà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "prlerà"
-    replace: "parlerà"
-    word: true
-
-  - trigger: "aprlerò"
+  - triggers:
+    - "aprlerò"
+    - "palerò"
+    - "palrerò"
+    - "parelrò"
+    - "parerò"
+    - "parlero"
+    - "parlero'"
+    - "parlero1"
+    - "parleò"
+    - "parleòr"
+    - "parlreò"
+    - "parlrò"
+    - "pralerò"
+    - "prlerò"
     replace: "parlerò"
     word: true
 
-  - trigger: "palerò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "palrerò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parelrò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parerò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parlero"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parlero'"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parlero1"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parleò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parleòr"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parlreò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "parlrò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "pralerò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "prlerò"
-    replace: "parlerò"
-    word: true
-
-  - trigger: "apsserai"
+  - triggers:
+    - "apsserai"
+    - "paserai"
+    - "pasesrai"
+    - "passeai"
+    - "passeari"
+    - "passeri"
+    - "passeria"
+    - "passrai"
+    - "passreai"
+    - "psaserai"
+    - "psserai"
     replace: "passerai"
     propagate_case: true
     word: true
 
-  - trigger: "paserai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pasesrai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeari"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeri"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeria"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passrai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "passreai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "psaserai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "psserai"
-    replace: "passerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "apsseranno"
+  - triggers:
+    - "apsseranno"
+    - "paseranno"
+    - "pasesranno"
+    - "passeanno"
+    - "passearnno"
+    - "passerano"
+    - "passeranon"
+    - "passernano"
+    - "passernno"
+    - "passranno"
+    - "passreanno"
+    - "psaseranno"
+    - "psseranno"
     replace: "passeranno"
     propagate_case: true
     word: true
 
-  - trigger: "paseranno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pasesranno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeanno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passearnno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passerano"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeranon"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passernano"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passernno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passranno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "passreanno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "psaseranno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "psseranno"
-    replace: "passeranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "apsseremo"
+  - triggers:
+    - "apsseremo"
+    - "paseremo"
+    - "pasesremo"
+    - "passeemo"
+    - "passeermo"
+    - "passereo"
+    - "passereom"
+    - "passermeo"
+    - "passermo"
+    - "passreemo"
+    - "passremo"
+    - "psaseremo"
+    - "psseremo"
     replace: "passeremo"
     propagate_case: true
     word: true
 
-  - trigger: "paseremo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pasesremo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeemo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passeermo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passereo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passereom"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passermeo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passermo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passreemo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "passremo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psaseremo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psseremo"
-    replace: "passeremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "apsserà"
+  - triggers:
+    - "apsserà"
+    - "paserà"
+    - "pasesrà"
+    - "passera"
+    - "passera'"
+    - "passera1"
+    - "passeà"
+    - "passeàr"
+    - "passreà"
+    - "passrà"
+    - "psaserà"
+    - "psserà"
     replace: "passerà"
     word: true
 
-  - trigger: "paserà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "pasesrà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passera"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passera'"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passera1"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passeà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passeàr"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passreà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "passrà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "psaserà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "psserà"
-    replace: "passerà"
-    word: true
-
-  - trigger: "apsserò"
+  - triggers:
+    - "apsserò"
+    - "paserò"
+    - "pasesrò"
+    - "passero"
+    - "passero'"
+    - "passero1"
+    - "passeò"
+    - "passeòr"
+    - "passreò"
+    - "passrò"
+    - "psaserò"
+    - "psserò"
     replace: "passerò"
     word: true
 
-  - trigger: "paserò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "pasesrò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passero"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passero'"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passero1"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passeò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passeòr"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passreò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "passrò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "psaserò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "psserò"
-    replace: "passerò"
-    word: true
-
-  - trigger: "eprché"
+  - triggers:
+    - "eprché"
+    - "peché"
+    - "pecrhé"
+    - "perche"
+    - "perche'"
+    - "perche1"
+    - "percé"
+    - "percéh"
+    - "perhcé"
+    - "perhé"
+    - "prché"
+    - "preché"
     replace: "perché"
     word: true
 
-  - trigger: "peché"
-    replace: "perché"
-    word: true
-
-  - trigger: "pecrhé"
-    replace: "perché"
-    word: true
-
-  - trigger: "perche"
-    replace: "perché"
-    word: true
-
-  - trigger: "perche'"
-    replace: "perché"
-    word: true
-
-  - trigger: "perche1"
-    replace: "perché"
-    word: true
-
-  - trigger: "percé"
-    replace: "perché"
-    word: true
-
-  - trigger: "percéh"
-    replace: "perché"
-    word: true
-
-  - trigger: "perhcé"
-    replace: "perché"
-    word: true
-
-  - trigger: "perhé"
-    replace: "perché"
-    word: true
-
-  - trigger: "prché"
-    replace: "perché"
-    word: true
-
-  - trigger: "preché"
-    replace: "perché"
-    word: true
-
-  - trigger: "eprciò"
+  - triggers:
+    - "eprciò"
+    - "peciò"
+    - "pecriò"
+    - "percio"
+    - "percio'"
+    - "percio1"
+    - "percò"
+    - "percòi"
+    - "pericò"
+    - "periò"
+    - "prciò"
+    - "preciò"
     replace: "perciò"
     word: true
 
-  - trigger: "peciò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "pecriò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "percio"
-    replace: "perciò"
-    word: true
-
-  - trigger: "percio'"
-    replace: "perciò"
-    word: true
-
-  - trigger: "percio1"
-    replace: "perciò"
-    word: true
-
-  - trigger: "percò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "percòi"
-    replace: "perciò"
-    word: true
-
-  - trigger: "pericò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "periò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "prciò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "preciò"
-    replace: "perciò"
-    word: true
-
-  - trigger: "eprò"
+  - triggers:
+    - "eprò"
+    - "pero"
+    - "pero'"
+    - "pero1"
+    - "peòr"
+    - "preò"
     replace: "però"
     word: true
 
-  - trigger: "pero"
-    replace: "però"
-    word: true
-
-  - trigger: "pero'"
-    replace: "però"
-    word: true
-
-  - trigger: "pero1"
-    replace: "però"
-    word: true
-
-  - trigger: "peòr"
-    replace: "però"
-    word: true
-
-  - trigger: "preò"
-    replace: "però"
-    word: true
-
-  - trigger: "ipaceranno"
+  - triggers:
+    - "ipaceranno"
+    - "paceranno"
+    - "paiceranno"
+    - "piaceanno"
+    - "piacearnno"
+    - "piacerano"
+    - "piaceranon"
+    - "piacernano"
+    - "piacernno"
+    - "piacranno"
+    - "piacreanno"
+    - "piaecranno"
+    - "piaeranno"
+    - "picaeranno"
+    - "piceranno"
     replace: "piaceranno"
     propagate_case: true
     word: true
 
-  - trigger: "paceranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "paiceranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piaceanno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacearnno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacerano"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piaceranon"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacernano"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacernno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piacreanno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piaecranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piaeranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "picaeranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "piceranno"
-    replace: "piaceranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipacerà"
+  - triggers:
+    - "ipacerà"
+    - "pacerà"
+    - "paicerà"
+    - "piacera"
+    - "piacera'"
+    - "piacera1"
+    - "piaceà"
+    - "piaceàr"
+    - "piacreà"
+    - "piacrà"
+    - "piaecrà"
+    - "piaerà"
+    - "picaerà"
+    - "picerà"
     replace: "piacerà"
     word: true
 
-  - trigger: "pacerà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "paicerà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piacera"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piacera'"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piacera1"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piaceà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piaceàr"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piacreà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piacrà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piaecrà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "piaerà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "picaerà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "picerà"
-    replace: "piacerà"
-    word: true
-
-  - trigger: "ipacerò"
+  - triggers:
+    - "ipacerò"
+    - "pacerò"
+    - "paicerò"
+    - "piacero"
+    - "piacero'"
+    - "piacero1"
+    - "piaceò"
+    - "piaceòr"
+    - "piacreò"
+    - "piacrò"
+    - "piaecrò"
+    - "piaerò"
+    - "picaerò"
+    - "picerò"
     replace: "piacerò"
     word: true
 
-  - trigger: "pacerò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "paicerò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piacero"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piacero'"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piacero1"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piaceò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piaceòr"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piacreò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piacrò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piaecrò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "piaerò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "picaerò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "picerò"
-    replace: "piacerò"
-    word: true
-
-  - trigger: "ipù"
+  - triggers:
+    - "ipù"
+    - "piu"
+    - "piu'"
+    - "piu1"
+    - "pùi"
     replace: "più"
     word: true
 
-  - trigger: "piu"
-    replace: "più"
-    word: true
-
-  - trigger: "piu'"
-    replace: "più"
-    word: true
-
-  - trigger: "piu1"
-    replace: "più"
-    word: true
-
-  - trigger: "pùi"
-    replace: "più"
-    word: true
-
-  - trigger: "opiché"
+  - triggers:
+    - "opiché"
+    - "piché"
+    - "pioché"
+    - "poché"
+    - "pocihé"
+    - "poiche"
+    - "poiche'"
+    - "poiche1"
+    - "poicé"
+    - "poicéh"
+    - "poihcé"
+    - "poihé"
     replace: "poiché"
     word: true
 
-  - trigger: "piché"
-    replace: "poiché"
-    word: true
-
-  - trigger: "pioché"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poché"
-    replace: "poiché"
-    word: true
-
-  - trigger: "pocihé"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poiche"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poiche'"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poiche1"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poicé"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poicéh"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poihcé"
-    replace: "poiché"
-    word: true
-
-  - trigger: "poihé"
-    replace: "poiché"
-    word: true
-
-  - trigger: "opssibilità"
+  - triggers:
+    - "opssibilità"
+    - "posibilità"
+    - "posisbilità"
+    - "possbiilità"
+    - "possbilità"
+    - "possibiiltà"
+    - "possibiità"
+    - "possibilita"
+    - "possibilita'"
+    - "possibilita1"
+    - "possibilià"
+    - "possibiliàt"
+    - "possibiltià"
+    - "possibiltà"
+    - "possibliità"
+    - "possiblità"
+    - "possiiblità"
+    - "possiilità"
+    - "psosibilità"
+    - "pssibilità"
     replace: "possibilità"
     word: true
 
-  - trigger: "posibilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "posisbilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possbiilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possbilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibiiltà"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibiità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibilita"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibilita'"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibilita1"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibilià"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibiliàt"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibiltià"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibiltà"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possibliità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possiblità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possiiblità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "possiilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "psosibilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "pssibilità"
-    replace: "possibilità"
-    word: true
-
-  - trigger: "optrai"
+  - triggers:
+    - "optrai"
+    - "porai"
+    - "portai"
+    - "potai"
+    - "potari"
+    - "potri"
+    - "potria"
+    - "ptorai"
+    - "ptrai"
     replace: "potrai"
     propagate_case: true
     word: true
 
-  - trigger: "porai"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "portai"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "potai"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "potari"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "potri"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "potria"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptorai"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptrai"
-    replace: "potrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "optranno"
+  - triggers:
+    - "optranno"
+    - "poranno"
+    - "portanno"
+    - "potanno"
+    - "potarnno"
+    - "potrano"
+    - "potranon"
+    - "potrnano"
+    - "potrnno"
+    - "ptoranno"
+    - "ptranno"
     replace: "potranno"
     propagate_case: true
     word: true
 
-  - trigger: "poranno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "portanno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potanno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potarnno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrano"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potranon"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrnano"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrnno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptoranno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptranno"
-    replace: "potranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "optremo"
+  - triggers:
+    - "optremo"
+    - "poremo"
+    - "portemo"
+    - "potemo"
+    - "potermo"
+    - "potreo"
+    - "potreom"
+    - "potrmeo"
+    - "potrmo"
+    - "ptoremo"
+    - "ptremo"
     replace: "potremo"
     propagate_case: true
     word: true
 
-  - trigger: "poremo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "portemo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potemo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potermo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potreo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potreom"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrmeo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrmo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptoremo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptremo"
-    replace: "potremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "optrà"
+  - triggers:
+    - "optrà"
+    - "portà"
+    - "porà"
+    - "potra"
+    - "potra'"
+    - "potra1"
+    - "potà"
+    - "potàr"
+    - "ptorà"
+    - "ptrà"
     replace: "potrà"
     word: true
 
-  - trigger: "portà"
-    replace: "potrà"
-    word: true
-
-  - trigger: "porà"
-    replace: "potrà"
-    word: true
-
-  - trigger: "potra"
-    replace: "potrà"
-    word: true
-
-  - trigger: "potra'"
-    replace: "potrà"
-    word: true
-
-  - trigger: "potra1"
-    replace: "potrà"
-    word: true
-
-  - trigger: "potà"
-    replace: "potrà"
-    word: true
-
-  - trigger: "potàr"
-    replace: "potrà"
-    word: true
-
-  - trigger: "ptorà"
-    replace: "potrà"
-    word: true
-
-  - trigger: "ptrà"
-    replace: "potrà"
-    word: true
-
-  - trigger: "optrò"
+  - triggers:
+    - "optrò"
+    - "portò"
+    - "porò"
+    - "potro"
+    - "potro'"
+    - "potro1"
+    - "potò"
+    - "potòr"
+    - "ptorò"
+    - "ptrò"
     replace: "potrò"
     word: true
 
-  - trigger: "portò"
-    replace: "potrò"
-    word: true
-
-  - trigger: "porò"
-    replace: "potrò"
-    word: true
-
-  - trigger: "potro"
-    replace: "potrò"
-    word: true
-
-  - trigger: "potro'"
-    replace: "potrò"
-    word: true
-
-  - trigger: "potro1"
-    replace: "potrò"
-    word: true
-
-  - trigger: "potò"
-    replace: "potrò"
-    word: true
-
-  - trigger: "potòr"
-    replace: "potrò"
-    word: true
-
-  - trigger: "ptorò"
-    replace: "potrò"
-    word: true
-
-  - trigger: "ptrò"
-    replace: "potrò"
-    word: true
-
-  - trigger: "penderai"
+  - triggers:
+    - "penderai"
+    - "pernderai"
+    - "prederai"
+    - "prednerai"
+    - "prendeai"
+    - "prendeari"
+    - "prenderi"
+    - "prenderia"
+    - "prendrai"
+    - "prendreai"
+    - "prenedrai"
+    - "prenerai"
+    - "prnderai"
+    - "prnederai"
+    - "rpenderai"
     replace: "prenderai"
     propagate_case: true
     word: true
 
-  - trigger: "pernderai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prederai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prednerai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeari"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenderi"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenderia"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendrai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendreai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenedrai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenerai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnderai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnederai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpenderai"
-    replace: "prenderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "penderanno"
+  - triggers:
+    - "penderanno"
+    - "pernderanno"
+    - "prederanno"
+    - "predneranno"
+    - "prendeanno"
+    - "prendearnno"
+    - "prenderano"
+    - "prenderanon"
+    - "prendernano"
+    - "prendernno"
+    - "prendranno"
+    - "prendreanno"
+    - "prenedranno"
+    - "preneranno"
+    - "prnderanno"
+    - "prnederanno"
+    - "rpenderanno"
     replace: "prenderanno"
     propagate_case: true
     word: true
 
-  - trigger: "pernderanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prederanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "predneranno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendearnno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenderano"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenderanon"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendernano"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendernno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendranno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendreanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenedranno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preneranno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnderanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnederanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpenderanno"
-    replace: "prenderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "penderemo"
+  - triggers:
+    - "penderemo"
+    - "pernderemo"
+    - "prederemo"
+    - "predneremo"
+    - "prendeemo"
+    - "prendeermo"
+    - "prendereo"
+    - "prendereom"
+    - "prendermeo"
+    - "prendermo"
+    - "prendreemo"
+    - "prendremo"
+    - "prenedremo"
+    - "preneremo"
+    - "prnderemo"
+    - "prnederemo"
+    - "rpenderemo"
     replace: "prenderemo"
     propagate_case: true
     word: true
 
-  - trigger: "pernderemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prederemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "predneremo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeermo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendereo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendereom"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendermeo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendermo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendreemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendremo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenedremo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preneremo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnderemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnederemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpenderemo"
-    replace: "prenderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "penderà"
+  - triggers:
+    - "penderà"
+    - "pernderà"
+    - "prederà"
+    - "prednerà"
+    - "prendera"
+    - "prendera'"
+    - "prendera1"
+    - "prendeà"
+    - "prendeàr"
+    - "prendreà"
+    - "prendrà"
+    - "prenedrà"
+    - "prenerà"
+    - "prnderà"
+    - "prnederà"
+    - "rpenderà"
     replace: "prenderà"
     word: true
 
-  - trigger: "pernderà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prederà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prednerà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendera"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendera'"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendera1"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendeà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendeàr"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendreà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prendrà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prenedrà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prenerà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prnderà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "prnederà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "rpenderà"
-    replace: "prenderà"
-    word: true
-
-  - trigger: "penderò"
+  - triggers:
+    - "penderò"
+    - "pernderò"
+    - "prederò"
+    - "prednerò"
+    - "prendero"
+    - "prendero'"
+    - "prendero1"
+    - "prendeò"
+    - "prendeòr"
+    - "prendreò"
+    - "prendrò"
+    - "prenedrò"
+    - "prenerò"
+    - "prnderò"
+    - "prnederò"
+    - "rpenderò"
     replace: "prenderò"
     word: true
 
-  - trigger: "pernderò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prederò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prednerò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendero"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendero'"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendero1"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendeò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendeòr"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendreò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prendrò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prenedrò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prenerò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prnderò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "prnederò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "rpenderò"
-    replace: "prenderò"
-    word: true
-
-  - trigger: "peparerai"
+  - triggers:
+    - "peparerai"
+    - "perparerai"
+    - "preaprerai"
+    - "prearerai"
+    - "prepaerai"
+    - "prepaerrai"
+    - "prepareai"
+    - "prepareari"
+    - "prepareri"
+    - "prepareria"
+    - "preparrai"
+    - "preparreai"
+    - "prepraerai"
+    - "preprerai"
+    - "prparerai"
+    - "prpearerai"
+    - "rpeparerai"
     replace: "preparerai"
     propagate_case: true
     word: true
 
-  - trigger: "perparerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "preaprerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prearerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaerrai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareari"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareri"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareria"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparrai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparreai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepraerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "preprerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prparerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prpearerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpeparerai"
-    replace: "preparerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pepareranno"
+  - triggers:
+    - "pepareranno"
+    - "perpareranno"
+    - "preapreranno"
+    - "preareranno"
+    - "prepaeranno"
+    - "prepaerranno"
+    - "prepareanno"
+    - "preparearnno"
+    - "preparerano"
+    - "prepareranon"
+    - "preparernano"
+    - "preparernno"
+    - "preparranno"
+    - "preparreanno"
+    - "prepraeranno"
+    - "prepreranno"
+    - "prpareranno"
+    - "prpeareranno"
+    - "rpepareranno"
     replace: "prepareranno"
     propagate_case: true
     word: true
 
-  - trigger: "perpareranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preapreranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preareranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaeranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaerranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareanno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparearnno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparerano"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareranon"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparernano"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparernno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparreanno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepraeranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepreranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prpareranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prpeareranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpepareranno"
-    replace: "prepareranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pepareremo"
+  - triggers:
+    - "pepareremo"
+    - "perpareremo"
+    - "preapreremo"
+    - "preareremo"
+    - "prepaeremo"
+    - "prepaerremo"
+    - "prepareemo"
+    - "prepareermo"
+    - "preparereo"
+    - "preparereom"
+    - "preparermeo"
+    - "preparermo"
+    - "preparreemo"
+    - "preparremo"
+    - "prepraeremo"
+    - "prepreremo"
+    - "prpareremo"
+    - "prpeareremo"
+    - "rpepareremo"
     replace: "prepareremo"
     propagate_case: true
     word: true
 
-  - trigger: "perpareremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preapreremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preareremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaeremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepaerremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareemo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepareermo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparereo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparereom"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparermeo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparermo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparreemo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "preparremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepraeremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prepreremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prpareremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prpeareremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpepareremo"
-    replace: "prepareremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "peparerà"
+  - triggers:
+    - "peparerà"
+    - "perparerà"
+    - "preaprerà"
+    - "prearerà"
+    - "prepaerrà"
+    - "prepaerà"
+    - "preparera"
+    - "preparera'"
+    - "preparera1"
+    - "prepareà"
+    - "prepareàr"
+    - "preparreà"
+    - "preparrà"
+    - "prepraerà"
+    - "preprerà"
+    - "prparerà"
+    - "prpearerà"
+    - "rpeparerà"
     replace: "preparerà"
     word: true
 
-  - trigger: "perparerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preaprerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prearerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prepaerrà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prepaerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preparera"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preparera'"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preparera1"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prepareà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prepareàr"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preparreà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preparrà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prepraerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "preprerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prparerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "prpearerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "rpeparerà"
-    replace: "preparerà"
-    word: true
-
-  - trigger: "peparerò"
+  - triggers:
+    - "peparerò"
+    - "perparerò"
+    - "preaprerò"
+    - "prearerò"
+    - "prepaerrò"
+    - "prepaerò"
+    - "preparero"
+    - "preparero'"
+    - "preparero1"
+    - "prepareò"
+    - "prepareòr"
+    - "preparreò"
+    - "preparrò"
+    - "prepraerò"
+    - "preprerò"
+    - "prparerò"
+    - "prpearerò"
+    - "rpeparerò"
     replace: "preparerò"
     word: true
 
-  - trigger: "perparerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preaprerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prearerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prepaerrò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prepaerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preparero"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preparero'"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preparero1"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prepareò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prepareòr"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preparreò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preparrò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prepraerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "preprerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prparerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "prpearerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "rpeparerò"
-    replace: "preparerò"
-    word: true
-
-  - trigger: "porverai"
+  - triggers:
+    - "porverai"
+    - "poverai"
+    - "proerai"
+    - "proevrai"
+    - "proveai"
+    - "proveari"
+    - "proveri"
+    - "proveria"
+    - "provrai"
+    - "provreai"
+    - "prverai"
+    - "prvoerai"
+    - "rpoverai"
     replace: "proverai"
     propagate_case: true
     word: true
 
-  - trigger: "poverai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proerai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proevrai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveari"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveri"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveria"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "provrai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "provreai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prverai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "prvoerai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoverai"
-    replace: "proverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "porveranno"
+  - triggers:
+    - "porveranno"
+    - "poveranno"
+    - "proeranno"
+    - "proevranno"
+    - "proveanno"
+    - "provearnno"
+    - "proverano"
+    - "proveranon"
+    - "provernano"
+    - "provernno"
+    - "provranno"
+    - "provreanno"
+    - "prveranno"
+    - "prvoeranno"
+    - "rpoveranno"
     replace: "proveranno"
     propagate_case: true
     word: true
 
-  - trigger: "poveranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "proeranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "proevranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveanno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "provearnno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "proverano"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveranon"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "provernano"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "provernno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "provranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "provreanno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prveranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "prvoeranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoveranno"
-    replace: "proveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "porveremo"
+  - triggers:
+    - "porveremo"
+    - "poveremo"
+    - "proeremo"
+    - "proevremo"
+    - "proveemo"
+    - "proveermo"
+    - "provereo"
+    - "provereom"
+    - "provermeo"
+    - "provermo"
+    - "provreemo"
+    - "provremo"
+    - "prveremo"
+    - "prvoeremo"
+    - "rpoveremo"
     replace: "proveremo"
     propagate_case: true
     word: true
 
-  - trigger: "poveremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proeremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proevremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveemo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proveermo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provereo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provereom"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provermeo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provermo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provreemo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "provremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prveremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prvoeremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoveremo"
-    replace: "proveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "porverà"
+  - triggers:
+    - "porverà"
+    - "poverà"
+    - "proerà"
+    - "proevrà"
+    - "provera"
+    - "provera'"
+    - "provera1"
+    - "proveà"
+    - "proveàr"
+    - "provreà"
+    - "provrà"
+    - "prverà"
+    - "prvoerà"
+    - "rpoverà"
     replace: "proverà"
     word: true
 
-  - trigger: "poverà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "proerà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "proevrà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "provera"
-    replace: "proverà"
-    word: true
-
-  - trigger: "provera'"
-    replace: "proverà"
-    word: true
-
-  - trigger: "provera1"
-    replace: "proverà"
-    word: true
-
-  - trigger: "proveà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "proveàr"
-    replace: "proverà"
-    word: true
-
-  - trigger: "provreà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "provrà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "prverà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "prvoerà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "rpoverà"
-    replace: "proverà"
-    word: true
-
-  - trigger: "porverò"
+  - triggers:
+    - "porverò"
+    - "poverò"
+    - "proerò"
+    - "proevrò"
+    - "provero"
+    - "provero'"
+    - "provero1"
+    - "proveò"
+    - "proveòr"
+    - "provreò"
+    - "provrò"
+    - "prverò"
+    - "prvoerò"
+    - "rpoverò"
     replace: "proverò"
     word: true
 
-  - trigger: "poverò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "proerò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "proevrò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "provero"
-    replace: "proverò"
-    word: true
-
-  - trigger: "provero'"
-    replace: "proverò"
-    word: true
-
-  - trigger: "provero1"
-    replace: "proverò"
-    word: true
-
-  - trigger: "proveò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "proveòr"
-    replace: "proverò"
-    word: true
-
-  - trigger: "provreò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "provrò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "prverò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "prvoerò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "rpoverò"
-    replace: "proverò"
-    word: true
-
-  - trigger: "pbblicherai"
+  - triggers:
+    - "pbblicherai"
+    - "pbublicherai"
+    - "pubbicherai"
+    - "pubbilcherai"
+    - "pubblcherai"
+    - "pubblciherai"
+    - "pubblicehrai"
+    - "pubblicerai"
+    - "pubblicheai"
+    - "pubblicheari"
+    - "pubblicheri"
+    - "pubblicheria"
+    - "pubblichrai"
+    - "pubblichreai"
+    - "pubblihcerai"
+    - "pubbliherai"
+    - "publbicherai"
+    - "publicherai"
+    - "upbblicherai"
     replace: "pubblicherai"
     propagate_case: true
     word: true
 
-  - trigger: "pbublicherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbicherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbilcherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblcherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblciherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicehrai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicerai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheari"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheri"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheria"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichrai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichreai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblihcerai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbliherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "publbicherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "publicherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "upbblicherai"
-    replace: "pubblicherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "pbblicheranno"
+  - triggers:
+    - "pbblicheranno"
+    - "pbublicheranno"
+    - "pubbicheranno"
+    - "pubbilcheranno"
+    - "pubblcheranno"
+    - "pubblciheranno"
+    - "pubblicehranno"
+    - "pubbliceranno"
+    - "pubblicheanno"
+    - "pubblichearnno"
+    - "pubblicherano"
+    - "pubblicheranon"
+    - "pubblichernano"
+    - "pubblichernno"
+    - "pubblichranno"
+    - "pubblichreanno"
+    - "pubblihceranno"
+    - "pubbliheranno"
+    - "publbicheranno"
+    - "publicheranno"
+    - "upbblicheranno"
     replace: "pubblicheranno"
     propagate_case: true
     word: true
 
-  - trigger: "pbublicheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbicheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbilcheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblcheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblciheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicehranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbliceranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheanno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichearnno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicherano"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheranon"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichernano"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichernno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichreanno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblihceranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbliheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "publbicheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "publicheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "upbblicheranno"
-    replace: "pubblicheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "pbblicheremo"
+  - triggers:
+    - "pbblicheremo"
+    - "pbublicheremo"
+    - "pubbicheremo"
+    - "pubbilcheremo"
+    - "pubblcheremo"
+    - "pubblciheremo"
+    - "pubblicehremo"
+    - "pubbliceremo"
+    - "pubblicheemo"
+    - "pubblicheermo"
+    - "pubblichereo"
+    - "pubblichereom"
+    - "pubblichermeo"
+    - "pubblichermo"
+    - "pubblichreemo"
+    - "pubblichremo"
+    - "pubblihceremo"
+    - "pubbliheremo"
+    - "publbicheremo"
+    - "publicheremo"
+    - "upbblicheremo"
     replace: "pubblicheremo"
     propagate_case: true
     word: true
 
-  - trigger: "pbublicheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbicheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbilcheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblcheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblciheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicehremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbliceremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheemo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblicheermo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichereo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichereom"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichermeo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichermo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichreemo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblichremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubblihceremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pubbliheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "publbicheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "publicheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "upbblicheremo"
-    replace: "pubblicheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pbblicherà"
+  - triggers:
+    - "pbblicherà"
+    - "pbublicherà"
+    - "pubbicherà"
+    - "pubbilcherà"
+    - "pubblcherà"
+    - "pubblciherà"
+    - "pubblicehrà"
+    - "pubblicerà"
+    - "pubblichera"
+    - "pubblichera'"
+    - "pubblichera1"
+    - "pubblicheà"
+    - "pubblicheàr"
+    - "pubblichreà"
+    - "pubblichrà"
+    - "pubblihcerà"
+    - "pubbliherà"
+    - "publbicherà"
+    - "publicherà"
+    - "upbblicherà"
     replace: "pubblicherà"
     word: true
 
-  - trigger: "pbublicherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubbicherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubbilcherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblcherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblciherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblicehrà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblicerà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblichera"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblichera'"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblichera1"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblicheà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblicheàr"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblichreà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblichrà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubblihcerà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pubbliherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "publbicherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "publicherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "upbblicherà"
-    replace: "pubblicherà"
-    word: true
-
-  - trigger: "pbblicherò"
+  - triggers:
+    - "pbblicherò"
+    - "pbublicherò"
+    - "pubbicherò"
+    - "pubbilcherò"
+    - "pubblcherò"
+    - "pubblciherò"
+    - "pubblicehrò"
+    - "pubblicerò"
+    - "pubblichero"
+    - "pubblichero'"
+    - "pubblichero1"
+    - "pubblicheò"
+    - "pubblicheòr"
+    - "pubblichreò"
+    - "pubblichrò"
+    - "pubblihcerò"
+    - "pubbliherò"
+    - "publbicherò"
+    - "publicherò"
+    - "upbblicherò"
     replace: "pubblicherò"
     word: true
 
-  - trigger: "pbublicherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubbicherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubbilcherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblcherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblciherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblicehrò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblicerò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblichero"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblichero'"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblichero1"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblicheò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblicheòr"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblichreò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblichrò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubblihcerò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pubbliherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "publbicherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "publicherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "upbblicherò"
-    replace: "pubblicherò"
-    word: true
-
-  - trigger: "pruché"
+  - triggers:
+    - "pruché"
+    - "puché"
+    - "pucrhé"
+    - "purche"
+    - "purche'"
+    - "purche1"
+    - "purcé"
+    - "purcéh"
+    - "purhcé"
+    - "purhé"
+    - "uprché"
     replace: "purché"
     word: true
 
-  - trigger: "puché"
-    replace: "purché"
-    word: true
-
-  - trigger: "pucrhé"
-    replace: "purché"
-    word: true
-
-  - trigger: "purche"
-    replace: "purché"
-    word: true
-
-  - trigger: "purche'"
-    replace: "purché"
-    word: true
-
-  - trigger: "purche1"
-    replace: "purché"
-    word: true
-
-  - trigger: "purcé"
-    replace: "purché"
-    word: true
-
-  - trigger: "purcéh"
-    replace: "purché"
-    word: true
-
-  - trigger: "purhcé"
-    replace: "purché"
-    word: true
-
-  - trigger: "purhé"
-    replace: "purché"
-    word: true
-
-  - trigger: "uprché"
-    replace: "purché"
-    word: true
-
-  - trigger: "puo"
+  - triggers:
+    - "puo"
+    - "puo'"
+    - "puo1"
+    - "pòu"
+    - "upò"
     replace: "può"
     word: true
 
-  - trigger: "puo'"
-    replace: "può"
-    word: true
-
-  - trigger: "puo1"
-    replace: "può"
-    word: true
-
-  - trigger: "pòu"
-    replace: "può"
-    word: true
-
-  - trigger: "upò"
-    replace: "può"
-    word: true
-
-  - trigger: "qalità"
+  - triggers:
+    - "qalità"
+    - "qaulità"
+    - "quailtà"
+    - "quaità"
+    - "qualita"
+    - "qualita'"
+    - "qualita1"
+    - "qualià"
+    - "qualiàt"
+    - "qualtià"
+    - "qualtà"
+    - "qulaità"
+    - "qulità"
+    - "uqalità"
     replace: "qualità"
     word: true
 
-  - trigger: "qaulità"
-    replace: "qualità"
-    word: true
-
-  - trigger: "quailtà"
-    replace: "qualità"
-    word: true
-
-  - trigger: "quaità"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualita"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualita'"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualita1"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualià"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualiàt"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualtià"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qualtà"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qulaità"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qulità"
-    replace: "qualità"
-    word: true
-
-  - trigger: "uqalità"
-    replace: "qualità"
-    word: true
-
-  - trigger: "qantità"
+  - triggers:
+    - "qantità"
+    - "qauntità"
+    - "quanittà"
+    - "quanità"
+    - "quantita"
+    - "quantita'"
+    - "quantita1"
+    - "quantià"
+    - "quantiàt"
+    - "quanttià"
+    - "quanttà"
+    - "quatità"
+    - "quatnità"
+    - "qunatità"
+    - "quntità"
+    - "uqantità"
     replace: "quantità"
     word: true
 
-  - trigger: "qauntità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quanittà"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quanità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quantita"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quantita'"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quantita1"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quantià"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quantiàt"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quanttià"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quanttà"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quatità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quatnità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "qunatità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "quntità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "uqantità"
-    replace: "quantità"
-    word: true
-
-  - trigger: "eraltà"
+  - triggers:
+    - "eraltà"
+    - "raeltà"
+    - "raltà"
+    - "realta"
+    - "realta'"
+    - "realta1"
+    - "realà"
+    - "realàt"
+    - "reatlà"
+    - "reatà"
+    - "relatà"
+    - "reltà"
     replace: "realtà"
     word: true
 
-  - trigger: "raeltà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "raltà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "realta"
-    replace: "realtà"
-    word: true
-
-  - trigger: "realta'"
-    replace: "realtà"
-    word: true
-
-  - trigger: "realta1"
-    replace: "realtà"
-    word: true
-
-  - trigger: "realà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "realàt"
-    replace: "realtà"
-    word: true
-
-  - trigger: "reatlà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "reatà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "relatà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "reltà"
-    replace: "realtà"
-    word: true
-
-  - trigger: "ersponsabilità"
+  - triggers:
+    - "ersponsabilità"
+    - "reponsabilità"
+    - "repsonsabilità"
+    - "resonsabilità"
+    - "resopnsabilità"
+    - "respnosabilità"
+    - "respnsabilità"
+    - "responabilità"
+    - "responasbilità"
+    - "responsabiiltà"
+    - "responsabiità"
+    - "responsabilita"
+    - "responsabilita'"
+    - "responsabilita1"
+    - "responsabilià"
+    - "responsabiliàt"
+    - "responsabiltià"
+    - "responsabiltà"
+    - "responsabliità"
+    - "responsablità"
+    - "responsaiblità"
+    - "responsailità"
+    - "responsbailità"
+    - "responsbilità"
+    - "resposabilità"
+    - "resposnabilità"
+    - "rseponsabilità"
+    - "rsponsabilità"
     replace: "responsabilità"
     word: true
 
-  - trigger: "reponsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "repsonsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "resonsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "resopnsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "respnosabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "respnsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responasbilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabiiltà"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabiità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabilita"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabilita'"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabilita1"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabilià"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabiliàt"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabiltià"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabiltà"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsabliità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsablità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsaiblità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsailità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsbailità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "responsbilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "resposabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "resposnabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "rseponsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "rsponsabilità"
-    replace: "responsabilità"
-    word: true
-
-  - trigger: "ersterai"
+  - triggers:
+    - "ersterai"
+    - "reserai"
+    - "resetrai"
+    - "resteai"
+    - "resteari"
+    - "resteri"
+    - "resteria"
+    - "restrai"
+    - "restreai"
+    - "reterai"
+    - "retserai"
+    - "rseterai"
+    - "rsterai"
     replace: "resterai"
     propagate_case: true
     word: true
 
-  - trigger: "reserai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "resetrai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteari"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteri"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteria"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "restrai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "restreai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "reterai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "retserai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseterai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsterai"
-    replace: "resterai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersteranno"
+  - triggers:
+    - "ersteranno"
+    - "reseranno"
+    - "resetranno"
+    - "resteanno"
+    - "restearnno"
+    - "resterano"
+    - "resteranon"
+    - "resternano"
+    - "resternno"
+    - "restranno"
+    - "restreanno"
+    - "reteranno"
+    - "retseranno"
+    - "rseteranno"
+    - "rsteranno"
     replace: "resteranno"
     propagate_case: true
     word: true
 
-  - trigger: "reseranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resetranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteanno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "restearnno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resterano"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteranon"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resternano"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "resternno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "restranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "restreanno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "reteranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "retseranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseteranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsteranno"
-    replace: "resteranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersteremo"
+  - triggers:
+    - "ersteremo"
+    - "reseremo"
+    - "resetremo"
+    - "resteemo"
+    - "resteermo"
+    - "restereo"
+    - "restereom"
+    - "restermeo"
+    - "restermo"
+    - "restreemo"
+    - "restremo"
+    - "reteremo"
+    - "retseremo"
+    - "rseteremo"
+    - "rsteremo"
     replace: "resteremo"
     propagate_case: true
     word: true
 
-  - trigger: "reseremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "resetremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteemo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "resteermo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restereo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restereom"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restermeo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restermo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restreemo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "restremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "reteremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "retseremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseteremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsteremo"
-    replace: "resteremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersterà"
+  - triggers:
+    - "ersterà"
+    - "reserà"
+    - "resetrà"
+    - "restera"
+    - "restera'"
+    - "restera1"
+    - "resteà"
+    - "resteàr"
+    - "restreà"
+    - "restrà"
+    - "reterà"
+    - "retserà"
+    - "rseterà"
+    - "rsterà"
     replace: "resterà"
     word: true
 
-  - trigger: "reserà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "resetrà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "restera"
-    replace: "resterà"
-    word: true
-
-  - trigger: "restera'"
-    replace: "resterà"
-    word: true
-
-  - trigger: "restera1"
-    replace: "resterà"
-    word: true
-
-  - trigger: "resteà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "resteàr"
-    replace: "resterà"
-    word: true
-
-  - trigger: "restreà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "restrà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "reterà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "retserà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "rseterà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "rsterà"
-    replace: "resterà"
-    word: true
-
-  - trigger: "ersterò"
+  - triggers:
+    - "ersterò"
+    - "reserò"
+    - "resetrò"
+    - "restero"
+    - "restero'"
+    - "restero1"
+    - "resteò"
+    - "resteòr"
+    - "restreò"
+    - "restrò"
+    - "reterò"
+    - "retserò"
+    - "rseterò"
+    - "rsterò"
     replace: "resterò"
     word: true
 
-  - trigger: "reserò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "resetrò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "restero"
-    replace: "resterò"
-    word: true
-
-  - trigger: "restero'"
-    replace: "resterò"
-    word: true
-
-  - trigger: "restero1"
-    replace: "resterò"
-    word: true
-
-  - trigger: "resteò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "resteòr"
-    replace: "resterò"
-    word: true
-
-  - trigger: "restreò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "restrò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "reterò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "retserò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "rseterò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "rsterò"
-    replace: "resterò"
-    word: true
-
-  - trigger: "irceverai"
+  - triggers:
+    - "irceverai"
+    - "rceverai"
+    - "rcieverai"
+    - "riceerai"
+    - "riceevrai"
+    - "riceveai"
+    - "riceveari"
+    - "riceveri"
+    - "riceveria"
+    - "ricevrai"
+    - "ricevreai"
+    - "ricveerai"
+    - "ricverai"
+    - "riecverai"
+    - "rieverai"
     replace: "riceverai"
     propagate_case: true
     word: true
 
-  - trigger: "rceverai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcieverai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceerai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceevrai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveari"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveri"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveria"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevrai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevreai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricveerai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricverai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riecverai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rieverai"
-    replace: "riceverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "irceveranno"
+  - triggers:
+    - "irceveranno"
+    - "rceveranno"
+    - "rcieveranno"
+    - "riceeranno"
+    - "riceevranno"
+    - "riceveanno"
+    - "ricevearnno"
+    - "riceverano"
+    - "riceveranon"
+    - "ricevernano"
+    - "ricevernno"
+    - "ricevranno"
+    - "ricevreanno"
+    - "ricveeranno"
+    - "ricveranno"
+    - "riecveranno"
+    - "rieveranno"
     replace: "riceveranno"
     propagate_case: true
     word: true
 
-  - trigger: "rceveranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcieveranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceeranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceevranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveanno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevearnno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceverano"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveranon"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevernano"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevernno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevreanno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricveeranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricveranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riecveranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rieveranno"
-    replace: "riceveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "irceveremo"
+  - triggers:
+    - "irceveremo"
+    - "rceveremo"
+    - "rcieveremo"
+    - "riceeremo"
+    - "riceevremo"
+    - "riceveemo"
+    - "riceveermo"
+    - "ricevereo"
+    - "ricevereom"
+    - "ricevermeo"
+    - "ricevermo"
+    - "ricevreemo"
+    - "ricevremo"
+    - "ricveeremo"
+    - "ricveremo"
+    - "riecveremo"
+    - "rieveremo"
     replace: "riceveremo"
     propagate_case: true
     word: true
 
-  - trigger: "rceveremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcieveremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceeremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceevremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveemo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riceveermo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevereo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevereom"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevermeo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevermo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevreemo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricevremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricveeremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ricveremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riecveremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rieveremo"
-    replace: "riceveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "irceverà"
+  - triggers:
+    - "irceverà"
+    - "rceverà"
+    - "rcieverà"
+    - "riceerà"
+    - "riceevrà"
+    - "ricevera"
+    - "ricevera'"
+    - "ricevera1"
+    - "riceveà"
+    - "riceveàr"
+    - "ricevreà"
+    - "ricevrà"
+    - "ricveerà"
+    - "ricverà"
+    - "riecverà"
+    - "rieverà"
     replace: "riceverà"
     word: true
 
-  - trigger: "rceverà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "rcieverà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "riceerà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "riceevrà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricevera"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricevera'"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricevera1"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "riceveà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "riceveàr"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricevreà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricevrà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricveerà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "ricverà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "riecverà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "rieverà"
-    replace: "riceverà"
-    word: true
-
-  - trigger: "irceverò"
+  - triggers:
+    - "irceverò"
+    - "rceverò"
+    - "rcieverò"
+    - "riceerò"
+    - "riceevrò"
+    - "ricevero"
+    - "ricevero'"
+    - "ricevero1"
+    - "riceveò"
+    - "riceveòr"
+    - "ricevreò"
+    - "ricevrò"
+    - "ricveerò"
+    - "ricverò"
+    - "riecverò"
+    - "rieverò"
     replace: "riceverò"
     word: true
 
-  - trigger: "rceverò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "rcieverò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "riceerò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "riceevrò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricevero"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricevero'"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricevero1"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "riceveò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "riceveòr"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricevreò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricevrò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricveerò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "ricverò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "riecverò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "rieverò"
-    replace: "riceverò"
-    word: true
-
-  - trigger: "irmarrai"
+  - triggers:
+    - "irmarrai"
+    - "riamrrai"
+    - "riarrai"
+    - "rimarai"
+    - "rimarari"
+    - "rimarri"
+    - "rimarria"
+    - "rimrarai"
+    - "rimrrai"
+    - "rmarrai"
+    - "rmiarrai"
     replace: "rimarrai"
     propagate_case: true
     word: true
 
-  - trigger: "riamrrai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "riarrai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarari"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarri"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarria"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimrarai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimrrai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmarrai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmiarrai"
-    replace: "rimarrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "irmarranno"
+  - triggers:
+    - "irmarranno"
+    - "riamrranno"
+    - "riarranno"
+    - "rimaranno"
+    - "rimararnno"
+    - "rimarrano"
+    - "rimarranon"
+    - "rimarrnano"
+    - "rimarrnno"
+    - "rimraranno"
+    - "rimrranno"
+    - "rmarranno"
+    - "rmiarranno"
     replace: "rimarranno"
     propagate_case: true
     word: true
 
-  - trigger: "riamrranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "riarranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimaranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimararnno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarrano"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarranon"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarrnano"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarrnno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimraranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimrranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmarranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmiarranno"
-    replace: "rimarranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "irmarremo"
+  - triggers:
+    - "irmarremo"
+    - "riamrremo"
+    - "riarremo"
+    - "rimaremo"
+    - "rimarermo"
+    - "rimarreo"
+    - "rimarreom"
+    - "rimarrmeo"
+    - "rimarrmo"
+    - "rimraremo"
+    - "rimrremo"
+    - "rmarremo"
+    - "rmiarremo"
     replace: "rimarremo"
     propagate_case: true
     word: true
 
-  - trigger: "riamrremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "riarremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimaremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarermo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarreo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarreom"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarrmeo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimarrmo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimraremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rimrremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmarremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmiarremo"
-    replace: "rimarremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "irmarrà"
+  - triggers:
+    - "irmarrà"
+    - "riamrrà"
+    - "riarrà"
+    - "rimarra"
+    - "rimarra'"
+    - "rimarra1"
+    - "rimarà"
+    - "rimaràr"
+    - "rimrarà"
+    - "rimrrà"
+    - "rmarrà"
+    - "rmiarrà"
     replace: "rimarrà"
     word: true
 
-  - trigger: "riamrrà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "riarrà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimarra"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimarra'"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimarra1"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimarà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimaràr"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimrarà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rimrrà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rmarrà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "rmiarrà"
-    replace: "rimarrà"
-    word: true
-
-  - trigger: "irmarrò"
+  - triggers:
+    - "irmarrò"
+    - "riamrrò"
+    - "riarrò"
+    - "rimarro"
+    - "rimarro'"
+    - "rimarro1"
+    - "rimarò"
+    - "rimaròr"
+    - "rimrarò"
+    - "rimrrò"
+    - "rmarrò"
+    - "rmiarrò"
     replace: "rimarrò"
     word: true
 
-  - trigger: "riamrrò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "riarrò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimarro"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimarro'"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimarro1"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimarò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimaròr"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimrarò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rimrrò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rmarrò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "rmiarrò"
-    replace: "rimarrò"
-    word: true
-
-  - trigger: "irsolverai"
+  - triggers:
+    - "irsolverai"
+    - "riolverai"
+    - "rioslverai"
+    - "risloverai"
+    - "rislverai"
+    - "risolerai"
+    - "risolevrai"
+    - "risolveai"
+    - "risolveari"
+    - "risolveri"
+    - "risolveria"
+    - "risolvrai"
+    - "risolvreai"
+    - "risoverai"
+    - "risovlerai"
+    - "rsiolverai"
+    - "rsolverai"
     replace: "risolverai"
     propagate_case: true
     word: true
 
-  - trigger: "riolverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rioslverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risloverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rislverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolerai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolevrai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveari"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveri"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveria"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvrai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvreai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risoverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risovlerai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiolverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsolverai"
-    replace: "risolverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsolveranno"
+  - triggers:
+    - "irsolveranno"
+    - "riolveranno"
+    - "rioslveranno"
+    - "risloveranno"
+    - "rislveranno"
+    - "risoleranno"
+    - "risolevranno"
+    - "risolveanno"
+    - "risolvearnno"
+    - "risolverano"
+    - "risolveranon"
+    - "risolvernano"
+    - "risolvernno"
+    - "risolvranno"
+    - "risolvreanno"
+    - "risoveranno"
+    - "risovleranno"
+    - "rsiolveranno"
+    - "rsolveranno"
     replace: "risolveranno"
     propagate_case: true
     word: true
 
-  - trigger: "riolveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rioslveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risloveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rislveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risoleranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolevranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveanno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvearnno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolverano"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveranon"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvernano"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvernno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvreanno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risoveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risovleranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiolveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsolveranno"
-    replace: "risolveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsolveremo"
+  - triggers:
+    - "irsolveremo"
+    - "riolveremo"
+    - "rioslveremo"
+    - "risloveremo"
+    - "rislveremo"
+    - "risoleremo"
+    - "risolevremo"
+    - "risolveemo"
+    - "risolveermo"
+    - "risolvereo"
+    - "risolvereom"
+    - "risolvermeo"
+    - "risolvermo"
+    - "risolvreemo"
+    - "risolvremo"
+    - "risoveremo"
+    - "risovleremo"
+    - "rsiolveremo"
+    - "rsolveremo"
     replace: "risolveremo"
     propagate_case: true
     word: true
 
-  - trigger: "riolveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rioslveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risloveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rislveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risoleremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolevremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveemo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolveermo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvereo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvereom"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvermeo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvermo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvreemo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risolvremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risoveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risovleremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiolveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsolveremo"
-    replace: "risolveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsolverà"
+  - triggers:
+    - "irsolverà"
+    - "riolverà"
+    - "rioslverà"
+    - "risloverà"
+    - "rislverà"
+    - "risolerà"
+    - "risolevrà"
+    - "risolvera"
+    - "risolvera'"
+    - "risolvera1"
+    - "risolveà"
+    - "risolveàr"
+    - "risolvreà"
+    - "risolvrà"
+    - "risoverà"
+    - "risovlerà"
+    - "rsiolverà"
+    - "rsolverà"
     replace: "risolverà"
     word: true
 
-  - trigger: "riolverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "rioslverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risloverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "rislverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolerà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolevrà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolvera"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolvera'"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolvera1"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolveà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolveàr"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolvreà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risolvrà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risoverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "risovlerà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "rsiolverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "rsolverà"
-    replace: "risolverà"
-    word: true
-
-  - trigger: "irsolverò"
+  - triggers:
+    - "irsolverò"
+    - "riolverò"
+    - "rioslverò"
+    - "risloverò"
+    - "rislverò"
+    - "risolerò"
+    - "risolevrò"
+    - "risolvero"
+    - "risolvero'"
+    - "risolvero1"
+    - "risolveò"
+    - "risolveòr"
+    - "risolvreò"
+    - "risolvrò"
+    - "risoverò"
+    - "risovlerò"
+    - "rsiolverò"
+    - "rsolverò"
     replace: "risolverò"
     word: true
 
-  - trigger: "riolverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "rioslverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risloverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "rislverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolerò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolevrò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolvero"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolvero'"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolvero1"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolveò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolveòr"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolvreò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risolvrò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risoverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "risovlerò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "rsiolverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "rsolverò"
-    replace: "risolverò"
-    word: true
-
-  - trigger: "irsponderai"
+  - triggers:
+    - "irsponderai"
+    - "riponderai"
+    - "ripsonderai"
+    - "risonderai"
+    - "risopnderai"
+    - "rispnderai"
+    - "rispnoderai"
+    - "rispoderai"
+    - "rispodnerai"
+    - "rispondeai"
+    - "rispondeari"
+    - "risponderi"
+    - "risponderia"
+    - "rispondrai"
+    - "rispondreai"
+    - "risponedrai"
+    - "risponerai"
+    - "rsiponderai"
+    - "rsponderai"
     replace: "risponderai"
     propagate_case: true
     word: true
 
-  - trigger: "riponderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ripsonderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risonderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risopnderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnoderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispoderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispodnerai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondeai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondeari"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponderi"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponderia"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondrai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondreai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponedrai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponerai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiponderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsponderai"
-    replace: "risponderai"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsponderanno"
+  - triggers:
+    - "irsponderanno"
+    - "riponderanno"
+    - "ripsonderanno"
+    - "risonderanno"
+    - "risopnderanno"
+    - "rispnderanno"
+    - "rispnoderanno"
+    - "rispoderanno"
+    - "rispodneranno"
+    - "rispondeanno"
+    - "rispondearnno"
+    - "risponderano"
+    - "risponderanon"
+    - "rispondernano"
+    - "rispondernno"
+    - "rispondranno"
+    - "rispondreanno"
+    - "risponedranno"
+    - "risponeranno"
+    - "rsiponderanno"
+    - "rsponderanno"
     replace: "risponderanno"
     propagate_case: true
     word: true
 
-  - trigger: "riponderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ripsonderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risonderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risopnderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnoderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispoderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispodneranno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondeanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondearnno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponderano"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponderanon"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondernano"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondernno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondranno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondreanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponedranno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponeranno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiponderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsponderanno"
-    replace: "risponderanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsponderemo"
+  - triggers:
+    - "irsponderemo"
+    - "riponderemo"
+    - "ripsonderemo"
+    - "risonderemo"
+    - "risopnderemo"
+    - "rispnderemo"
+    - "rispnoderemo"
+    - "rispoderemo"
+    - "rispodneremo"
+    - "rispondeemo"
+    - "rispondeermo"
+    - "rispondereo"
+    - "rispondereom"
+    - "rispondermeo"
+    - "rispondermo"
+    - "rispondreemo"
+    - "rispondremo"
+    - "risponedremo"
+    - "risponeremo"
+    - "rsiponderemo"
+    - "rsponderemo"
     replace: "risponderemo"
     propagate_case: true
     word: true
 
-  - trigger: "riponderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ripsonderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risonderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risopnderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispnoderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispoderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispodneremo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondeemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondeermo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondereo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondereom"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondermeo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondermo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondreemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispondremo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponedremo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "risponeremo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiponderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsponderemo"
-    replace: "risponderemo"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsponderà"
+  - triggers:
+    - "irsponderà"
+    - "riponderà"
+    - "ripsonderà"
+    - "risonderà"
+    - "risopnderà"
+    - "rispnderà"
+    - "rispnoderà"
+    - "rispoderà"
+    - "rispodnerà"
+    - "rispondera"
+    - "rispondera'"
+    - "rispondera1"
+    - "rispondeà"
+    - "rispondeàr"
+    - "rispondreà"
+    - "rispondrà"
+    - "risponedrà"
+    - "risponerà"
+    - "rsiponderà"
+    - "rsponderà"
     replace: "risponderà"
     word: true
 
-  - trigger: "riponderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "ripsonderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "risonderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "risopnderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispnderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispnoderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispoderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispodnerà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondera"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondera'"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondera1"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondeà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondeàr"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondreà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rispondrà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "risponedrà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "risponerà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rsiponderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "rsponderà"
-    replace: "risponderà"
-    word: true
-
-  - trigger: "irsponderò"
+  - triggers:
+    - "irsponderò"
+    - "riponderò"
+    - "ripsonderò"
+    - "risonderò"
+    - "risopnderò"
+    - "rispnderò"
+    - "rispnoderò"
+    - "rispoderò"
+    - "rispodnerò"
+    - "rispondero"
+    - "rispondero'"
+    - "rispondero1"
+    - "rispondeò"
+    - "rispondeòr"
+    - "rispondreò"
+    - "rispondrò"
+    - "risponedrò"
+    - "risponerò"
+    - "rsiponderò"
+    - "rsponderò"
     replace: "risponderò"
     word: true
 
-  - trigger: "riponderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "ripsonderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "risonderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "risopnderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispnderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispnoderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispoderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispodnerò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondero"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondero'"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondero1"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondeò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondeòr"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondreò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rispondrò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "risponedrò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "risponerò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rsiponderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "rsponderò"
-    replace: "risponderò"
-    word: true
-
-  - trigger: "asprai"
+  - triggers:
+    - "asprai"
+    - "sapai"
+    - "sapari"
+    - "sapri"
+    - "sapria"
+    - "sarpai"
+    - "sparai"
+    - "sprai"
     replace: "saprai"
     propagate_case: true
     word: true
 
-  - trigger: "sapai"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapari"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapri"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapria"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarpai"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sparai"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sprai"
-    replace: "saprai"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspranno"
+  - triggers:
+    - "aspranno"
+    - "sapanno"
+    - "saparnno"
+    - "saprano"
+    - "sapranon"
+    - "saprnano"
+    - "saprnno"
+    - "sarpanno"
+    - "sparanno"
+    - "spranno"
     replace: "sapranno"
     propagate_case: true
     word: true
 
-  - trigger: "sapanno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saparnno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saprano"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapranon"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saprnano"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saprnno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarpanno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sparanno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spranno"
-    replace: "sapranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspremo"
+  - triggers:
+    - "aspremo"
+    - "sapemo"
+    - "sapermo"
+    - "sapreo"
+    - "sapreom"
+    - "saprmeo"
+    - "saprmo"
+    - "sarpemo"
+    - "sparemo"
+    - "spremo"
     replace: "sapremo"
     propagate_case: true
     word: true
 
-  - trigger: "sapemo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapermo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapreo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapreom"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "saprmeo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "saprmo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarpemo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sparemo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spremo"
-    replace: "sapremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "asprà"
+  - triggers:
+    - "asprà"
+    - "sapra"
+    - "sapra'"
+    - "sapra1"
+    - "sapà"
+    - "sapàr"
+    - "sarpà"
+    - "sparà"
+    - "sprà"
     replace: "saprà"
     word: true
 
-  - trigger: "sapra"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sapra'"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sapra1"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sapà"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sapàr"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sarpà"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sparà"
-    replace: "saprà"
-    word: true
-
-  - trigger: "sprà"
-    replace: "saprà"
-    word: true
-
-  - trigger: "asprò"
+  - triggers:
+    - "asprò"
+    - "sapro"
+    - "sapro'"
+    - "sapro1"
+    - "sapò"
+    - "sapòr"
+    - "sarpò"
+    - "sparò"
+    - "sprò"
     replace: "saprò"
     word: true
 
-  - trigger: "sapro"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sapro'"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sapro1"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sapò"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sapòr"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sarpò"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sparò"
-    replace: "saprò"
-    word: true
-
-  - trigger: "sprò"
-    replace: "saprò"
-    word: true
-
-  - trigger: "asrai"
+  - triggers:
+    - "asrai"
+    - "saai"
+    - "saari"
+    - "sari"
+    - "saria"
+    - "sraai"
+    - "srai"
     replace: "sarai"
     propagate_case: true
     word: true
 
-  - trigger: "saai"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "saari"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sari"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "saria"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sraai"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "srai"
-    replace: "sarai"
-    propagate_case: true
-    word: true
-
-  - trigger: "asranno"
+  - triggers:
+    - "asranno"
+    - "saanno"
+    - "saarnno"
+    - "sarano"
+    - "saranon"
+    - "sarnano"
+    - "sarnno"
+    - "sraanno"
+    - "sranno"
     replace: "saranno"
     propagate_case: true
     word: true
 
-  - trigger: "saanno"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saarnno"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarano"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "saranon"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarnano"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarnno"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sraanno"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sranno"
-    replace: "saranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "asremo"
+  - triggers:
+    - "asremo"
+    - "saemo"
+    - "saermo"
+    - "sareo"
+    - "sareom"
+    - "sarmeo"
+    - "sarmo"
+    - "sraemo"
+    - "sremo"
     replace: "saremo"
     propagate_case: true
     word: true
 
-  - trigger: "saemo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "saermo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sareo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sareom"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarmeo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarmo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sraemo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sremo"
-    replace: "saremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "asrà"
+  - triggers:
+    - "asrà"
+    - "sara"
+    - "sara'"
+    - "sara1"
+    - "saàr"
+    - "sraà"
     replace: "sarà"
     word: true
 
-  - trigger: "sara"
-    replace: "sarà"
-    word: true
-
-  - trigger: "sara'"
-    replace: "sarà"
-    word: true
-
-  - trigger: "sara1"
-    replace: "sarà"
-    word: true
-
-  - trigger: "saàr"
-    replace: "sarà"
-    word: true
-
-  - trigger: "sraà"
-    replace: "sarà"
-    word: true
-
-  - trigger: "asrò"
+  - triggers:
+    - "asrò"
+    - "saro"
+    - "saro'"
+    - "saro1"
+    - "saòr"
+    - "sraò"
     replace: "sarò"
     word: true
 
-  - trigger: "saro"
-    replace: "sarò"
-    word: true
-
-  - trigger: "saro'"
-    replace: "sarò"
-    word: true
-
-  - trigger: "saro1"
-    replace: "sarò"
-    word: true
-
-  - trigger: "saòr"
-    replace: "sarò"
-    word: true
-
-  - trigger: "sraò"
-    replace: "sarò"
-    word: true
-
-  - trigger: "csriverai"
+  - triggers:
+    - "csriverai"
+    - "scirverai"
+    - "sciverai"
+    - "scrierai"
+    - "scrievrai"
+    - "scriveai"
+    - "scriveari"
+    - "scriveri"
+    - "scriveria"
+    - "scrivrai"
+    - "scrivreai"
+    - "scrverai"
+    - "scrvierai"
+    - "srciverai"
+    - "sriverai"
     replace: "scriverai"
     propagate_case: true
     word: true
 
-  - trigger: "scirverai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sciverai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrierai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrievrai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveari"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveri"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveria"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivrai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivreai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrverai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrvierai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "srciverai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sriverai"
-    replace: "scriverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "csriveranno"
+  - triggers:
+    - "csriveranno"
+    - "scirveranno"
+    - "sciveranno"
+    - "scrieranno"
+    - "scrievranno"
+    - "scriveanno"
+    - "scrivearnno"
+    - "scriverano"
+    - "scriveranon"
+    - "scrivernano"
+    - "scrivernno"
+    - "scrivranno"
+    - "scrivreanno"
+    - "scrveranno"
+    - "scrvieranno"
+    - "srciveranno"
+    - "sriveranno"
     replace: "scriveranno"
     propagate_case: true
     word: true
 
-  - trigger: "scirveranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sciveranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrieranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrievranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveanno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivearnno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriverano"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveranon"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivernano"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivernno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivreanno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrveranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrvieranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "srciveranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sriveranno"
-    replace: "scriveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "csriveremo"
+  - triggers:
+    - "csriveremo"
+    - "scirveremo"
+    - "sciveremo"
+    - "scrieremo"
+    - "scrievremo"
+    - "scriveemo"
+    - "scriveermo"
+    - "scrivereo"
+    - "scrivereom"
+    - "scrivermeo"
+    - "scrivermo"
+    - "scrivreemo"
+    - "scrivremo"
+    - "scrveremo"
+    - "scrvieremo"
+    - "srciveremo"
+    - "sriveremo"
     replace: "scriveremo"
     propagate_case: true
     word: true
 
-  - trigger: "scirveremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sciveremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrieremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrievremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveemo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveermo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivereo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivereom"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivermeo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivermo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivreemo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrveremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrvieremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "srciveremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sriveremo"
-    replace: "scriveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "csriverà"
+  - triggers:
+    - "csriverà"
+    - "scirverà"
+    - "sciverà"
+    - "scrierà"
+    - "scrievrà"
+    - "scrivera"
+    - "scrivera'"
+    - "scrivera1"
+    - "scriveà"
+    - "scriveàr"
+    - "scrivreà"
+    - "scrivrà"
+    - "scrverà"
+    - "scrvierà"
+    - "srciverà"
+    - "sriverà"
     replace: "scriverà"
     word: true
 
-  - trigger: "scirverà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "sciverà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrierà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrievrà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrivera"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrivera'"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrivera1"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scriveà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scriveàr"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrivreà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrivrà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrverà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "scrvierà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "srciverà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "sriverà"
-    replace: "scriverà"
-    word: true
-
-  - trigger: "csriverò"
+  - triggers:
+    - "csriverò"
+    - "scirverò"
+    - "sciverò"
+    - "scrierò"
+    - "scrievrò"
+    - "scrivero"
+    - "scrivero'"
+    - "scrivero1"
+    - "scriveò"
+    - "scriveòr"
+    - "scrivreò"
+    - "scrivrò"
+    - "scrverò"
+    - "scrvierò"
+    - "srciverò"
+    - "sriverò"
     replace: "scriverò"
     word: true
 
-  - trigger: "scirverò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "sciverò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrierò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrievrò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrivero"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrivero'"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrivero1"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scriveò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scriveòr"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrivreò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrivrò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrverò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "scrvierò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "srciverò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "sriverò"
-    replace: "scriverò"
-    word: true
-
-  - trigger: "esnsibilità"
+  - triggers:
+    - "esnsibilità"
+    - "senibilità"
+    - "senisbilità"
+    - "sensbiilità"
+    - "sensbilità"
+    - "sensibiiltà"
+    - "sensibiità"
+    - "sensibilita"
+    - "sensibilita'"
+    - "sensibilita1"
+    - "sensibilià"
+    - "sensibiliàt"
+    - "sensibiltià"
+    - "sensibiltà"
+    - "sensibliità"
+    - "sensiblità"
+    - "sensiiblità"
+    - "sensiilità"
+    - "sesibilità"
+    - "sesnibilità"
+    - "snesibilità"
+    - "snsibilità"
     replace: "sensibilità"
     word: true
 
-  - trigger: "senibilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "senisbilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensbiilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensbilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibiiltà"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibiità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibilita"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibilita'"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibilita1"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibilià"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibiliàt"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibiltià"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibiltà"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensibliità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensiblità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensiiblità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sensiilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sesibilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "sesnibilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "snesibilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "snsibilità"
-    replace: "sensibilità"
-    word: true
-
-  - trigger: "esntirai"
+  - triggers:
+    - "esntirai"
+    - "senirai"
+    - "senitrai"
+    - "sentiai"
+    - "sentiari"
+    - "sentiri"
+    - "sentiria"
+    - "sentrai"
+    - "sentriai"
+    - "setirai"
+    - "setnirai"
+    - "snetirai"
+    - "sntirai"
     replace: "sentirai"
     propagate_case: true
     word: true
 
-  - trigger: "senirai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "senitrai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiari"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiri"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiria"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentrai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentriai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "setirai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "setnirai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "snetirai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sntirai"
-    replace: "sentirai"
-    propagate_case: true
-    word: true
-
-  - trigger: "esntiranno"
+  - triggers:
+    - "esntiranno"
+    - "seniranno"
+    - "senitranno"
+    - "sentianno"
+    - "sentiarnno"
+    - "sentirano"
+    - "sentiranon"
+    - "sentirnano"
+    - "sentirnno"
+    - "sentranno"
+    - "sentrianno"
+    - "setiranno"
+    - "setniranno"
+    - "snetiranno"
+    - "sntiranno"
     replace: "sentiranno"
     propagate_case: true
     word: true
 
-  - trigger: "seniranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "senitranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentianno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiarnno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentirano"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiranon"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentirnano"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentirnno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentrianno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "setiranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "setniranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "snetiranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sntiranno"
-    replace: "sentiranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "esntiremo"
+  - triggers:
+    - "esntiremo"
+    - "seniremo"
+    - "senitremo"
+    - "sentiemo"
+    - "sentiermo"
+    - "sentireo"
+    - "sentireom"
+    - "sentirmeo"
+    - "sentirmo"
+    - "sentremo"
+    - "sentriemo"
+    - "setiremo"
+    - "setniremo"
+    - "snetiremo"
+    - "sntiremo"
     replace: "sentiremo"
     propagate_case: true
     word: true
 
-  - trigger: "seniremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "senitremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiemo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentiermo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentireo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentireom"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentirmeo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentirmo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentriemo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "setiremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "setniremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "snetiremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sntiremo"
-    replace: "sentiremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "esntirà"
+  - triggers:
+    - "esntirà"
+    - "senirà"
+    - "senitrà"
+    - "sentira"
+    - "sentira'"
+    - "sentira1"
+    - "sentià"
+    - "sentiàr"
+    - "sentrià"
+    - "sentrà"
+    - "setirà"
+    - "setnirà"
+    - "snetirà"
+    - "sntirà"
     replace: "sentirà"
     word: true
 
-  - trigger: "senirà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "senitrà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentira"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentira'"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentira1"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentià"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentiàr"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentrià"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sentrà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "setirà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "setnirà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "snetirà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "sntirà"
-    replace: "sentirà"
-    word: true
-
-  - trigger: "esntirò"
+  - triggers:
+    - "esntirò"
+    - "senirò"
+    - "senitrò"
+    - "sentiro"
+    - "sentiro'"
+    - "sentiro1"
+    - "sentiò"
+    - "sentiòr"
+    - "sentriò"
+    - "sentrò"
+    - "setirò"
+    - "setnirò"
+    - "snetirò"
+    - "sntirò"
     replace: "sentirò"
     word: true
 
-  - trigger: "senirò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "senitrò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentiro"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentiro'"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentiro1"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentiò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentiòr"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentriò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sentrò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "setirò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "setnirò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "snetirò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "sntirò"
-    replace: "sentirò"
-    word: true
-
-  - trigger: "psiegherai"
+  - triggers:
+    - "psiegherai"
+    - "siegherai"
+    - "sipegherai"
+    - "spegherai"
+    - "speigherai"
+    - "spiegehrai"
+    - "spiegerai"
+    - "spiegheai"
+    - "spiegheari"
+    - "spiegheri"
+    - "spiegheria"
+    - "spieghrai"
+    - "spieghreai"
+    - "spieherai"
+    - "spiehgerai"
+    - "spigeherai"
+    - "spigherai"
     replace: "spiegherai"
     propagate_case: true
     word: true
 
-  - trigger: "siegherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sipegherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spegherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "speigherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegehrai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegerai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheari"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheri"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheria"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghrai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghreai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiehgerai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigeherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigherai"
-    replace: "spiegherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "psiegheranno"
+  - triggers:
+    - "psiegheranno"
+    - "siegheranno"
+    - "sipegheranno"
+    - "spegheranno"
+    - "speigheranno"
+    - "spiegehranno"
+    - "spiegeranno"
+    - "spiegheanno"
+    - "spieghearnno"
+    - "spiegherano"
+    - "spiegheranon"
+    - "spieghernano"
+    - "spieghernno"
+    - "spieghranno"
+    - "spieghreanno"
+    - "spieheranno"
+    - "spiehgeranno"
+    - "spigeheranno"
+    - "spigheranno"
     replace: "spiegheranno"
     propagate_case: true
     word: true
 
-  - trigger: "siegheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sipegheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spegheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "speigheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegehranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegeranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheanno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghearnno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegherano"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheranon"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghernano"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghernno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghreanno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiehgeranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigeheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigheranno"
-    replace: "spiegheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "psiegheremo"
+  - triggers:
+    - "psiegheremo"
+    - "siegheremo"
+    - "sipegheremo"
+    - "spegheremo"
+    - "speigheremo"
+    - "spiegehremo"
+    - "spiegeremo"
+    - "spiegheemo"
+    - "spiegheermo"
+    - "spieghereo"
+    - "spieghereom"
+    - "spieghermeo"
+    - "spieghermo"
+    - "spieghreemo"
+    - "spieghremo"
+    - "spieheremo"
+    - "spiehgeremo"
+    - "spigeheremo"
+    - "spigheremo"
     replace: "spiegheremo"
     propagate_case: true
     word: true
 
-  - trigger: "siegheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sipegheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spegheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "speigheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegehremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegeremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheemo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiegheermo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghereo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghereom"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghermeo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghermo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghreemo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieghremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spieheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiehgeremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigeheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "spigheremo"
-    replace: "spiegheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psiegherà"
+  - triggers:
+    - "psiegherà"
+    - "siegherà"
+    - "sipegherà"
+    - "spegherà"
+    - "speigherà"
+    - "spiegehrà"
+    - "spiegerà"
+    - "spieghera"
+    - "spieghera'"
+    - "spieghera1"
+    - "spiegheà"
+    - "spiegheàr"
+    - "spieghreà"
+    - "spieghrà"
+    - "spieherà"
+    - "spiehgerà"
+    - "spigeherà"
+    - "spigherà"
     replace: "spiegherà"
     word: true
 
-  - trigger: "siegherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "sipegherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spegherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "speigherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spiegehrà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spiegerà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieghera"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieghera'"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieghera1"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spiegheà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spiegheàr"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieghreà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieghrà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spieherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spiehgerà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spigeherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "spigherà"
-    replace: "spiegherà"
-    word: true
-
-  - trigger: "psiegherò"
+  - triggers:
+    - "psiegherò"
+    - "siegherò"
+    - "sipegherò"
+    - "spegherò"
+    - "speigherò"
+    - "spiegehrò"
+    - "spiegerò"
+    - "spieghero"
+    - "spieghero'"
+    - "spieghero1"
+    - "spiegheò"
+    - "spiegheòr"
+    - "spieghreò"
+    - "spieghrò"
+    - "spieherò"
+    - "spiehgerò"
+    - "spigeherò"
+    - "spigherò"
     replace: "spiegherò"
     word: true
 
-  - trigger: "siegherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "sipegherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spegherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "speigherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spiegehrò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spiegerò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieghero"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieghero'"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieghero1"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spiegheò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spiegheòr"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieghreò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieghrò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spieherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spiehgerò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spigeherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "spigherò"
-    replace: "spiegherò"
-    word: true
-
-  - trigger: "satrai"
+  - triggers:
+    - "satrai"
+    - "staai"
+    - "staari"
+    - "stari"
+    - "staria"
+    - "straai"
+    - "strai"
+    - "tsarai"
     replace: "starai"
     propagate_case: true
     word: true
 
-  - trigger: "staai"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "staari"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "stari"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "staria"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "straai"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "strai"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsarai"
-    replace: "starai"
-    propagate_case: true
-    word: true
-
-  - trigger: "satranno"
+  - triggers:
+    - "satranno"
+    - "staanno"
+    - "staarnno"
+    - "starano"
+    - "staranon"
+    - "starnano"
+    - "starnno"
+    - "straanno"
+    - "stranno"
+    - "tsaranno"
     replace: "staranno"
     propagate_case: true
     word: true
 
-  - trigger: "staanno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "staarnno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "starano"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "staranon"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "starnano"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "starnno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "straanno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "stranno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsaranno"
-    replace: "staranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "satremo"
+  - triggers:
+    - "satremo"
+    - "staemo"
+    - "staermo"
+    - "stareo"
+    - "stareom"
+    - "starmeo"
+    - "starmo"
+    - "straemo"
+    - "stremo"
+    - "tsaremo"
     replace: "staremo"
     propagate_case: true
     word: true
 
-  - trigger: "staemo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "staermo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "stareo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "stareom"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "starmeo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "starmo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "straemo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "stremo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsaremo"
-    replace: "staremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "satrà"
+  - triggers:
+    - "satrà"
+    - "stara"
+    - "stara'"
+    - "stara1"
+    - "staà"
+    - "staàr"
+    - "straà"
+    - "strà"
+    - "tsarà"
     replace: "starà"
     word: true
 
-  - trigger: "stara"
-    replace: "starà"
-    word: true
-
-  - trigger: "stara'"
-    replace: "starà"
-    word: true
-
-  - trigger: "stara1"
-    replace: "starà"
-    word: true
-
-  - trigger: "staà"
-    replace: "starà"
-    word: true
-
-  - trigger: "staàr"
-    replace: "starà"
-    word: true
-
-  - trigger: "straà"
-    replace: "starà"
-    word: true
-
-  - trigger: "strà"
-    replace: "starà"
-    word: true
-
-  - trigger: "tsarà"
-    replace: "starà"
-    word: true
-
-  - trigger: "satrò"
+  - triggers:
+    - "satrò"
+    - "staro"
+    - "staro'"
+    - "staro1"
+    - "staò"
+    - "staòr"
+    - "straò"
+    - "strò"
+    - "tsarò"
     replace: "starò"
     word: true
 
-  - trigger: "staro"
-    replace: "starò"
-    word: true
-
-  - trigger: "staro'"
-    replace: "starò"
-    word: true
-
-  - trigger: "staro1"
-    replace: "starò"
-    word: true
-
-  - trigger: "staò"
-    replace: "starò"
-    word: true
-
-  - trigger: "staòr"
-    replace: "starò"
-    word: true
-
-  - trigger: "straò"
-    replace: "starò"
-    word: true
-
-  - trigger: "strò"
-    replace: "starò"
-    word: true
-
-  - trigger: "tsarò"
-    replace: "starò"
-    word: true
-
-  - trigger: "etrrai"
+  - triggers:
+    - "etrrai"
+    - "terai"
+    - "terari"
+    - "terri"
+    - "terria"
+    - "trerai"
+    - "trrai"
     replace: "terrai"
     propagate_case: true
     word: true
 
-  - trigger: "terai"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "terari"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "terri"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "terria"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trerai"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trrai"
-    replace: "terrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrranno"
+  - triggers:
+    - "etrranno"
+    - "teranno"
+    - "terarnno"
+    - "terrano"
+    - "terranon"
+    - "terrnano"
+    - "terrnno"
+    - "treranno"
+    - "trranno"
     replace: "terranno"
     propagate_case: true
     word: true
 
-  - trigger: "teranno"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "terarnno"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrano"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "terranon"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrnano"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrnno"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "treranno"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trranno"
-    replace: "terranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrremo"
+  - triggers:
+    - "etrremo"
+    - "teremo"
+    - "terermo"
+    - "terreo"
+    - "terreom"
+    - "terrmeo"
+    - "terrmo"
+    - "treremo"
+    - "trremo"
     replace: "terremo"
     propagate_case: true
     word: true
 
-  - trigger: "teremo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "terermo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "terreo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "terreom"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrmeo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrmo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "treremo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trremo"
-    replace: "terremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrrà"
+  - triggers:
+    - "etrrà"
+    - "terra"
+    - "terra'"
+    - "terra1"
+    - "terà"
+    - "teràr"
+    - "trerà"
+    - "trrà"
     replace: "terrà"
     word: true
 
-  - trigger: "terra"
-    replace: "terrà"
-    word: true
-
-  - trigger: "terra'"
-    replace: "terrà"
-    word: true
-
-  - trigger: "terra1"
-    replace: "terrà"
-    word: true
-
-  - trigger: "terà"
-    replace: "terrà"
-    word: true
-
-  - trigger: "teràr"
-    replace: "terrà"
-    word: true
-
-  - trigger: "trerà"
-    replace: "terrà"
-    word: true
-
-  - trigger: "trrà"
-    replace: "terrà"
-    word: true
-
-  - trigger: "etrrò"
+  - triggers:
+    - "etrrò"
+    - "terro"
+    - "terro'"
+    - "terro1"
+    - "terò"
+    - "teròr"
+    - "trerò"
+    - "trrò"
     replace: "terrò"
     word: true
 
-  - trigger: "terro"
-    replace: "terrò"
-    word: true
-
-  - trigger: "terro'"
-    replace: "terrò"
-    word: true
-
-  - trigger: "terro1"
-    replace: "terrò"
-    word: true
-
-  - trigger: "terò"
-    replace: "terrò"
-    word: true
-
-  - trigger: "teròr"
-    replace: "terrò"
-    word: true
-
-  - trigger: "trerò"
-    replace: "terrò"
-    word: true
-
-  - trigger: "trrò"
-    replace: "terrò"
-    word: true
-
-  - trigger: "otrnerai"
+  - triggers:
+    - "otrnerai"
+    - "tonerai"
+    - "tonrerai"
+    - "torenrai"
+    - "torerai"
+    - "torneai"
+    - "torneari"
+    - "torneri"
+    - "torneria"
+    - "tornrai"
+    - "tornreai"
+    - "trnerai"
+    - "tronerai"
     replace: "tornerai"
     propagate_case: true
     word: true
 
-  - trigger: "tonerai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "tonrerai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torenrai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torerai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneari"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneri"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneria"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornrai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornreai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnerai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "tronerai"
-    replace: "tornerai"
-    propagate_case: true
-    word: true
-
-  - trigger: "otrneranno"
+  - triggers:
+    - "otrneranno"
+    - "toneranno"
+    - "tonreranno"
+    - "torenranno"
+    - "toreranno"
+    - "torneanno"
+    - "tornearnno"
+    - "tornerano"
+    - "torneranon"
+    - "tornernano"
+    - "tornernno"
+    - "tornranno"
+    - "tornreanno"
+    - "trneranno"
+    - "troneranno"
     replace: "torneranno"
     propagate_case: true
     word: true
 
-  - trigger: "toneranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tonreranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "torenranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "toreranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneanno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornearnno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornerano"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneranon"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornernano"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornernno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornreanno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trneranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troneranno"
-    replace: "torneranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "otrneremo"
+  - triggers:
+    - "otrneremo"
+    - "toneremo"
+    - "tonreremo"
+    - "torenremo"
+    - "toreremo"
+    - "torneemo"
+    - "torneermo"
+    - "tornereo"
+    - "tornereom"
+    - "tornermeo"
+    - "tornermo"
+    - "tornreemo"
+    - "tornremo"
+    - "trneremo"
+    - "troneremo"
     replace: "torneremo"
     propagate_case: true
     word: true
 
-  - trigger: "toneremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tonreremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "torenremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "toreremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneemo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "torneermo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornereo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornereom"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornermeo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornermo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornreemo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trneremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "troneremo"
-    replace: "torneremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "otrnerà"
+  - triggers:
+    - "otrnerà"
+    - "tonerà"
+    - "tonrerà"
+    - "torenrà"
+    - "torerà"
+    - "tornera"
+    - "tornera'"
+    - "tornera1"
+    - "torneà"
+    - "torneàr"
+    - "tornreà"
+    - "tornrà"
+    - "trnerà"
+    - "tronerà"
     replace: "tornerà"
     word: true
 
-  - trigger: "tonerà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tonrerà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "torenrà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "torerà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tornera"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tornera'"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tornera1"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "torneà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "torneàr"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tornreà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tornrà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "trnerà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "tronerà"
-    replace: "tornerà"
-    word: true
-
-  - trigger: "otrnerò"
+  - triggers:
+    - "otrnerò"
+    - "tonerò"
+    - "tonrerò"
+    - "torenrò"
+    - "torerò"
+    - "tornero"
+    - "tornero'"
+    - "tornero1"
+    - "torneò"
+    - "torneòr"
+    - "tornreò"
+    - "tornrò"
+    - "trnerò"
+    - "tronerò"
     replace: "tornerò"
     word: true
 
-  - trigger: "tonerò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tonrerò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "torenrò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "torerò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tornero"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tornero'"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tornero1"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "torneò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "torneòr"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tornreò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tornrò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "trnerò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "tronerò"
-    replace: "tornerò"
-    word: true
-
-  - trigger: "rtoverai"
+  - triggers:
+    - "rtoverai"
+    - "torverai"
+    - "toverai"
+    - "troerai"
+    - "troevrai"
+    - "troveai"
+    - "troveari"
+    - "troveri"
+    - "troveria"
+    - "trovrai"
+    - "trovreai"
+    - "trverai"
+    - "trvoerai"
     replace: "troverai"
     propagate_case: true
     word: true
 
-  - trigger: "torverai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "toverai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troerai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troevrai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveari"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveri"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveria"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovrai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovreai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trverai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "trvoerai"
-    replace: "troverai"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtoveranno"
+  - triggers:
+    - "rtoveranno"
+    - "torveranno"
+    - "toveranno"
+    - "troeranno"
+    - "troevranno"
+    - "troveanno"
+    - "trovearnno"
+    - "troverano"
+    - "troveranon"
+    - "trovernano"
+    - "trovernno"
+    - "trovranno"
+    - "trovreanno"
+    - "trveranno"
+    - "trvoeranno"
     replace: "troveranno"
     propagate_case: true
     word: true
 
-  - trigger: "torveranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "toveranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troeranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troevranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveanno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovearnno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troverano"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveranon"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovernano"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovernno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovreanno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trveranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "trvoeranno"
-    replace: "troveranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtoveremo"
+  - triggers:
+    - "rtoveremo"
+    - "torveremo"
+    - "toveremo"
+    - "troeremo"
+    - "troevremo"
+    - "troveemo"
+    - "troveermo"
+    - "trovereo"
+    - "trovereom"
+    - "trovermeo"
+    - "trovermo"
+    - "trovreemo"
+    - "trovremo"
+    - "trveremo"
+    - "trvoeremo"
     replace: "troveremo"
     propagate_case: true
     word: true
 
-  - trigger: "torveremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "toveremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "troeremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "troevremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveemo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "troveermo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovereo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovereom"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovermeo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovermo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovreemo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trveremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trvoeremo"
-    replace: "troveremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtoverà"
+  - triggers:
+    - "rtoverà"
+    - "torverà"
+    - "toverà"
+    - "troerà"
+    - "troevrà"
+    - "trovera"
+    - "trovera'"
+    - "trovera1"
+    - "troveà"
+    - "troveàr"
+    - "trovreà"
+    - "trovrà"
+    - "trverà"
+    - "trvoerà"
     replace: "troverà"
     word: true
 
-  - trigger: "torverà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "toverà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "troerà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "troevrà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trovera"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trovera'"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trovera1"
-    replace: "troverà"
-    word: true
-
-  - trigger: "troveà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "troveàr"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trovreà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trovrà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trverà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "trvoerà"
-    replace: "troverà"
-    word: true
-
-  - trigger: "rtoverò"
+  - triggers:
+    - "rtoverò"
+    - "torverò"
+    - "toverò"
+    - "troerò"
+    - "troevrò"
+    - "trovero"
+    - "trovero'"
+    - "trovero1"
+    - "troveò"
+    - "troveòr"
+    - "trovreò"
+    - "trovrò"
+    - "trverò"
+    - "trvoerò"
     replace: "troverò"
     word: true
 
-  - trigger: "torverò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "toverò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "troerò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "troevrò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trovero"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trovero'"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trovero1"
-    replace: "troverò"
-    word: true
-
-  - trigger: "troveò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "troveòr"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trovreò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trovrò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trverò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "trvoerò"
-    replace: "troverò"
-    word: true
-
-  - trigger: "nuiversità"
+  - triggers:
+    - "nuiversità"
+    - "uinversità"
+    - "uiversità"
+    - "uniersità"
+    - "unievrsità"
+    - "univeristà"
+    - "univerità"
+    - "universita"
+    - "universita'"
+    - "universita1"
+    - "universià"
+    - "universiàt"
+    - "universtià"
+    - "universtà"
+    - "univesità"
+    - "univesrità"
+    - "univresità"
+    - "univrsità"
+    - "unversità"
+    - "unviersità"
     replace: "università"
     word: true
 
-  - trigger: "uinversità"
-    replace: "università"
-    word: true
-
-  - trigger: "uiversità"
-    replace: "università"
-    word: true
-
-  - trigger: "uniersità"
-    replace: "università"
-    word: true
-
-  - trigger: "unievrsità"
-    replace: "università"
-    word: true
-
-  - trigger: "univeristà"
-    replace: "università"
-    word: true
-
-  - trigger: "univerità"
-    replace: "università"
-    word: true
-
-  - trigger: "universita"
-    replace: "università"
-    word: true
-
-  - trigger: "universita'"
-    replace: "università"
-    word: true
-
-  - trigger: "universita1"
-    replace: "università"
-    word: true
-
-  - trigger: "universià"
-    replace: "università"
-    word: true
-
-  - trigger: "universiàt"
-    replace: "università"
-    word: true
-
-  - trigger: "universtià"
-    replace: "università"
-    word: true
-
-  - trigger: "universtà"
-    replace: "università"
-    word: true
-
-  - trigger: "univesità"
-    replace: "università"
-    word: true
-
-  - trigger: "univesrità"
-    replace: "università"
-    word: true
-
-  - trigger: "univresità"
-    replace: "università"
-    word: true
-
-  - trigger: "univrsità"
-    replace: "università"
-    word: true
-
-  - trigger: "unversità"
-    replace: "università"
-    word: true
-
-  - trigger: "unviersità"
-    replace: "università"
-    word: true
-
-  - trigger: "suerai"
+  - triggers:
+    - "suerai"
+    - "uerai"
+    - "uesrai"
+    - "useai"
+    - "useari"
+    - "useri"
+    - "useria"
+    - "usrai"
+    - "usreai"
     replace: "userai"
     propagate_case: true
     word: true
 
-  - trigger: "uerai"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "uesrai"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "useai"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "useari"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "useri"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "useria"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "usrai"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "usreai"
-    replace: "userai"
-    propagate_case: true
-    word: true
-
-  - trigger: "sueranno"
+  - triggers:
+    - "sueranno"
+    - "ueranno"
+    - "uesranno"
+    - "useanno"
+    - "usearnno"
+    - "userano"
+    - "useranon"
+    - "usernano"
+    - "usernno"
+    - "usranno"
+    - "usreanno"
     replace: "useranno"
     propagate_case: true
     word: true
 
-  - trigger: "ueranno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "uesranno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "useanno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "usearnno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "userano"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "useranon"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "usernano"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "usernno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "usranno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "usreanno"
-    replace: "useranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "sueremo"
+  - triggers:
+    - "sueremo"
+    - "ueremo"
+    - "uesremo"
+    - "useemo"
+    - "useermo"
+    - "usereo"
+    - "usereom"
+    - "usermeo"
+    - "usermo"
+    - "usreemo"
+    - "usremo"
     replace: "useremo"
     propagate_case: true
     word: true
 
-  - trigger: "ueremo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "uesremo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "useemo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "useermo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usereo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usereom"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usermeo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usermo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usreemo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "usremo"
-    replace: "useremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "suerà"
+  - triggers:
+    - "suerà"
+    - "uerà"
+    - "uesrà"
+    - "usera"
+    - "usera'"
+    - "usera1"
+    - "useà"
+    - "useàr"
+    - "usreà"
+    - "usrà"
     replace: "userà"
     word: true
 
-  - trigger: "uerà"
-    replace: "userà"
-    word: true
-
-  - trigger: "uesrà"
-    replace: "userà"
-    word: true
-
-  - trigger: "usera"
-    replace: "userà"
-    word: true
-
-  - trigger: "usera'"
-    replace: "userà"
-    word: true
-
-  - trigger: "usera1"
-    replace: "userà"
-    word: true
-
-  - trigger: "useà"
-    replace: "userà"
-    word: true
-
-  - trigger: "useàr"
-    replace: "userà"
-    word: true
-
-  - trigger: "usreà"
-    replace: "userà"
-    word: true
-
-  - trigger: "usrà"
-    replace: "userà"
-    word: true
-
-  - trigger: "suerò"
+  - triggers:
+    - "suerò"
+    - "uerò"
+    - "uesrò"
+    - "usero"
+    - "usero'"
+    - "usero1"
+    - "useò"
+    - "useòr"
+    - "usreò"
+    - "usrò"
     replace: "userò"
     word: true
 
-  - trigger: "uerò"
-    replace: "userò"
-    word: true
-
-  - trigger: "uesrò"
-    replace: "userò"
-    word: true
-
-  - trigger: "usero"
-    replace: "userò"
-    word: true
-
-  - trigger: "usero'"
-    replace: "userò"
-    word: true
-
-  - trigger: "usero1"
-    replace: "userò"
-    word: true
-
-  - trigger: "useò"
-    replace: "userò"
-    word: true
-
-  - trigger: "useòr"
-    replace: "userò"
-    word: true
-
-  - trigger: "usreò"
-    replace: "userò"
-    word: true
-
-  - trigger: "usrò"
-    replace: "userò"
-    word: true
-
-  - trigger: "tuilità"
+  - triggers:
+    - "tuilità"
+    - "uilità"
+    - "uitlità"
+    - "utiiltà"
+    - "utiità"
+    - "utilita"
+    - "utilita'"
+    - "utilita1"
+    - "utilià"
+    - "utiliàt"
+    - "utiltià"
+    - "utiltà"
+    - "utliità"
+    - "utlità"
     replace: "utilità"
     word: true
 
-  - trigger: "uilità"
-    replace: "utilità"
-    word: true
-
-  - trigger: "uitlità"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utiiltà"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utiità"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utilita"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utilita'"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utilita1"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utilià"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utiliàt"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utiltià"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utiltà"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utliità"
-    replace: "utilità"
-    word: true
-
-  - trigger: "utlità"
-    replace: "utilità"
-    word: true
-
-  - trigger: "evdrai"
+  - triggers:
+    - "evdrai"
+    - "vderai"
+    - "vdrai"
+    - "vedai"
+    - "vedari"
+    - "vedri"
+    - "vedria"
+    - "verai"
+    - "verdai"
     replace: "vedrai"
     propagate_case: true
     word: true
 
-  - trigger: "vderai"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vdrai"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedai"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedari"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedri"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedria"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verai"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verdai"
-    replace: "vedrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "evdranno"
+  - triggers:
+    - "evdranno"
+    - "vderanno"
+    - "vdranno"
+    - "vedanno"
+    - "vedarnno"
+    - "vedrano"
+    - "vedranon"
+    - "vedrnano"
+    - "vedrnno"
+    - "veranno"
+    - "verdanno"
     replace: "vedranno"
     propagate_case: true
     word: true
 
-  - trigger: "vderanno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vdranno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedanno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedarnno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedrano"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedranon"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedrnano"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedrnno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "veranno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verdanno"
-    replace: "vedranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "evdremo"
+  - triggers:
+    - "evdremo"
+    - "vderemo"
+    - "vdremo"
+    - "vedemo"
+    - "vedermo"
+    - "vedreo"
+    - "vedreom"
+    - "vedrmeo"
+    - "vedrmo"
+    - "verdemo"
+    - "veremo"
     replace: "vedremo"
     propagate_case: true
     word: true
 
-  - trigger: "vderemo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vdremo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedemo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedermo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedreo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedreom"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedrmeo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedrmo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verdemo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "veremo"
-    replace: "vedremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "evdrà"
+  - triggers:
+    - "evdrà"
+    - "vderà"
+    - "vdrà"
+    - "vedra"
+    - "vedra'"
+    - "vedra1"
+    - "vedà"
+    - "vedàr"
+    - "verdà"
+    - "verà"
     replace: "vedrà"
     word: true
 
-  - trigger: "vderà"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vdrà"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vedra"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vedra'"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vedra1"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vedà"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "vedàr"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "verdà"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "verà"
-    replace: "vedrà"
-    word: true
-
-  - trigger: "evdrò"
+  - triggers:
+    - "evdrò"
+    - "vderò"
+    - "vdrò"
+    - "vedro"
+    - "vedro'"
+    - "vedro1"
+    - "vedò"
+    - "vedòr"
+    - "verdò"
+    - "verò"
     replace: "vedrò"
     word: true
 
-  - trigger: "vderò"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vdrò"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vedro"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vedro'"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vedro1"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vedò"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "vedòr"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "verdò"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "verò"
-    replace: "vedrò"
-    word: true
-
-  - trigger: "evnerdì"
+  - triggers:
+    - "evnerdì"
+    - "veenrdì"
+    - "veerdì"
+    - "venedrì"
+    - "venedì"
+    - "venerdi"
+    - "venerdi'"
+    - "venerdi1"
+    - "venerì"
+    - "venerìd"
+    - "venrdì"
+    - "venredì"
+    - "vneerdì"
+    - "vnerdì"
     replace: "venerdì"
     word: true
 
-  - trigger: "veenrdì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "veerdì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venedrì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venedì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venerdi"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venerdi'"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venerdi1"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venerì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venerìd"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venrdì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "venredì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "vneerdì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "vnerdì"
-    replace: "venerdì"
-    word: true
-
-  - trigger: "evrificherai"
+  - triggers:
+    - "evrificherai"
+    - "veificherai"
+    - "veirficherai"
+    - "verficherai"
+    - "verfiicherai"
+    - "verifcherai"
+    - "verifciherai"
+    - "verificehrai"
+    - "verificerai"
+    - "verificheai"
+    - "verificheari"
+    - "verificheri"
+    - "verificheria"
+    - "verifichrai"
+    - "verifichreai"
+    - "verifihcerai"
+    - "verifiherai"
+    - "veriicherai"
+    - "veriifcherai"
+    - "vreificherai"
+    - "vrificherai"
     replace: "verificherai"
     propagate_case: true
     word: true
 
-  - trigger: "veificherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "veirficherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verficherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verfiicherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifcherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifciherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificehrai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificerai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheari"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheri"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheria"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichrai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichreai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifihcerai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifiherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriicherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriifcherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreificherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrificherai"
-    replace: "verificherai"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrificheranno"
+  - triggers:
+    - "evrificheranno"
+    - "veificheranno"
+    - "veirficheranno"
+    - "verficheranno"
+    - "verfiicheranno"
+    - "verifcheranno"
+    - "verifciheranno"
+    - "verificehranno"
+    - "verificeranno"
+    - "verificheanno"
+    - "verifichearnno"
+    - "verificherano"
+    - "verificheranon"
+    - "verifichernano"
+    - "verifichernno"
+    - "verifichranno"
+    - "verifichreanno"
+    - "verifihceranno"
+    - "verifiheranno"
+    - "veriicheranno"
+    - "veriifcheranno"
+    - "vreificheranno"
+    - "vrificheranno"
     replace: "verificheranno"
     propagate_case: true
     word: true
 
-  - trigger: "veificheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "veirficheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verficheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verfiicheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifcheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifciheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificehranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificeranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheanno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichearnno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificherano"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheranon"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichernano"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichernno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichreanno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifihceranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifiheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriicheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriifcheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreificheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrificheranno"
-    replace: "verificheranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrificheremo"
+  - triggers:
+    - "evrificheremo"
+    - "veificheremo"
+    - "veirficheremo"
+    - "verficheremo"
+    - "verfiicheremo"
+    - "verifcheremo"
+    - "verifciheremo"
+    - "verificehremo"
+    - "verificeremo"
+    - "verificheemo"
+    - "verificheermo"
+    - "verifichereo"
+    - "verifichereom"
+    - "verifichermeo"
+    - "verifichermo"
+    - "verifichreemo"
+    - "verifichremo"
+    - "verifihceremo"
+    - "verifiheremo"
+    - "veriicheremo"
+    - "veriifcheremo"
+    - "vreificheremo"
+    - "vrificheremo"
     replace: "verificheremo"
     propagate_case: true
     word: true
 
-  - trigger: "veificheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "veirficheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verficheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verfiicheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifcheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifciheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificehremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificeremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheemo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verificheermo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichereo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichereom"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichermeo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichermo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichreemo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifichremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifihceremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verifiheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriicheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "veriifcheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreificheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrificheremo"
-    replace: "verificheremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrificherà"
+  - triggers:
+    - "evrificherà"
+    - "veificherà"
+    - "veirficherà"
+    - "verficherà"
+    - "verfiicherà"
+    - "verifcherà"
+    - "verifciherà"
+    - "verificehrà"
+    - "verificerà"
+    - "verifichera"
+    - "verifichera'"
+    - "verifichera1"
+    - "verificheà"
+    - "verificheàr"
+    - "verifichreà"
+    - "verifichrà"
+    - "verifihcerà"
+    - "verifiherà"
+    - "veriicherà"
+    - "veriifcherà"
+    - "vreificherà"
+    - "vrificherà"
     replace: "verificherà"
     word: true
 
-  - trigger: "veificherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "veirficherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verficherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verfiicherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifcherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifciherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verificehrà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verificerà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifichera"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifichera'"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifichera1"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verificheà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verificheàr"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifichreà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifichrà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifihcerà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "verifiherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "veriicherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "veriifcherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "vreificherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "vrificherà"
-    replace: "verificherà"
-    word: true
-
-  - trigger: "evrificherò"
+  - triggers:
+    - "evrificherò"
+    - "veificherò"
+    - "veirficherò"
+    - "verficherò"
+    - "verfiicherò"
+    - "verifcherò"
+    - "verifciherò"
+    - "verificehrò"
+    - "verificerò"
+    - "verifichero"
+    - "verifichero'"
+    - "verifichero1"
+    - "verificheò"
+    - "verificheòr"
+    - "verifichreò"
+    - "verifichrò"
+    - "verifihcerò"
+    - "verifiherò"
+    - "veriicherò"
+    - "veriifcherò"
+    - "vreificherò"
+    - "vrificherò"
     replace: "verificherò"
     word: true
 
-  - trigger: "veificherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "veirficherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verficherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verfiicherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifcherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifciherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verificehrò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verificerò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifichero"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifichero'"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifichero1"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verificheò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verificheòr"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifichreò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifichrò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifihcerò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "verifiherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "veriicherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "veriifcherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "vreificherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "vrificherò"
-    replace: "verificherò"
-    word: true
-
-  - trigger: "evrrai"
+  - triggers:
+    - "evrrai"
+    - "verari"
+    - "verri"
+    - "verria"
+    - "vrerai"
+    - "vrrai"
     replace: "verrai"
     propagate_case: true
     word: true
 
-  - trigger: "verari"
-    replace: "verrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verri"
-    replace: "verrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "verria"
-    replace: "verrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrerai"
-    replace: "verrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrrai"
-    replace: "verrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrranno"
+  - triggers:
+    - "evrranno"
+    - "verarnno"
+    - "verrano"
+    - "verranon"
+    - "verrnano"
+    - "verrnno"
+    - "vreranno"
+    - "vrranno"
     replace: "verranno"
     propagate_case: true
     word: true
 
-  - trigger: "verarnno"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verrano"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verranon"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verrnano"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "verrnno"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreranno"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrranno"
-    replace: "verranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrremo"
+  - triggers:
+    - "evrremo"
+    - "verermo"
+    - "verreo"
+    - "verreom"
+    - "verrmeo"
+    - "verrmo"
+    - "vreremo"
+    - "vrremo"
     replace: "verremo"
     propagate_case: true
     word: true
 
-  - trigger: "verermo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verreo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verreom"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verrmeo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "verrmo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreremo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrremo"
-    replace: "verremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrrà"
+  - triggers:
+    - "evrrà"
+    - "verra"
+    - "verra'"
+    - "verra1"
+    - "veràr"
+    - "vrerà"
+    - "vrrà"
     replace: "verrà"
     word: true
 
-  - trigger: "verra"
-    replace: "verrà"
-    word: true
-
-  - trigger: "verra'"
-    replace: "verrà"
-    word: true
-
-  - trigger: "verra1"
-    replace: "verrà"
-    word: true
-
-  - trigger: "veràr"
-    replace: "verrà"
-    word: true
-
-  - trigger: "vrerà"
-    replace: "verrà"
-    word: true
-
-  - trigger: "vrrà"
-    replace: "verrà"
-    word: true
-
-  - trigger: "evrrò"
+  - triggers:
+    - "evrrò"
+    - "verro"
+    - "verro'"
+    - "verro1"
+    - "veròr"
+    - "vrerò"
+    - "vrrò"
     replace: "verrò"
     word: true
 
-  - trigger: "verro"
-    replace: "verrò"
-    word: true
-
-  - trigger: "verro'"
-    replace: "verrò"
-    word: true
-
-  - trigger: "verro1"
-    replace: "verrò"
-    word: true
-
-  - trigger: "veròr"
-    replace: "verrò"
-    word: true
-
-  - trigger: "vrerò"
-    replace: "verrò"
-    word: true
-
-  - trigger: "vrrò"
-    replace: "verrò"
-    word: true
-
-  - trigger: "ovrrai"
+  - triggers:
+    - "ovrrai"
+    - "vorai"
+    - "vorari"
+    - "vorri"
+    - "vorria"
+    - "vrorai"
     replace: "vorrai"
     propagate_case: true
     word: true
 
-  - trigger: "vorai"
-    replace: "vorrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorari"
-    replace: "vorrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorri"
-    replace: "vorrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorria"
-    replace: "vorrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrorai"
-    replace: "vorrai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovrranno"
+  - triggers:
+    - "ovrranno"
+    - "voranno"
+    - "vorarnno"
+    - "vorrano"
+    - "vorranon"
+    - "vorrnano"
+    - "vorrnno"
+    - "vroranno"
     replace: "vorranno"
     propagate_case: true
     word: true
 
-  - trigger: "voranno"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorarnno"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorrano"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorranon"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorrnano"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorrnno"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vroranno"
-    replace: "vorranno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovrremo"
+  - triggers:
+    - "ovrremo"
+    - "voremo"
+    - "vorermo"
+    - "vorreo"
+    - "vorreom"
+    - "vorrmeo"
+    - "vorrmo"
+    - "vroremo"
     replace: "vorremo"
     propagate_case: true
     word: true
 
-  - trigger: "voremo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorermo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorreo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorreom"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorrmeo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vorrmo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vroremo"
-    replace: "vorremo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovrrà"
+  - triggers:
+    - "ovrrà"
+    - "vorra"
+    - "vorra'"
+    - "vorra1"
+    - "vorà"
+    - "voràr"
+    - "vrorà"
     replace: "vorrà"
     word: true
 
-  - trigger: "vorra"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "vorra'"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "vorra1"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "vorà"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "voràr"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "vrorà"
-    replace: "vorrà"
-    word: true
-
-  - trigger: "ovrrò"
+  - triggers:
+    - "ovrrò"
+    - "vorro"
+    - "vorro'"
+    - "vorro1"
+    - "vorò"
+    - "voròr"
+    - "vrorò"
     replace: "vorrò"
     word: true
 
-  - trigger: "vorro"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "vorro'"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "vorro1"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "vorò"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "voròr"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "vrorò"
-    replace: "vorrò"
-    word: true
-
-  - trigger: "uvlnerabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vlnerabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vlunerabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulenrabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulerabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulneabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnearbilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabiiltà"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabiità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabilita"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabilita'"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabilita1"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabilià"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabiliàt"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabiltià"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabiltà"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerabliità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerablità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulneraiblità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerailità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerbailità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnerbilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnrabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vulnreabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vunerabilità"
-    replace: "vulnerabilità"
-    word: true
-
-  - trigger: "vunlerabilità"
+  - triggers:
+    - "uvlnerabilità"
+    - "vlnerabilità"
+    - "vlunerabilità"
+    - "vulenrabilità"
+    - "vulerabilità"
+    - "vulneabilità"
+    - "vulnearbilità"
+    - "vulnerabiiltà"
+    - "vulnerabiità"
+    - "vulnerabilita"
+    - "vulnerabilita'"
+    - "vulnerabilita1"
+    - "vulnerabilià"
+    - "vulnerabiliàt"
+    - "vulnerabiltià"
+    - "vulnerabiltà"
+    - "vulnerabliità"
+    - "vulnerablità"
+    - "vulneraiblità"
+    - "vulnerailità"
+    - "vulnerbailità"
+    - "vulnerbilità"
+    - "vulnrabilità"
+    - "vulnreabilità"
+    - "vunerabilità"
+    - "vunlerabilità"
     replace: "vulnerabilità"
     word: true
 
   # Short accented words (too short for the auto-generator)
-  - trigger: "e'"
+  - triggers:
+    - "e'"
+    - "e1"
     replace: "è"
     word: true
 
-  - trigger: "e1"
-    replace: "è"
-    word: true
-
-  - trigger: "si'"
+  - triggers:
+    - "si'"
+    - "si1"
     replace: "sì"
     word: true
 
-  - trigger: "si1"
-    replace: "sì"
-    word: true
-
-  - trigger: "la'"
+  - triggers:
+    - "la'"
+    - "la1"
     replace: "là"
     word: true
 
-  - trigger: "la1"
-    replace: "là"
-    word: true
-
-  - trigger: "li'"
-    replace: "lì"
-    word: true
-
-  - trigger: "li1"
+  - triggers:
+    - "li'"
+    - "li1"
     replace: "lì"
     word: true

--- a/packages/refuos-dev/0.1.0/README.md
+++ b/packages/refuos-dev/0.1.0/README.md
@@ -1,0 +1,26 @@
+# Refuos Dev
+
+Real-time autocorrection for tech and code terms, powered by [Espanso](https://espanso.org).
+
+## What it fixes
+
+Common typos in language keywords, HTML, CSS, design patterns, paradigms,
+Git, DevOps tools, Python, and infrastructure — for example:
+
+| You type       | Corrected to   |
+|----------------|----------------|
+| `cosnt`        | `const`        |
+| `reutrn`       | `return`       |
+| `ipmort`       | `import`       |
+| `dockerfiel`   | `dockerfile`   |
+| `migraiton`    | `migration`    |
+| `Kuberentes`   | `Kubernetes`   |
+
+Framework-agnostic: works for JavaScript, TypeScript, Python, Go, Java,
+and any other stack. For framework-specific terms (React hooks, Vue
+Composition API, NestJS decorators, Django ORM, etc.) use a local
+dictionary — see `dictionaries/local/README.md`.
+
+## Source
+
+<https://github.com/heavybeard/refuos>

--- a/packages/refuos-dev/0.1.0/README.md
+++ b/packages/refuos-dev/0.1.0/README.md
@@ -19,7 +19,8 @@ Git, DevOps tools, Python, and infrastructure — for example:
 Framework-agnostic: works for JavaScript, TypeScript, Python, Go, Java,
 and any other stack. For framework-specific terms (React hooks, Vue
 Composition API, NestJS decorators, Django ORM, etc.) use a local
-dictionary — see `dictionaries/local/README.md`.
+dictionary — see the [project repository](https://github.com/heavybeard/refuos)
+for documentation on local dictionaries.
 
 ## Source
 

--- a/packages/refuos-dev/0.1.0/_manifest.yml
+++ b/packages/refuos-dev/0.1.0/_manifest.yml
@@ -1,0 +1,7 @@
+name: "refuos-dev"
+title: "Refuos Dev"
+description: "Autocorrection for tech and code terms: HTML, CSS, patterns, paradigms, Git, DevOps, Python and more. Fixes cosnt→const, reutrn→return."
+version: "0.1.0"
+author: "Andrea Cognini"
+tags: ["dev", "autocorrect", "code", "html", "css", "git", "devops", "python", "patterns", "architecture"]
+homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-dev/0.1.0/_manifest.yml
+++ b/packages/refuos-dev/0.1.0/_manifest.yml
@@ -3,5 +3,5 @@ title: "Refuos Dev"
 description: "Autocorrection for tech and code terms: HTML, CSS, patterns, paradigms, Git, DevOps, Python and more. Fixes cosnt→const, reutrn→return."
 version: "0.1.0"
 author: "Andrea Cognini"
-tags: ["dev", "autocorrect", "code", "html", "css", "git", "devops", "python", "patterns", "architecture"]
+tags: ["dev", "autocorrect", "code", "html", "css", "git", "devops", "python", "patterns", "architecture", "spell-correction", "typofixer"]
 homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-dev/0.1.0/package.yml
+++ b/packages/refuos-dev/0.1.0/package.yml
@@ -1,0 +1,15891 @@
+# Refuos - Dev
+# Tech and code terms: HTML, CSS, patterns, paradigms, Git, DevOps, Python and more
+# https://github.com/heavybeard/refuos
+# Auto-generated - regenerate with: python3 generate_espanso.py
+
+matches:
+
+  - trigger: "absraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "absrtaction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstaction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstarction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstracion"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstraciton"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstractin"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstractino"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstractoin"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstracton"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstratcion"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstration"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstrcation"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abstrction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abtraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "abtsraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "asbtraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "astraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "bastraction"
+    replace: "abstraction"
+    propagate_case: true
+    word: true
+
+  - trigger: "accesibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accesisbility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessbiility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessbility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibiilty"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibiity"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibiliy"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibiliyt"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibiltiy"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibilty"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessibliity"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessiblity"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessiiblity"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accessiility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accsesibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "accssibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "acecssibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "acessibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "cacessibility"
+    replace: "accessibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "aadpter"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "aapter"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adaper"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adapetr"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adaptr"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adaptre"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adater"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adatper"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adpater"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "adpter"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "daapter"
+    replace: "adapter"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggegate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggergate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggreagte"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggreate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggregae"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggregaet"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggregtae"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggregte"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggrgate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggrgeate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "agregate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "agrgegate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagregate"
+    replace: "aggregate"
+    propagate_case: true
+    word: true
+
+  - trigger: "achor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "acnhor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "anchr"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "anchro"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancohr"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "anhcor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "anhor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "nachor"
+    replace: "anchor"
+    propagate_case: true
+    word: true
+
+  - trigger: "aimation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "ainmation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "aniamtion"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "aniation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animaion"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animaiton"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animatin"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animatino"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animatoin"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animaton"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animtaion"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "animtion"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "anmation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "anmiation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "naimation"
+    replace: "animation"
+    propagate_case: true
+    word: true
+
+  - trigger: "agrument"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "agument"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argment"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argmuent"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "arguemnt"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "arguent"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argumet"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argumetn"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argumnet"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "argumnt"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "arugment"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "arument"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "ragument"
+    replace: "argument"
+    propagate_case: true
+    word: true
+
+  - trigger: "asert"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "asesrt"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "asset"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "assetr"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "assret"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "assrt"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "sasert"
+    replace: "assert"
+    propagate_case: true
+    word: true
+
+  - trigger: "asnc"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "asnyc"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "asyc"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "asycn"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "aync"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "aysnc"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "saync"
+    replace: "async"
+    propagate_case: true
+    word: true
+
+  - trigger: "asnchronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asnychronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asychronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asycnhronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchonous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchornous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchrnoous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchrnous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchronos"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchronosu"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchronuos"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchronus"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchroonus"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynchroous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asyncrhonous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asyncronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynhcronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "asynhronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "aynchronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "aysnchronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "saynchronous"
+    replace: "asynchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "atribute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "atrtibute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attibute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attirbute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attrbiute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attrbute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attribte"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attribtue"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attribue"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attribuet"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attriubte"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "attriute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "tatribute"
+    replace: "attribute"
+    propagate_case: true
+    word: true
+
+  - trigger: "atocomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "atuocomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "auocomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "auotcomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autcomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autcoomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocmoplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocmplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocomlete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocomlpete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocompelte"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocompete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocomplee"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocompleet"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocomplte"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocompltee"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocoplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autocopmlete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autoocmplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "autoomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "uatocomplete"
+    replace: "autocomplete"
+    propagate_case: true
+    word: true
+
+  - trigger: "atofocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "atuofocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "auofocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "auotfocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autfocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autfoocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofcous"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofcus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofocs"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofocsu"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofoucs"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autofous"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autoocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "autoofcus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "uatofocus"
+    replace: "autofocus"
+    propagate_case: true
+    word: true
+
+  - trigger: "aatar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "aavtar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avaar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avaatr"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avatr"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avatra"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avtaar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "avtar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "vaatar"
+    replace: "avatar"
+    propagate_case: true
+    word: true
+
+  - trigger: "aait"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "aawit"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "awat"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "awati"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "awiat"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "awit"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "waait"
+    replace: "await"
+    propagate_case: true
+    word: true
+
+  - trigger: "abckground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bacgkround"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bacground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgorund"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgound"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgrond"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgronud"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgroud"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgroudn"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgrund"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backgruond"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backrgound"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "backround"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bakcground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bakground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bcakground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "bckground"
+    replace: "background"
+    propagate_case: true
+    word: true
+
+  - trigger: "abcklog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "backlg"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "backlgo"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "backog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "backolg"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "baclkog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "baclog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "bakclog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "baklog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "bcaklog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "bcklog"
+    replace: "backlog"
+    propagate_case: true
+    word: true
+
+  - trigger: "abdge"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bade"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "badeg"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bagde"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bage"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bdage"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bdge"
+    replace: "badge"
+    propagate_case: true
+    word: true
+
+  - trigger: "bolean"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boloean"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "booean"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "booelan"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boolaen"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boolan"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boolen"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boolena"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "obolean"
+    replace: "boolean"
+    propagate_case: true
+    word: true
+
+  - trigger: "boder"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "bodrer"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "bordr"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "bordre"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "boredr"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "borer"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "brder"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "broder"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "obrder"
+    replace: "border"
+    propagate_case: true
+    word: true
+
+  - trigger: "banch"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "barnch"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "brach"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "bracnh"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "branh"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "branhc"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "brnach"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "brnch"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbanch"
+    replace: "branch"
+    propagate_case: true
+    word: true
+
+  - trigger: "beadcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "beradcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "bradcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "braedcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breacdrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breacrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcrmb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcrmub"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcrub"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcrubm"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadcurmb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadrcumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "breadrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "bredacrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "bredcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbeadcrumb"
+    replace: "breadcrumb"
+    propagate_case: true
+    word: true
+
+  - trigger: "beakpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "berakpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "braekpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "brakpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakopint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakpint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakpiont"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakpoit"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakpoitn"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakponit"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breakpont"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breapkoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "breapoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "brekapoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "brekpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbeakpoint"
+    replace: "breakpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "bild"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "biuld"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "buid"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "buidl"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "buld"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "bulid"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubild"
+    replace: "build"
+    propagate_case: true
+    word: true
+
+  - trigger: "btton"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "btuton"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "buton"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "butotn"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "buttn"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "buttno"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubtton"
+    replace: "button"
+    propagate_case: true
+    word: true
+
+  - trigger: "acllback"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "calback"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "calblack"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callabck"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callack"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callbak"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callbakc"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callbcak"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "callbck"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "clalback"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "cllback"
+    replace: "callback"
+    propagate_case: true
+    word: true
+
+  - trigger: "acrd"
+    replace: "card"
+    propagate_case: true
+    word: true
+
+  - trigger: "cadr"
+    replace: "card"
+    propagate_case: true
+    word: true
+
+  - trigger: "crad"
+    replace: "card"
+    propagate_case: true
+    word: true
+
+  - trigger: "acrousel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "caorusel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "caousel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carosel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carosuel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carouel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carouesl"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carousl"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carousle"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "caruosel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "carusel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "craousel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "crousel"
+    replace: "carousel"
+    propagate_case: true
+    word: true
+
+  - trigger: "acscade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cacade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cacsade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "casacde"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "casade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cascae"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cascaed"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cascdae"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cascde"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "csacade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "cscade"
+    replace: "cascade"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceckbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "cehckbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "chcekbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "chckbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checbkox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkbx"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkbxo"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkobx"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "chekbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "chekcbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "hceckbox"
+    replace: "checkbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceckout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "cehckout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "chcekout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "chckout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkot"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkotu"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkuot"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checkut"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checokut"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "checout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "chekcout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "chekout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "hceckout"
+    replace: "checkout"
+    propagate_case: true
+    word: true
+
+  - trigger: "clne"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "clnoe"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloe"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloen"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "colne"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "cone"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "lcone"
+    replace: "clone"
+    propagate_case: true
+    word: true
+
+  - trigger: "closre"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "closrue"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "closue"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "closuer"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "clousre"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "clsoure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "clsure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "colsure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "cosure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "lcosure"
+    replace: "closure"
+    propagate_case: true
+    word: true
+
+  - trigger: "clodflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloduflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudfalre"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudfare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudflae"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudflaer"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudflrae"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudflre"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudlare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloudlfare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloufdlare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "clouflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cludflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cluodflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "coludflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "coudflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lcoudflare"
+    replace: "cloudflare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cloor"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "clor"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "colr"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "colro"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "coolr"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "coor"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "oclor"
+    replace: "color"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmmit"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmomit"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "comimt"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "comit"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "commt"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "commti"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmmit"
+    replace: "commit"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmoponent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmponent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "comonent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "comopnent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "compnent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "compnoent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "compoennt"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "compoent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "componet"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "componetn"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "componnet"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "componnt"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "copmonent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "coponent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmponent"
+    replace: "component"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmoposition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmposition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "comopsition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "comosition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compoistion"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compoition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "composiion"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "composiiton"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compositin"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compositino"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compositoin"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compositon"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compostiion"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compostion"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compsition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "compsoition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "copmosition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "coposition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmposition"
+    replace: "composition"
+    propagate_case: true
+    word: true
+
+  - trigger: "cncurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnocurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "cocnurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "cocurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concrrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concrurency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurerncy"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurrecny"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurrecy"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurreny"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurrenyc"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurrncy"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "concurrnecy"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "conucrrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "conurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocncurrency"
+    replace: "concurrency"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnfig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnofig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofnig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "confg"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "confgi"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "conifg"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "conig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnfig"
+    replace: "config"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnfiguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnofiguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofiguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofniguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "confgiuration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "confguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configruation"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuartion"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuation"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuraion"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuraiton"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuratin"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuratino"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuratoin"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configuraton"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configurtaion"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "configurtion"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "confiugration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "confiuration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "conifguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "coniguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnfiguration"
+    replace: "configuration"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnflict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnoflict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "coflict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "cofnlict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "confict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "confilct"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conflcit"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conflct"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conflit"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conflitc"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conlfict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "conlict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnflict"
+    replace: "conflict"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnost"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnst"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "cont"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "conts"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "cosnt"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "cost"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnst"
+    replace: "const"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnostructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnstructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "consrtuctor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "consructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "constrctor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "constrcutor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "construcor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "construcotr"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "constructr"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "constructro"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "construtcor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "construtor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "constuctor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "consturctor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "contructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "contsructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cosntructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "costructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnstructor"
+    replace: "constructor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnotainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "cntainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "conainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "conatiner"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "contaienr"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "contaier"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "containr"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "containre"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "contaner"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "contanier"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "contianer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "continer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotnainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocntainer"
+    replace: "container"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnotenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "cntenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "conenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "conetnteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "conteneditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenetditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentdeitable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentediable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentediatble"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditabe"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditabel"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditalbe"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditale"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditbale"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteditble"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentedtable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contentedtiable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteidtable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contenteitable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "conteteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contetneditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contneteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "contnteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotnenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocntenteditable"
+    replace: "contenteditable"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnotroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "cntroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "conroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "conrtoller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "contoller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "contorller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "contrller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "contrloler"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "controlelr"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "controler"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "controllr"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "controllre"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotnroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocntroller"
+    replace: "controller"
+    propagate_case: true
+    word: true
+
+  - trigger: "coorutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "cooutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "corotine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "corotuine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "corouine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "corouitne"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coroutie"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coroutien"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coroutne"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coroutnie"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coruotine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "corutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "crooutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "croutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocroutine"
+    replace: "coroutine"
+    propagate_case: true
+    word: true
+
+  - trigger: "coerage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "coevrage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "coveage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "covearge"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "coverae"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "coveraeg"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "covergae"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "coverge"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "covrage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "covreage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "cverage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "cvoerage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocverage"
+    replace: "coverage"
+    propagate_case: true
+    word: true
+
+  - trigger: "crsor"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "crusor"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "curor"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "curosr"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cursr"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cursro"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cusor"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "cusror"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "ucrsor"
+    replace: "cursor"
+    propagate_case: true
+    word: true
+
+  - trigger: "adshboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dahboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dahsboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dasbhoard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dasboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashbaord"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashbard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashboad"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashboadr"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashborad"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashbord"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashoard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dashobard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsahboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "dshboard"
+    replace: "dashboard"
+    propagate_case: true
+    word: true
+
+  - trigger: "adta"
+    replace: "data"
+    propagate_case: true
+    word: true
+
+  - trigger: "daat"
+    replace: "data"
+    propagate_case: true
+    word: true
+
+  - trigger: "dtaa"
+    replace: "data"
+    propagate_case: true
+    word: true
+
+  - trigger: "adtabase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "daabase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "daatbase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "dataabse"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "dataase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "databae"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "databaes"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "databsae"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "databse"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "datbaase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "datbase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "dtaabase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "dtabase"
+    replace: "database"
+    propagate_case: true
+    word: true
+
+  - trigger: "dadlock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "daedlock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadlck"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadlcok"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadlok"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadlokc"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "deadolck"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "dealdock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "dealock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "dedalock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "dedlock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "edadlock"
+    replace: "deadlock"
+    propagate_case: true
+    word: true
+
+  - trigger: "dbeounce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "dbounce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debonce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debonuce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debouce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "deboucne"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "deboune"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debounec"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debunce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "debuonce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "deobunce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "deounce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "edbounce"
+    replace: "debounce"
+    propagate_case: true
+    word: true
+
+  - trigger: "dbeug"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "dbug"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "debg"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "debgu"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "deubg"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "deug"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "edbug"
+    replace: "debug"
+    propagate_case: true
+    word: true
+
+  - trigger: "dceorator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcorator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoartor"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoraor"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoraotr"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoratr"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decoratro"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decortaor"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decortor"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decrator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "decroator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "deocrator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "deorator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "edcorator"
+    replace: "decorator"
+    propagate_case: true
+    word: true
+
+  - trigger: "deendency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "deepndency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depedency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depednency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependecny"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependecy"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependeny"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependenyc"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependncy"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dependnecy"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depenedncy"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depenency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depndency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "depnedency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dpeendency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "dpendency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "edpendency"
+    replace: "dependency"
+    propagate_case: true
+    word: true
+
+  - trigger: "deloy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "delpoy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "deply"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "deplyo"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "depoly"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "depoy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "dpeloy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "dploy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "edploy"
+    replace: "deploy"
+    propagate_case: true
+    word: true
+
+  - trigger: "deloyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "delpoyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deploment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deplomyent"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deployemnt"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deployent"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deploymet"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deploymetn"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deploymnet"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deploymnt"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deplyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "deplyoment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "depolyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "depoyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "dpeloyment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "dployment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "edployment"
+    replace: "deployment"
+    propagate_case: true
+    word: true
+
+  - trigger: "decribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "decsribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descibe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descirbe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrbe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrbie"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrie"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrieb"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "desrcibe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "desribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "dscribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsecribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "edscribe"
+    replace: "describe"
+    propagate_case: true
+    word: true
+
+  - trigger: "decriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "decsriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "desciptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descirptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descripor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descripotr"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descriptr"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descriptro"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descritor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descritpor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrpitor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "descrptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "desrciptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "desriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "dscriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsecriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "edscriptor"
+    replace: "descriptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "deerialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deesrialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deseialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deseiralization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserailization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deseralization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deseriailzation"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deseriaization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserialiation"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserialiaztion"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializaion"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializaiton"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializatin"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializatino"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializatoin"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializaton"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializtaion"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserializtion"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserialzation"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserialziation"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserilaization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deserilization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "desreialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "desrialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "dseerialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "dserialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "edserialization"
+    replace: "deserialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "deign"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "deisgn"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "desgin"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "desgn"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "desin"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "desing"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "dseign"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsign"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "edsign"
+    replace: "design"
+    propagate_case: true
+    word: true
+
+  - trigger: "diective"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "dierctive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "dircetive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "dirctive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "direcitve"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "direcive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "directie"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "directiev"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "directve"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "directvie"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "diretcive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "diretive"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "drective"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "driective"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "idrective"
+    replace: "directive"
+    propagate_case: true
+    word: true
+
+  - trigger: "diplay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dipslay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dislay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dislpay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispaly"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "disply"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "displya"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsiplay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsplay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "idsplay"
+    replace: "display"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcker"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcoker"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "docekr"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "docer"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "dockr"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "dockre"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "dokcer"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "doker"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "odcker"
+    replace: "docker"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcostring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcstring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docsring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docsrting"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docsting"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docstirng"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docstrig"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docstrign"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docstrng"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "docstrnig"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctsring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "dosctring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "dostring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "odcstring"
+    replace: "docstring"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcotype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "dctype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctpe"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctpye"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctye"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "doctyep"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "docype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "docytpe"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "dotcype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "dotype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "odctype"
+    replace: "doctype"
+    propagate_case: true
+    word: true
+
+  - trigger: "dopdown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorpdown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "drodown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "drodpown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropdon"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropdonw"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropdwn"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropdwon"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropodwn"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "dropown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "drpdown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "drpodown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "rdopdown"
+    replace: "dropdown"
+    propagate_case: true
+    word: true
+
+  - trigger: "aesing"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "eaing"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "eaisng"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "easig"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "easign"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "easng"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "easnig"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "esaing"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "esing"
+    replace: "easing"
+    propagate_case: true
+    word: true
+
+  - trigger: "ealsticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "easticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasicsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasitcsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elastcisearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elastcsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticesarch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticsaerch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticsarch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticseach"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticseacrh"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticsearh"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticsearhc"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticserach"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elasticserch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elastiscearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elastisearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elaticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elatsicsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elsaticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "elsticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "leasticsearch"
+    replace: "elasticsearch"
+    propagate_case: true
+    word: true
+
+  - trigger: "eelment"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "eement"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "eleemnt"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "eleent"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elemet"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elemetn"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elemnet"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elemnt"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elmeent"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "elment"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "leement"
+    replace: "element"
+    propagate_case: true
+    word: true
+
+  - trigger: "ecapsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "ecnapsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "enacpsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "enapsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapslation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsluation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsualtion"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsuation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulaion"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulaiton"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulatin"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulatino"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulatoin"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsulaton"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsultaion"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapsultion"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encapuslation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encaspulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encasulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encpasulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "encpsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "necapsulation"
+    replace: "encapsulation"
+    propagate_case: true
+    word: true
+
+  - trigger: "ednpoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "edpoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endopint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endpint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endpiont"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endpoit"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endpoitn"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endponit"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "endpont"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "enpdoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "enpoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "nedpoint"
+    replace: "endpoint"
+    propagate_case: true
+    word: true
+
+  - trigger: "enironment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "enivronment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "envionment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "enviornment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "envirnment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "envirnoment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "enviroment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "enviromnent"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environemnt"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environent"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environmet"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environmetn"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environmnet"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "environmnt"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "envrionment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "envronment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "evironment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "evnironment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "nevironment"
+    replace: "environment"
+    propagate_case: true
+    word: true
+
+  - trigger: "eror"
+    replace: "error"
+    propagate_case: true
+    word: true
+
+  - trigger: "erorr"
+    replace: "error"
+    propagate_case: true
+    word: true
+
+  - trigger: "errr"
+    replace: "error"
+    propagate_case: true
+    word: true
+
+  - trigger: "errro"
+    replace: "error"
+    propagate_case: true
+    word: true
+
+  - trigger: "reror"
+    replace: "error"
+    propagate_case: true
+    word: true
+
+  - trigger: "elint"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "elsint"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "esilnt"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "esint"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslit"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslitn"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslnit"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslnt"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "selint"
+    replace: "eslint"
+    propagate_case: true
+    word: true
+
+  - trigger: "eception"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "ecxeption"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excepion"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excepiton"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "exceptin"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "exceptino"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "exceptoin"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excepton"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excetion"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excetpion"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excpetion"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "excption"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "execption"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "exeption"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "xeception"
+    replace: "exception"
+    propagate_case: true
+    word: true
+
+  - trigger: "epect"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "epxect"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "exect"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "exepct"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "expcet"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "expct"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "expet"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "expetc"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "xepect"
+    replace: "expect"
+    propagate_case: true
+    word: true
+
+  - trigger: "eport"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "epxort"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "exoprt"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "exort"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "expot"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "expotr"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "exprot"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "exprt"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "xeport"
+    replace: "export"
+    propagate_case: true
+    word: true
+
+  - trigger: "afcade"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "faacde"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "faade"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "facae"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "facaed"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "facdae"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "facde"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcaade"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcade"
+    replace: "facade"
+    propagate_case: true
+    word: true
+
+  - trigger: "afctory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "facory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "facotry"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "factoy"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "factoyr"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "factroy"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "factry"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "fatcory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "fatory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcatory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "fctory"
+    replace: "factory"
+    propagate_case: true
+    word: true
+
+  - trigger: "afvicon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "faicon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "faivcon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "favcion"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "favcon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "favicn"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "favicno"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "faviocn"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "favion"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "fvaicon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "fvicon"
+    replace: "favicon"
+    propagate_case: true
+    word: true
+
+  - trigger: "eftch"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "fech"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "fecth"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "feth"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "fethc"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "ftch"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "ftech"
+    replace: "fetch"
+    propagate_case: true
+    word: true
+
+  - trigger: "feildset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "feldset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiedlset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiedset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fieldest"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fieldet"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fieldst"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fieldste"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fielsdet"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fielset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fildset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "filedset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifeldset"
+    replace: "fieldset"
+    propagate_case: true
+    word: true
+
+  - trigger: "fgcaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "fgicaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "ficaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "ficgaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figacption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcapion"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcapiton"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcaptin"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcaptino"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcaptoin"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcapton"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcation"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcatpion"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcpation"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "figcption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifgcaption"
+    replace: "figcaption"
+    propagate_case: true
+    word: true
+
+  - trigger: "filer"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "filetr"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "filtr"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "filtre"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiter"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "fitler"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "fliter"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "flter"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "iflter"
+    replace: "filter"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiture"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fitxure"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixtre"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixtrue"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixtue"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixtuer"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixure"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fixutre"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fxiture"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "fxture"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifxture"
+    replace: "fixture"
+    propagate_case: true
+    word: true
+
+  - trigger: "felx"
+    replace: "flex"
+    propagate_case: true
+    word: true
+
+  - trigger: "flxe"
+    replace: "flex"
+    propagate_case: true
+    word: true
+
+  - trigger: "lfex"
+    replace: "flex"
+    propagate_case: true
+    word: true
+
+  - trigger: "felxbox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "fexbox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flebox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flebxox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flexbx"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flexbxo"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flexobx"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flexox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flxbox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "flxebox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "lfexbox"
+    replace: "flexbox"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnot"
+    replace: "font"
+    propagate_case: true
+    word: true
+
+  - trigger: "fotn"
+    replace: "font"
+    propagate_case: true
+    word: true
+
+  - trigger: "ofnt"
+    replace: "font"
+    propagate_case: true
+    word: true
+
+  - trigger: "fooer"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "fooetr"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "footr"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "footre"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "foter"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "fotoer"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "ofoter"
+    replace: "footer"
+    propagate_case: true
+    word: true
+
+  - trigger: "foeground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foerground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregorund"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregound"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregrond"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregronud"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregroud"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregroudn"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregrund"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foregruond"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "forergound"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "foreround"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "forgeround"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "forground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "freground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "froeground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "ofreground"
+    replace: "foreground"
+    propagate_case: true
+    word: true
+
+  - trigger: "famework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "farmework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraemwork"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "frameork"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "frameowrk"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framewok"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framewokr"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framewrk"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framewrok"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framweork"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "framwork"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "frmaework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "frmework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfamework"
+    replace: "framework"
+    propagate_case: true
+    word: true
+
+  - trigger: "fontend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "forntend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frnotend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frntend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "fronend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "fronetnd"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "fronted"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frontedn"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frontnd"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frontned"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frotend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "frotnend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfontend"
+    replace: "frontend"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnction"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnuction"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "fucntion"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuction"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "funcion"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "funciton"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "functin"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "functino"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "functoin"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "functon"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "funtcion"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "funtion"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "ufnction"
+    replace: "function"
+    propagate_case: true
+    word: true
+
+  - trigger: "agteway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gaetway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gaeway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gateawy"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gateay"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gatewy"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gatewya"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gatway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gatweay"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gtaeway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "gteway"
+    replace: "gateway"
+    propagate_case: true
+    word: true
+
+  - trigger: "egnerator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "geenrator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "geerator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "geneartor"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "geneator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "generaor"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "generaotr"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "generatr"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "generatro"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "genertaor"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "genertor"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "genrator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "genreator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "gneerator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "gnerator"
+    replace: "generator"
+    propagate_case: true
+    word: true
+
+  - trigger: "gadient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gardient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradeint"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradent"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradiet"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradietn"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradinet"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradint"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "graident"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "graient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "grdaient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "grdient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgadient"
+    replace: "gradient"
+    propagate_case: true
+    word: true
+
+  - trigger: "gafana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "garfana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "graafna"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "graana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grafaa"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grafaan"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grafna"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grafnaa"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grfaana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "grfana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgafana"
+    replace: "grafana"
+    propagate_case: true
+    word: true
+
+  - trigger: "gaphql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "garphql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grahpql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grahql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "graphl"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "graphlq"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grapqhl"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grapql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grpahql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "grphql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgaphql"
+    replace: "graphql"
+    propagate_case: true
+    word: true
+
+  - trigger: "gird"
+    replace: "grid"
+    propagate_case: true
+    word: true
+
+  - trigger: "grdi"
+    replace: "grid"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgid"
+    replace: "grid"
+    propagate_case: true
+    word: true
+
+  - trigger: "gard"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "gaurd"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "guad"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "guadr"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "gurad"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "gurd"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "ugard"
+    replace: "guard"
+    propagate_case: true
+    word: true
+
+  - trigger: "gnicorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "gnuicorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guicorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guincorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "gunciorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guncorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "gunicon"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guniconr"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "gunicrn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "gunicron"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guniocrn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "guniorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "ugnicorn"
+    replace: "gunicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "diempotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idemoptent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idemotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempoent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempoetnt"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempotet"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempotetn"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempotnet"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idempotnt"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idemptent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idemptoent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idepmotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idepotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idmepotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "idmpotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "iedmpotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "iempotent"
+    replace: "idempotent"
+    propagate_case: true
+    word: true
+
+  - trigger: "immtable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immtuable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immuable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immuatble"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutabe"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutabel"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutalbe"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutale"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutbale"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "immutble"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "imumtable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "imutable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "mimutable"
+    replace: "immutable"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlpements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "impelments"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "impements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleemnts"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "impleents"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemens"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemenst"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemetns"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemets"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemnets"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implemnts"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implmeents"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "implments"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "iplements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmlements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "miplements"
+    replace: "implements"
+    propagate_case: true
+    word: true
+
+  - trigger: "imoprt"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "imort"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "impot"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "impotr"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "improt"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "imprt"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmort"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "iport"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "miport"
+    replace: "import"
+    propagate_case: true
+    word: true
+
+  - trigger: "identation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "idnentation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indenation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indenattion"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentaion"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentaiton"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentatin"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentatino"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentatoin"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indentaton"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indenttaion"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indenttion"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indetation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indetnation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indnetation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "indntation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "inedntation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "inentation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "nidentation"
+    replace: "indentation"
+    propagate_case: true
+    word: true
+
+  - trigger: "iheritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "ihneritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inehritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "ineritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheirtance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheitance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheriance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheriatnce"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritace"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritacne"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritane"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritanec"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritnace"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inheritnce"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inhertance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inhertiance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inhreitance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "inhritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "niheritance"
+    replace: "inheritance"
+    propagate_case: true
+    word: true
+
+  - trigger: "ijectable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "ijnectable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "inectable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "inejctable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injcetable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injctable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injecable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injecatble"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectabe"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectabel"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectalbe"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectale"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectbale"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injectble"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injetable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "injetcable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "nijectable"
+    replace: "injectable"
+    propagate_case: true
+    word: true
+
+  - trigger: "inpt"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "inptu"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "inupt"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "inut"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipnut"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "iput"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "niput"
+    replace: "input"
+    propagate_case: true
+    word: true
+
+  - trigger: "inerceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "inetrceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "inteceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intecreptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercepor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercepotr"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "interceptr"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "interceptro"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercetor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercetpor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercpetor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intercptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "interecptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intereptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intrceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "intreceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "itnerceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "niterceptor"
+    replace: "interceptor"
+    propagate_case: true
+    word: true
+
+  - trigger: "inerface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "inetrface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "inteface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "intefrace"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interace"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interafce"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interfae"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interfaec"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interfcae"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "interfce"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "intreface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "intrface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "itnerface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "niterface"
+    replace: "interface"
+    propagate_case: true
+    word: true
+
+  - trigger: "inerpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "inetrpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "intepreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "inteprreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interperter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interpeter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interpreer"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interpreetr"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interpretr"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interpretre"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interprteer"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interprter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "interrpeter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "intrepreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "intrpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "itnerpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "niterpreter"
+    replace: "interpreter"
+    propagate_case: true
+    word: true
+
+  - trigger: "isse"
+    replace: "issue"
+    propagate_case: true
+    word: true
+
+  - trigger: "isseu"
+    replace: "issue"
+    propagate_case: true
+    word: true
+
+  - trigger: "isue"
+    replace: "issue"
+    propagate_case: true
+    word: true
+
+  - trigger: "isuse"
+    replace: "issue"
+    propagate_case: true
+    word: true
+
+  - trigger: "sisue"
+    replace: "issue"
+    propagate_case: true
+    word: true
+
+  - trigger: "ierable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "ietrable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "itearble"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterabe"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterabel"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteralbe"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterale"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterbale"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "iterble"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "itrable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "itreable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "tierable"
+    replace: "iterable"
+    propagate_case: true
+    word: true
+
+  - trigger: "ierator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "ietrator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteartor"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteraor"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteraotr"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteratr"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "iteratro"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "itertaor"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "itertor"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "itrator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "itreator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "tierator"
+    replace: "iterator"
+    propagate_case: true
+    word: true
+
+  - trigger: "ajvascript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "jaascript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "jaavscript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javacript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javacsript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascipt"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascirpt"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascrit"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascritp"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascrpit"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javascrpt"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javasrcipt"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javasript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javsacript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "javscript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "jvaascript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "jvascript"
+    replace: "javascript"
+    propagate_case: true
+    word: true
+
+  - trigger: "ekyframe"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keframe"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "kefyrame"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfame"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfarme"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfrae"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfraem"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfrmae"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyfrme"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyrame"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "keyrfame"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "kyeframe"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "kyframe"
+    replace: "keyframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "kbernetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kbuernetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubenetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubenretes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuberentes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuberetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubernees"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuberneets"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubernets"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubernetse"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuberntees"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuberntes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubrenetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kubrnetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuebrnetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "kuernetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "ukbernetes"
+    replace: "kubernetes"
+    propagate_case: true
+    word: true
+
+  - trigger: "almbda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "labda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "labmda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lamba"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lambad"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lamda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lamdba"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lmabda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "lmbda"
+    replace: "lambda"
+    propagate_case: true
+    word: true
+
+  - trigger: "alyout"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "laout"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "laoyut"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "layot"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "layotu"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "layuot"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "layut"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "lyaout"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "lyout"
+    replace: "layout"
+    propagate_case: true
+    word: true
+
+  - trigger: "ilbrary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "lbirary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "lbrary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "libarry"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "libary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "libray"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "librayr"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "librray"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "librry"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "lirary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "lirbary"
+    replace: "library"
+    propagate_case: true
+    word: true
+
+  - trigger: "ilfecycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lfecycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lfiecycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "liecycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "liefcycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifceycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifcycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifeccle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifeccyle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifecyce"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifecycel"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifecylce"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifecyle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifeyccle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "lifeycle"
+    replace: "lifecycle"
+    propagate_case: true
+    word: true
+
+  - trigger: "ilst"
+    replace: "list"
+    propagate_case: true
+    word: true
+
+  - trigger: "lits"
+    replace: "list"
+    propagate_case: true
+    word: true
+
+  - trigger: "lsit"
+    replace: "list"
+    propagate_case: true
+    word: true
+
+  - trigger: "lading"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "laoding"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loadig"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loadign"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loadng"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loadnig"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loaidng"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loaing"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "lodaing"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "loding"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "olading"
+    replace: "loading"
+    propagate_case: true
+    word: true
+
+  - trigger: "amnifest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "maifest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "mainfest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manfest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manfiest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "maniefst"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "maniest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manifet"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manifets"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manifset"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "manifst"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnaifest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnifest"
+    replace: "manifest"
+    propagate_case: true
+    word: true
+
+  - trigger: "amrgin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "magin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "magrin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "margn"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "margni"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "marign"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "marin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mragin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mrgin"
+    replace: "margin"
+    propagate_case: true
+    word: true
+
+  - trigger: "emrge"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "mege"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "megre"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "mere"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "mereg"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "mrege"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "mrge"
+    replace: "merge"
+    propagate_case: true
+    word: true
+
+  - trigger: "emtaclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "meaclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "meatclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metacalss"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metacass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metaclas"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metaclsas"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metaclss"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metalass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metalcass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metcalass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "metclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtaclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "mteaclass"
+    replace: "metaclass"
+    propagate_case: true
+    word: true
+
+  - trigger: "emtadata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "meadata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "meatdata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metaadta"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metaata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metadaa"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metadaat"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metadta"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metadtaa"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metdaata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "metdata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtadata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "mteadata"
+    replace: "metadata"
+    propagate_case: true
+    word: true
+
+  - trigger: "imcroservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "mciroservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "mcroservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "micorservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "micoservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microervice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microesrvice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microserice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microserivce"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microservce"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microservcie"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microservie"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microserviec"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microsevice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microsevrice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microsrevice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "microsrvice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "micrservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "micrsoervice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "mircoservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "miroservice"
+    replace: "microservice"
+    propagate_case: true
+    word: true
+
+  - trigger: "imddleware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "mddleware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdidleware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middelware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middeware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middleare"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middleawre"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlewae"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlewaer"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlewrae"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlewre"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "middlweare"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "midldeware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "midleware"
+    replace: "middleware"
+    propagate_case: true
+    word: true
+
+  - trigger: "imgration"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "mgiration"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "mgration"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migartion"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migation"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migraion"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migraiton"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migratin"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migratino"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migratoin"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migraton"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migrtaion"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "migrtion"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "miration"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "mirgation"
+    replace: "migration"
+    propagate_case: true
+    word: true
+
+  - trigger: "imlestone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "mielstone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "miestone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milesone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milesotne"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milestne"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milestnoe"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milestoe"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milestoen"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "miletone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "miletsone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milsetone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "milstone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "mlestone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "mliestone"
+    replace: "milestone"
+    propagate_case: true
+    word: true
+
+  - trigger: "imnification"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "miification"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "miinfication"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minfication"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minfiication"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifcation"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifciation"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifiaction"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifiation"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificaion"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificaiton"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificatin"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificatino"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificatoin"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minificaton"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifictaion"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "minifiction"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "miniication"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "miniifcation"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnification"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "mniification"
+    replace: "minification"
+    propagate_case: true
+    word: true
+
+  - trigger: "imxin"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "miin"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "miixn"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mixn"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mixni"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mxiin"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mxin"
+    replace: "mixin"
+    propagate_case: true
+    word: true
+
+  - trigger: "mcok"
+    replace: "mock"
+    propagate_case: true
+    word: true
+
+  - trigger: "mokc"
+    replace: "mock"
+    propagate_case: true
+    word: true
+
+  - trigger: "omck"
+    replace: "mock"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdoule"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdule"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "modle"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "modlue"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "modue"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "moduel"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "moudle"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "moule"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "omdule"
+    replace: "module"
+    propagate_case: true
+    word: true
+
+  - trigger: "mngodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnogodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mognodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mogodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mongdb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mongdob"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mongob"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mongobd"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "monodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "monogdb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "omngodb"
+    replace: "mongodb"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnolith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnoolith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monlith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monloith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monoilth"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monoith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monolih"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monoliht"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monolth"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "monoltih"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "moolith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "moonlith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "omnolith"
+    replace: "monolith"
+    propagate_case: true
+    word: true
+
+  - trigger: "mpyy"
+    replace: "mypy"
+    propagate_case: true
+    word: true
+
+  - trigger: "myyp"
+    replace: "mypy"
+    propagate_case: true
+    word: true
+
+  - trigger: "ympy"
+    replace: "mypy"
+    propagate_case: true
+    word: true
+
+  - trigger: "anmespace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "naemspace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "naespace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namepace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namepsace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namesace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namesapce"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namespae"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namespaec"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namespcae"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namespce"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namsepace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "namspace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmaespace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmespace"
+    replace: "namespace"
+    propagate_case: true
+    word: true
+
+  - trigger: "anvigation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "naigation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "naivgation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navgation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navgiation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "naviagtion"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "naviation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigaion"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigaiton"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigatin"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigatino"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigatoin"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigaton"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigtaion"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "navigtion"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "nvaigation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "nvigation"
+    replace: "navigation"
+    propagate_case: true
+    word: true
+
+  - trigger: "enutral"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "netral"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "netural"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neural"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neurtal"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neutal"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neutarl"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neutrl"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "neutrla"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuetral"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "nutral"
+    replace: "neutral"
+    propagate_case: true
+    word: true
+
+  - trigger: "gninx"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "ngix"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "ngixn"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "ngnix"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "ngnx"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "nignx"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "ninx"
+    replace: "nginx"
+    propagate_case: true
+    word: true
+
+  - trigger: "noification"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "noitfication"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notfication"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notfiication"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifcation"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifciation"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifiaction"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifiation"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificaion"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificaiton"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificatin"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificatino"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificatoin"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notificaton"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifictaion"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notifiction"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notiication"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "notiifcation"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "ntification"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "ntoification"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "ontification"
+    replace: "notification"
+    propagate_case: true
+    word: true
+
+  - trigger: "nlul"
+    replace: "null"
+    propagate_case: true
+    word: true
+
+  - trigger: "nul"
+    replace: "null"
+    propagate_case: true
+    word: true
+
+  - trigger: "unll"
+    replace: "null"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmber"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmuber"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuber"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "nubmer"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "numbr"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "numbre"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "numebr"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "numer"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "unmber"
+    replace: "number"
+    propagate_case: true
+    word: true
+
+  - trigger: "boservable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obervable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obesrvable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obserable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obseravble"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observabe"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observabel"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observalbe"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observale"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observbale"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "observble"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsevable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsevrable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsrevable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsrvable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "osbervable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "oservable"
+    replace: "observable"
+    propagate_case: true
+    word: true
+
+  - trigger: "boserver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "oberver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obesrver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obserer"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obserevr"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "observr"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "observre"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsever"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsevrer"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsrever"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "obsrver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "osberver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "oserver"
+    replace: "observer"
+    propagate_case: true
+    word: true
+
+  - trigger: "oacity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "oapcity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opaciy"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opaciyt"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opactiy"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opacty"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opaicty"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opaity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opcaity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "opcity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "poacity"
+    replace: "opacity"
+    propagate_case: true
+    word: true
+
+  - trigger: "ochestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrhestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orcehstration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orcestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchesration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchesrtation"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestartion"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestation"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestraion"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestraiton"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestratin"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestratino"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestratoin"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestraton"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestrtaion"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchestrtion"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchetration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchetsration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchsetration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orchstration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orhcestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "orhestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "rochestration"
+    replace: "orchestration"
+    propagate_case: true
+    word: true
+
+  - trigger: "otline"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "otuline"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "ouline"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "oultine"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outilne"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outine"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outlie"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outlien"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outlne"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "outlnie"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "uotline"
+    replace: "outline"
+    propagate_case: true
+    word: true
+
+  - trigger: "oerload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "oevrload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "oveload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovelroad"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overlad"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overlaod"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overlod"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overloda"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overoad"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "overolad"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovreload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovrload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "voerload"
+    replace: "overload"
+    propagate_case: true
+    word: true
+
+  - trigger: "oerride"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "oevrride"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overide"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overirde"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overrde"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overrdie"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overrie"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "overried"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovreride"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovrride"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "voerride"
+    replace: "override"
+    propagate_case: true
+    word: true
+
+  - trigger: "apckage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pacage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pacakge"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "packae"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "packaeg"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "packgae"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "packge"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pakage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pakcage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pcakage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "pckage"
+    replace: "package"
+    propagate_case: true
+    word: true
+
+  - trigger: "apdding"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "paddig"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "paddign"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "paddng"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "paddnig"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "padidng"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "pading"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdading"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdding"
+    replace: "padding"
+    propagate_case: true
+    word: true
+
+  - trigger: "apgination"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagiantion"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagiation"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginaion"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginaiton"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginatin"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginatino"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginatoin"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paginaton"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagintaion"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagintion"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagnation"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pagniation"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paignation"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "paination"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pgaination"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "pgination"
+    replace: "pagination"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprallelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paallelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paarllelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralellism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralleilsm"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralleism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parallelim"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parallelims"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parallelsim"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parallelsm"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parallleism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralllism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlalelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "parllelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "praallelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "prallelism"
+    replace: "parallelism"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprameter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paameter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paarmeter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paraemter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paraeter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parameer"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parameetr"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parametr"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parametre"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paramteer"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "paramter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parmaeter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "parmeter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "praameter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "prameter"
+    replace: "parameter"
+    propagate_case: true
+    word: true
+
+  - trigger: "ippeline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pieline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "piepline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipeilne"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipeine"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipelie"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipelien"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipelne"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipelnie"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipleine"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "pipline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "ppeline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "ppieline"
+    replace: "pipeline"
+    propagate_case: true
+    word: true
+
+  - trigger: "lpaceholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "paceholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "palceholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placehlder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placehloder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placehoder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placehodler"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeholdr"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeholdre"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeholedr"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeholer"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeohlder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placeolder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placheolder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "placholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "plaecholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "plaeholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "plcaeholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "plceholder"
+    replace: "placeholder"
+    propagate_case: true
+    word: true
+
+  - trigger: "oplyfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "ployfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "plyfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polfyill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyfil"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyflil"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyfll"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyifll"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "poyfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "poylfill"
+    replace: "polyfill"
+    propagate_case: true
+    word: true
+
+  - trigger: "oplymorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "ploymorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "plymorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polmorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polmyorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymophism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymoprhism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorhism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorhpism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorphim"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorphims"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorphsim"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorphsm"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorpihsm"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymorpism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymrophism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polymrphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyomrphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "polyorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "poylmorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "poymorphism"
+    replace: "polymorphism"
+    propagate_case: true
+    word: true
+
+  - trigger: "opsition"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "poistion"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "poition"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "posiion"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "posiiton"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "positin"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "positino"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "positoin"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "positon"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "postiion"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "postion"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "psition"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "psoition"
+    replace: "position"
+    propagate_case: true
+    word: true
+
+  - trigger: "opstgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "posgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "posgtresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgersql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgesql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgreql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgreqsl"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgresl"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgreslq"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgrseql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postgrsql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "postrgesql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "potgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "potsgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "psotgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "pstgresql"
+    replace: "postgresql"
+    propagate_case: true
+    word: true
+
+  - trigger: "perttier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pettier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pretier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pretiter"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pretteir"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pretter"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "prettir"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "prettire"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "prtetier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "prttier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpettier"
+    replace: "prettier"
+    propagate_case: true
+    word: true
+
+  - trigger: "pimary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "pirmary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "priamry"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "priary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "primay"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "primayr"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "primray"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "primry"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmiary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpimary"
+    replace: "primary"
+    propagate_case: true
+    word: true
+
+  - trigger: "poduction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "porduction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prdouction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prduction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prodction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prodcution"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "producion"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "produciton"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "productin"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "productino"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "productoin"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "producton"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "produtcion"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prodution"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "prouction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "proudction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoduction"
+    replace: "production"
+    propagate_case: true
+    word: true
+
+  - trigger: "pofile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "porfile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "prfile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "prfoile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "profie"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "profiel"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "profle"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "proflie"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "proifle"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "proile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpofile"
+    replace: "profile"
+    propagate_case: true
+    word: true
+
+  - trigger: "pometheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "pormetheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmetheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmoetheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "proemtheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "proetheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promeheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promehteus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "prometehus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "prometeus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promethes"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promethesu"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promethues"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promethus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promteheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "promtheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpometheus"
+    replace: "prometheus"
+    propagate_case: true
+    word: true
+
+  - trigger: "pomise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "pormise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmoise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "proimse"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "proise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "promie"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "promies"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "promse"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "promsie"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpomise"
+    replace: "promise"
+    propagate_case: true
+    word: true
+
+  - trigger: "portotype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "pototype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "proottype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prootype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prototpe"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prototpye"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prototye"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prototyep"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "protoype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "protoytpe"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prottoype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prottype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prtootype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "prtotype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpototype"
+    replace: "prototype"
+    propagate_case: true
+    word: true
+
+  - trigger: "pesudo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "peudo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psedo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pseduo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pseuo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pseuod"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psudo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "psuedo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "speudo"
+    replace: "pseudo"
+    propagate_case: true
+    word: true
+
+  - trigger: "plul"
+    replace: "pull"
+    propagate_case: true
+    word: true
+
+  - trigger: "pul"
+    replace: "pull"
+    propagate_case: true
+    word: true
+
+  - trigger: "upll"
+    replace: "pull"
+    propagate_case: true
+    word: true
+
+  - trigger: "psuh"
+    replace: "push"
+    propagate_case: true
+    word: true
+
+  - trigger: "puhs"
+    replace: "push"
+    propagate_case: true
+    word: true
+
+  - trigger: "upsh"
+    replace: "push"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdantic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdyantic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyadntic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyantic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydanic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydanitc"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydantc"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydantci"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydatic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydatnic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydnatic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "pydntic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "ypdantic"
+    replace: "pydantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "plint"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "plyint"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyilnt"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyint"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pylit"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pylitn"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pylnit"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "pylnt"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "yplint"
+    replace: "pylint"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptest"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptyest"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyest"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pyetst"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pytet"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pytets"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pytset"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "pytst"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "yptest"
+    replace: "pytest"
+    propagate_case: true
+    word: true
+
+  - trigger: "arbbitmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbimq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbimtq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbitq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbitqm"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbtimq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabbtmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabibtmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rabitmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbabitmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbbitmq"
+    replace: "rabbitmq"
+    propagate_case: true
+    word: true
+
+  - trigger: "ardius"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "radis"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "radisu"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "raduis"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "radus"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "raidus"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "raius"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "rdaius"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "rdius"
+    replace: "radius"
+    propagate_case: true
+    word: true
+
+  - trigger: "eradonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "radonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "raedonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readnly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readnoly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readolny"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readoly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readony"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "readonyl"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "reaodnly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "reaonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "redaonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "redonly"
+    replace: "readonly"
+    propagate_case: true
+    word: true
+
+  - trigger: "erbase"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbase"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbease"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "reabse"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rease"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rebae"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rebaes"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rebsae"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "rebse"
+    replace: "rebase"
+    propagate_case: true
+    word: true
+
+  - trigger: "ercursion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceursion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcursion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recrsion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recrusion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recurion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recurison"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursin"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursino"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursoin"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recurson"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recusion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "recusrion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "reucrsion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "reursion"
+    replace: "recursion"
+    propagate_case: true
+    word: true
+
+  - trigger: "ercursive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "rceursive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcursive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recrsive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recrusive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recurisve"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recurive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursie"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursiev"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursve"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recursvie"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recusive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "recusrive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "reucrsive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "reursive"
+    replace: "recursive"
+    propagate_case: true
+    word: true
+
+  - trigger: "erdis"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "rdeis"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "rdis"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "reds"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "redsi"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "reids"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "reis"
+    replace: "redis"
+    propagate_case: true
+    word: true
+
+  - trigger: "erfactor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "reactor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "reafctor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refacor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refacotr"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refactr"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refactro"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refatcor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refator"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refcator"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "refctor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfactor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfeactor"
+    replace: "refactor"
+    propagate_case: true
+    word: true
+
+  - trigger: "erlease"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "reease"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "reelase"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "relaese"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "relase"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "releae"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "releaes"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "relesae"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "relese"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "rlease"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "rleease"
+    replace: "release"
+    propagate_case: true
+    word: true
+
+  - trigger: "ermote"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "remoe"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "remoet"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "remte"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "remtoe"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "reomte"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "reote"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmeote"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "rmote"
+    replace: "remote"
+    propagate_case: true
+    word: true
+
+  - trigger: "ernder"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "reder"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "redner"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "rendr"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "rendre"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "renedr"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "rener"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "rnder"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "rneder"
+    replace: "render"
+    propagate_case: true
+    word: true
+
+  - trigger: "erpository"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "reopsitory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "reository"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repoistory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repoitory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "reposiory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "reposiotry"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repositoy"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repositoyr"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repositroy"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repositry"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repostiory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repostory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repsitory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "repsoitory"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpeository"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpository"
+    replace: "repository"
+    propagate_case: true
+    word: true
+
+  - trigger: "erquest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "reqest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "reqeust"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "requet"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "requets"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "requset"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "requst"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "reuest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "reuqest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "rqeuest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "rquest"
+    replace: "request"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersolver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "reolver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "reoslver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "reslover"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "reslver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resoler"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resolevr"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resolvr"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resolvre"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resover"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "resovler"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseolver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsolver"
+    replace: "resolver"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersponse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "reponse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "repsonse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "resonse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "resopnse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "respnose"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "respnse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "respone"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "respones"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "respose"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "resposne"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseponse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsponse"
+    replace: "response"
+    propagate_case: true
+    word: true
+
+  - trigger: "ersponsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "reponsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "repsonsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "resonsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "resopnsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "respnosive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "respnsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responisve"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responsie"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responsiev"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responsve"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "responsvie"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "resposive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "resposnive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "rseponsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsponsive"
+    replace: "responsive"
+    propagate_case: true
+    word: true
+
+  - trigger: "erturn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "retrn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "retrun"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "retun"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "retunr"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "reurn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "reutrn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "rteurn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "rturn"
+    replace: "return"
+    propagate_case: true
+    word: true
+
+  - trigger: "rntime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "rnutime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runitme"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runtie"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runtiem"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runtme"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "runtmie"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "rutime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "rutnime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "urntime"
+    replace: "runtime"
+    propagate_case: true
+    word: true
+
+  - trigger: "astisfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "saisfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "saitsfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satifies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satifsies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisfeis"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisfes"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisfis"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisfise"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satisifes"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satsfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "satsifies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "staisfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "stisfies"
+    replace: "satisfies"
+    propagate_case: true
+    word: true
+
+  - trigger: "csaffold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "sacffold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "saffold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scaffld"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scafflod"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scaffod"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scaffodl"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scafofld"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scafold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scfafold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "scffold"
+    replace: "scaffold"
+    propagate_case: true
+    word: true
+
+  - trigger: "csroll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "scoll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "scorll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrlol"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrol"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "srcoll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "sroll"
+    replace: "scroll"
+    propagate_case: true
+    word: true
+
+  - trigger: "esarch"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "saerch"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "sarch"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "seach"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "seacrh"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "searh"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "searhc"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "serach"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "serch"
+    replace: "search"
+    propagate_case: true
+    word: true
+
+  - trigger: "escondary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "sceondary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "scondary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secndary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secnodary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secodary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secodnary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "seconadry"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "seconary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "seconday"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secondayr"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secondray"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "secondry"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "seocndary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "seondary"
+    replace: "secondary"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslect"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "seect"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "seelct"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "selcet"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "selct"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "selet"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "seletc"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "slect"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "sleect"
+    replace: "select"
+    propagate_case: true
+    word: true
+
+  - trigger: "eslector"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "seector"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "seelctor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selcetor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selctor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selecor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selecotr"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selectr"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "selectro"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "seletcor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "seletor"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "slector"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "sleector"
+    replace: "selector"
+    propagate_case: true
+    word: true
+
+  - trigger: "esmantic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "seamntic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "seantic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semanic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semanitc"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semantc"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semantci"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "sematic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "sematnic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semnatic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "semntic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "smantic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "smeantic"
+    replace: "semantic"
+    propagate_case: true
+    word: true
+
+  - trigger: "esrialization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "seialization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "seiralization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serailization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "seralization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "seriailzation"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "seriaization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialiation"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialiaztion"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializaion"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializaiton"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializatin"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializatino"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializatoin"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializaton"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializtaion"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializtion"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialzation"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialziation"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serilaization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "serilization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "sreialization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "srialization"
+    replace: "serialization"
+    propagate_case: true
+    word: true
+
+  - trigger: "esrializer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "seializer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "seiralizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serailizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "seralizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "seriailzer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "seriaizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialier"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialiezr"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializr"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serializre"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialzer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serialzier"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serilaizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "serilizer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "sreializer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "srializer"
+    replace: "serializer"
+    propagate_case: true
+    word: true
+
+  - trigger: "esrvice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "serice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "serivce"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "servce"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "servcie"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "servie"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "serviec"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "sevice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "sevrice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "srevice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "srvice"
+    replace: "service"
+    propagate_case: true
+    word: true
+
+  - trigger: "esttings"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "setings"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "setitngs"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settigns"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settigs"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settins"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settinsg"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settngs"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "settnigs"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "stetings"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "sttings"
+    replace: "settings"
+    propagate_case: true
+    word: true
+
+  - trigger: "hsadow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "sadow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "sahdow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shadw"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shadwo"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shaodw"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shaow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shdaow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "shdow"
+    replace: "shadow"
+    propagate_case: true
+    word: true
+
+  - trigger: "isdebar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sdebar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sdiebar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sidbar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sidbear"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sideabr"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sidear"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sidebr"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "sidebra"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "siebar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "siedbar"
+    replace: "sidebar"
+    propagate_case: true
+    word: true
+
+  - trigger: "isngleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "sigleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "signleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singelton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singeton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singleon"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singleotn"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singletn"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singletno"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singlteon"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "singlton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "sinleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "sinlgeton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "sngleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "snigleton"
+    replace: "singleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "kseleton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "sekleton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "seleton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeelton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeeton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeleon"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeleotn"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeletn"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skeletno"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skelteon"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skelton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skleeton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "skleton"
+    replace: "skeleton"
+    propagate_case: true
+    word: true
+
+  - trigger: "lsider"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "sider"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "silder"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "slder"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "sldier"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "slidr"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "slidre"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "sliedr"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "slier"
+    replace: "slider"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsapshot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "sanpshot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapshot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snaphot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snaphsot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snapsht"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snapshto"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snapsoht"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snapsot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snashot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snasphot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snpashot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "snpshot"
+    replace: "snapshot"
+    propagate_case: true
+    word: true
+
+  - trigger: "psacing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "sacing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapcing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spacig"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spacign"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spacng"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spacnig"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spaicng"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spaing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spcaing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "spcing"
+    replace: "spacing"
+    propagate_case: true
+    word: true
+
+  - trigger: "psinner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "sinner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "sipnner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spinenr"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spiner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spinnr"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spinnre"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spniner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "spnner"
+    replace: "spinner"
+    propagate_case: true
+    word: true
+
+  - trigger: "psrint"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "spint"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "spirnt"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "sprit"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "spritn"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "sprnit"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "sprnt"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "srint"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "srpint"
+    replace: "sprint"
+    propagate_case: true
+    word: true
+
+  - trigger: "saging"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "satging"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stagig"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stagign"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stagng"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stagnig"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "staigng"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "staing"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stgaing"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "stging"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsaging"
+    replace: "staging"
+    propagate_case: true
+    word: true
+
+  - trigger: "sash"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "satsh"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "stah"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "stahs"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "stsah"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "stsh"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsash"
+    replace: "stash"
+    propagate_case: true
+    word: true
+
+  - trigger: "sate"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "satte"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "stae"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "staet"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "sttae"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "stte"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsate"
+    replace: "state"
+    propagate_case: true
+    word: true
+
+  - trigger: "sattus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "satus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "stats"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "statsu"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "staus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "stauts"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "sttaus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "sttus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsatus"
+    replace: "status"
+    propagate_case: true
+    word: true
+
+  - trigger: "sepper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "setpper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "stepepr"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "steper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "steppr"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "steppre"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "stpeper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "stpper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsepper"
+    replace: "stepper"
+    propagate_case: true
+    word: true
+
+  - trigger: "srategy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "srtategy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "startegy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "stategy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "straegy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "straetgy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "stratey"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "strateyg"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "stratgey"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "stratgy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "strtaegy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "strtegy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsrategy"
+    replace: "strategy"
+    propagate_case: true
+    word: true
+
+  - trigger: "sring"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "srting"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "sting"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "stirng"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "strig"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "strign"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "strng"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "strnig"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsring"
+    replace: "string"
+    propagate_case: true
+    word: true
+
+  - trigger: "stbu"
+    replace: "stub"
+    propagate_case: true
+    word: true
+
+  - trigger: "sutb"
+    replace: "stub"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsub"
+    replace: "stub"
+    propagate_case: true
+    word: true
+
+  - trigger: "stlesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "stlyesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styelsheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styleheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "stylehseet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styleseet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "stylesehet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styleshet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "styleshete"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "stylseheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "stylsheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "sylesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "sytlesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsylesheet"
+    replace: "stylesheet"
+    propagate_case: true
+    word: true
+
+  - trigger: "spabase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "spuabase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "suabase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "suapbase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supaabse"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supaase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supabae"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supabaes"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supabsae"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supabse"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supbaase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "supbase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "uspabase"
+    replace: "supabase"
+    propagate_case: true
+    word: true
+
+  - trigger: "snchronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "snychronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "sychronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "sycnhronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchonous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchornous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchrnoous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchrnous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchronos"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchronosu"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchronuos"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchronus"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchroonus"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synchroous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "syncrhonous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "syncronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synhcronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "synhronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "ysnchronous"
+    replace: "synchronous"
+    propagate_case: true
+    word: true
+
+  - trigger: "sstem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "ssytem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "sysem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "sysetm"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "systm"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "systme"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "sytem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "sytsem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "ysstem"
+    replace: "system"
+    propagate_case: true
+    word: true
+
+  - trigger: "atble"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "tabe"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "tabel"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "talbe"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "tale"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "tbale"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "tble"
+    replace: "table"
+    propagate_case: true
+    word: true
+
+  - trigger: "etmplate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "temlate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "temlpate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "tempalte"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "tempate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "templae"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "templaet"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "templtae"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "templte"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "teplate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "tepmlate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "tmeplate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "tmplate"
+    replace: "template"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrraform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "teraform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terarform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrafom"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrafomr"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrafrm"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrafrom"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terraofrm"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terraorm"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrfaorm"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "terrform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "treraform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "trraform"
+    replace: "terraform"
+    propagate_case: true
+    word: true
+
+  - trigger: "etst"
+    replace: "test"
+    propagate_case: true
+    word: true
+
+  - trigger: "tets"
+    replace: "test"
+    propagate_case: true
+    word: true
+
+  - trigger: "tset"
+    replace: "test"
+    propagate_case: true
+    word: true
+
+  - trigger: "etxtarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "tetarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "tetxarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "texarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "texatrea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textaea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textaera"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textara"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textarae"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textraea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "textrea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "txetarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "txtarea"
+    replace: "textarea"
+    propagate_case: true
+    word: true
+
+  - trigger: "hteme"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "tehme"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "teme"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "thee"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "theem"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "thme"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "thmee"
+    replace: "theme"
+    propagate_case: true
+    word: true
+
+  - trigger: "htrottle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "thorttle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "thottle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "throtle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "throtlte"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "throtte"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "throttel"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "thrtotle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "thrttle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "trhottle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "trottle"
+    replace: "throttle"
+    propagate_case: true
+    word: true
+
+  - trigger: "itcket"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tciket"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tcket"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "ticekt"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "ticet"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tickt"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tickte"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tikcet"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "tiket"
+    replace: "ticket"
+    propagate_case: true
+    word: true
+
+  - trigger: "otast"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "taost"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "tast"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "toat"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "toats"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "tosat"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "tost"
+    replace: "toast"
+    propagate_case: true
+    word: true
+
+  - trigger: "otggle"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "tggle"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "tgogle"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "togge"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "toggel"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "togle"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "toglge"
+    replace: "toggle"
+    propagate_case: true
+    word: true
+
+  - trigger: "otken"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "tken"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "tkoen"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "toekn"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "toen"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "tokn"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "tokne"
+    replace: "token"
+    propagate_case: true
+    word: true
+
+  - trigger: "otoltip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "tolotip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "toltip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "toolip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "toolitp"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "tooltp"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "tooltpi"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "tootip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "tootlip"
+    replace: "tooltip"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtansform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "tansform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "tarnsform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranfsorm"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transfom"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transfomr"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transfrm"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transfrom"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transofrm"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "transorm"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasnform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnasform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnsform"
+    replace: "transform"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtansition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "tansition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "tarnsition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranistion"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transiion"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transiiton"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transitin"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transitino"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transitoin"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transiton"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transtiion"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "transtion"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasnition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnasition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnsition"
+    replace: "transition"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtansparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "tansparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "tarnsparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "tranpsarent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transaprent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transarent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transpaent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transpaernt"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transparet"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transparetn"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transparnet"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transparnt"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transpraent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "transprent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasnparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "trasparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnasparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnsparent"
+    replace: "transparent"
+    propagate_case: true
+    word: true
+
+  - trigger: "tpye"
+    replace: "type"
+    propagate_case: true
+    word: true
+
+  - trigger: "tyep"
+    replace: "type"
+    propagate_case: true
+    word: true
+
+  - trigger: "ytpe"
+    replace: "type"
+    propagate_case: true
+    word: true
+
+  - trigger: "tpography"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "tpyography"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "tyography"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "tyopgraphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typgoraphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typgraphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typogaphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typogarphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typograhpy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typograhy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typograpy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typograpyh"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typogrpahy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typogrphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typoraphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "typorgaphy"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "ytpography"
+    replace: "typography"
+    propagate_case: true
+    word: true
+
+  - trigger: "nudefined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "udefined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "udnefined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefied"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefiend"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefind"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefinde"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefned"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undefnied"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undeifned"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undeined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undfeined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "undfined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "unedfined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "unefined"
+    replace: "undefined"
+    propagate_case: true
+    word: true
+
+  - trigger: "uicorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uivcorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uvciorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uvcorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uvicon"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uviconr"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uvicrn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uvicron"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uviocrn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "uviorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "vuicorn"
+    replace: "uvicorn"
+    propagate_case: true
+    word: true
+
+  - trigger: "avriable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "vaiable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "vairable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "varable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "varaible"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "variabe"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "variabel"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "varialbe"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "variale"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "varibale"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "varible"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "vraiable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "vriable"
+    replace: "variable"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrcel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecrel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vercl"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vercle"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "verecl"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "verel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrcel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrecel"
+    replace: "vercel"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivewport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "veiwport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "vewport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "vieport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viepwort"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewoprt"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewort"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewpot"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewpotr"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewprot"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viewprt"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viweport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "viwport"
+    replace: "viewport"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivrtualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtalenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtaulenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtuaelnv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtuaenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtualev"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtualevn"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtualnev"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtualnv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtulaenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virtulenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "virutalenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "vitrualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "vitualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "vritualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrtualenv"
+    replace: "virtualenv"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivsibility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "viibility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "viisbility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visbiility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visbility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibiilty"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibiity"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibiliy"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibiliyt"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibiltiy"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibilty"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visibliity"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visiblity"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visiiblity"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "visiility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsibility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsiibility"
+    replace: "visibility"
+    propagate_case: true
+    word: true
+
+  - trigger: "ewbpack"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "wbepack"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "wbpack"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "weback"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "webapck"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "webpak"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "webpakc"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "webpcak"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "webpck"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "wepack"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "wepback"
+    replace: "webpack"
+    propagate_case: true
+    word: true
+
+  - trigger: "iwreframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wieframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wierframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefame"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefarme"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefrae"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefraem"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefrmae"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirefrme"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirerame"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirerfame"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirferame"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wirframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wreframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrieframe"
+    replace: "wireframe"
+    propagate_case: true
+    word: true
+
+  - trigger: "rwapper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wapper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "warpper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrapepr"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wraper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrappr"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrappre"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrpaper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true
+
+  - trigger: "wrpper"
+    replace: "wrapper"
+    propagate_case: true
+    word: true

--- a/packages/refuos-dev/0.1.0/package.yml
+++ b/packages/refuos-dev/0.1.0/package.yml
@@ -142,6 +142,7 @@ matches:
   - triggers:
     - "asert"
     - "asesrt"
+    - "asset"
     - "assetr"
     - "assret"
     - "assrt"
@@ -318,6 +319,7 @@ matches:
 
   - triggers:
     - "abdge"
+    - "bade"
     - "badeg"
     - "bagde"
     - "bage"
@@ -347,6 +349,7 @@ matches:
     - "bordr"
     - "bordre"
     - "boredr"
+    - "borer"
     - "brder"
     - "broder"
     - "obrder"
@@ -357,6 +360,7 @@ matches:
   - triggers:
     - "banch"
     - "barnch"
+    - "brach"
     - "bracnh"
     - "branh"
     - "branhc"
@@ -535,6 +539,7 @@ matches:
     - "cloe"
     - "cloen"
     - "colne"
+    - "cone"
     - "lcone"
     replace: "clone"
     propagate_case: true
@@ -734,6 +739,7 @@ matches:
     - "cont"
     - "conts"
     - "cosnt"
+    - "cost"
     - "ocnst"
     replace: "const"
     propagate_case: true
@@ -1132,6 +1138,7 @@ matches:
     word: true
 
   - triggers:
+    - "deign"
     - "deisgn"
     - "desgin"
     - "desgn"
@@ -1547,6 +1554,7 @@ matches:
     word: true
 
   - triggers:
+    - "filer"
     - "filetr"
     - "filtr"
     - "filtre"
@@ -1668,6 +1676,7 @@ matches:
     - "frntend"
     - "fronend"
     - "fronetnd"
+    - "fronted"
     - "frontedn"
     - "frontnd"
     - "frontned"
@@ -1783,6 +1792,7 @@ matches:
     word: true
 
   - triggers:
+    - "gird"
     - "grdi"
     - "rgid"
     replace: "grid"
@@ -2226,6 +2236,7 @@ matches:
     word: true
 
   - triggers:
+    - "lading"
     - "laoding"
     - "loadig"
     - "loadign"
@@ -2554,6 +2565,7 @@ matches:
     - "enutral"
     - "netral"
     - "netural"
+    - "neural"
     - "neurtal"
     - "neutal"
     - "neutarl"
@@ -2716,6 +2728,7 @@ matches:
     - "oultine"
     - "outilne"
     - "outine"
+    - "outlie"
     - "outlien"
     - "outlne"
     - "outlnie"
@@ -3297,6 +3310,7 @@ matches:
 
   - triggers:
     - "erfactor"
+    - "reactor"
     - "reafctor"
     - "refacor"
     - "refacotr"
@@ -3748,6 +3762,14 @@ matches:
     word: true
 
   - triggers:
+    - "iste"
+    - "siet"
+    - "stie"
+    replace: "site"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "kseleton"
     - "sekleton"
     - "seleton"
@@ -3767,6 +3789,7 @@ matches:
 
   - triggers:
     - "lsider"
+    - "sider"
     - "silder"
     - "slder"
     - "sldier"
@@ -3814,6 +3837,7 @@ matches:
 
   - triggers:
     - "psinner"
+    - "sinner"
     - "sipnner"
     - "spinenr"
     - "spiner"
@@ -3829,6 +3853,7 @@ matches:
     - "psrint"
     - "spint"
     - "spirnt"
+    - "sprit"
     - "spritn"
     - "sprnit"
     - "sprnt"
@@ -3855,6 +3880,7 @@ matches:
     word: true
 
   - triggers:
+    - "sash"
     - "satsh"
     - "stah"
     - "stahs"
@@ -3866,6 +3892,7 @@ matches:
     word: true
 
   - triggers:
+    - "sate"
     - "satte"
     - "stae"
     - "staet"
@@ -3925,6 +3952,7 @@ matches:
   - triggers:
     - "sring"
     - "srting"
+    - "sting"
     - "stirng"
     - "strig"
     - "strign"
@@ -4096,6 +4124,7 @@ matches:
     - "hteme"
     - "tehme"
     - "teme"
+    - "thee"
     - "theem"
     - "thme"
     - "thmee"
@@ -4140,6 +4169,7 @@ matches:
     - "toat"
     - "toats"
     - "tosat"
+    - "tost"
     replace: "toast"
     propagate_case: true
     word: true

--- a/packages/refuos-dev/0.1.0/package.yml
+++ b/packages/refuos-dev/0.1.0/package.yml
@@ -5,15887 +5,4455 @@
 
 matches:
 
-  - trigger: "absraction"
+  - triggers:
+    - "absraction"
+    - "absrtaction"
+    - "abstaction"
+    - "abstarction"
+    - "abstracion"
+    - "abstraciton"
+    - "abstractin"
+    - "abstractino"
+    - "abstractoin"
+    - "abstracton"
+    - "abstratcion"
+    - "abstration"
+    - "abstrcation"
+    - "abstrction"
+    - "abtraction"
+    - "abtsraction"
+    - "asbtraction"
+    - "astraction"
+    - "bastraction"
     replace: "abstraction"
     propagate_case: true
     word: true
 
-  - trigger: "absrtaction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstaction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstarction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstracion"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstraciton"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstractin"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstractino"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstractoin"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstracton"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstratcion"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstration"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstrcation"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abstrction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abtraction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "abtsraction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "asbtraction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "astraction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "bastraction"
-    replace: "abstraction"
-    propagate_case: true
-    word: true
-
-  - trigger: "accesibility"
+  - triggers:
+    - "accesibility"
+    - "accesisbility"
+    - "accessbiility"
+    - "accessbility"
+    - "accessibiilty"
+    - "accessibiity"
+    - "accessibiliy"
+    - "accessibiliyt"
+    - "accessibiltiy"
+    - "accessibilty"
+    - "accessibliity"
+    - "accessiblity"
+    - "accessiiblity"
+    - "accessiility"
+    - "accsesibility"
+    - "accssibility"
+    - "acecssibility"
+    - "acessibility"
+    - "cacessibility"
     replace: "accessibility"
     propagate_case: true
     word: true
 
-  - trigger: "accesisbility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessbiility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessbility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibiilty"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibiity"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibiliy"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibiliyt"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibiltiy"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibilty"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessibliity"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessiblity"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessiiblity"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accessiility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accsesibility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "accssibility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "acecssibility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "acessibility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "cacessibility"
-    replace: "accessibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "aadpter"
+  - triggers:
+    - "aadpter"
+    - "aapter"
+    - "adaper"
+    - "adapetr"
+    - "adaptr"
+    - "adaptre"
+    - "adater"
+    - "adatper"
+    - "adpater"
+    - "adpter"
+    - "daapter"
     replace: "adapter"
     propagate_case: true
     word: true
 
-  - trigger: "aapter"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adaper"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adapetr"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adaptr"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adaptre"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adater"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adatper"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adpater"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "adpter"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "daapter"
-    replace: "adapter"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggegate"
+  - triggers:
+    - "aggegate"
+    - "aggergate"
+    - "aggreagte"
+    - "aggreate"
+    - "aggregae"
+    - "aggregaet"
+    - "aggregtae"
+    - "aggregte"
+    - "aggrgate"
+    - "aggrgeate"
+    - "agregate"
+    - "agrgegate"
+    - "gagregate"
     replace: "aggregate"
     propagate_case: true
     word: true
 
-  - trigger: "aggergate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggreagte"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggreate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggregae"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggregaet"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggregtae"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggregte"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggrgate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggrgeate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "agregate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "agrgegate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagregate"
-    replace: "aggregate"
-    propagate_case: true
-    word: true
-
-  - trigger: "achor"
+  - triggers:
+    - "achor"
+    - "acnhor"
+    - "anchr"
+    - "anchro"
+    - "ancohr"
+    - "ancor"
+    - "anhcor"
+    - "anhor"
+    - "nachor"
     replace: "anchor"
     propagate_case: true
     word: true
 
-  - trigger: "acnhor"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "anchr"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "anchro"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancohr"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancor"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "anhcor"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "anhor"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "nachor"
-    replace: "anchor"
-    propagate_case: true
-    word: true
-
-  - trigger: "aimation"
+  - triggers:
+    - "aimation"
+    - "ainmation"
+    - "aniamtion"
+    - "aniation"
+    - "animaion"
+    - "animaiton"
+    - "animatin"
+    - "animatino"
+    - "animatoin"
+    - "animaton"
+    - "animtaion"
+    - "animtion"
+    - "anmation"
+    - "anmiation"
+    - "naimation"
     replace: "animation"
     propagate_case: true
     word: true
 
-  - trigger: "ainmation"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "aniamtion"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "aniation"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animaion"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animaiton"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animatin"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animatino"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animatoin"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animaton"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animtaion"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "animtion"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "anmation"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "anmiation"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "naimation"
-    replace: "animation"
-    propagate_case: true
-    word: true
-
-  - trigger: "agrument"
+  - triggers:
+    - "agrument"
+    - "agument"
+    - "argment"
+    - "argmuent"
+    - "arguemnt"
+    - "arguent"
+    - "argumet"
+    - "argumetn"
+    - "argumnet"
+    - "argumnt"
+    - "arugment"
+    - "arument"
+    - "ragument"
     replace: "argument"
     propagate_case: true
     word: true
 
-  - trigger: "agument"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argment"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argmuent"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "arguemnt"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "arguent"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argumet"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argumetn"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argumnet"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "argumnt"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "arugment"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "arument"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "ragument"
-    replace: "argument"
-    propagate_case: true
-    word: true
-
-  - trigger: "asert"
+  - triggers:
+    - "asert"
+    - "asesrt"
+    - "assetr"
+    - "assret"
+    - "assrt"
+    - "sasert"
     replace: "assert"
     propagate_case: true
     word: true
 
-  - trigger: "asesrt"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "asset"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "assetr"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "assret"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "assrt"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "sasert"
-    replace: "assert"
-    propagate_case: true
-    word: true
-
-  - trigger: "asnc"
+  - triggers:
+    - "asnc"
+    - "asnyc"
+    - "asyc"
+    - "asycn"
+    - "aync"
+    - "aysnc"
+    - "saync"
     replace: "async"
     propagate_case: true
     word: true
 
-  - trigger: "asnyc"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "asyc"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "asycn"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "aync"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "aysnc"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "saync"
-    replace: "async"
-    propagate_case: true
-    word: true
-
-  - trigger: "asnchronous"
+  - triggers:
+    - "asnchronous"
+    - "asnychronous"
+    - "asychronous"
+    - "asycnhronous"
+    - "asynchonous"
+    - "asynchornous"
+    - "asynchrnoous"
+    - "asynchrnous"
+    - "asynchronos"
+    - "asynchronosu"
+    - "asynchronuos"
+    - "asynchronus"
+    - "asynchroonus"
+    - "asynchroous"
+    - "asyncrhonous"
+    - "asyncronous"
+    - "asynhcronous"
+    - "asynhronous"
+    - "aynchronous"
+    - "aysnchronous"
+    - "saynchronous"
     replace: "asynchronous"
     propagate_case: true
     word: true
 
-  - trigger: "asnychronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asychronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asycnhronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchonous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchornous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchrnoous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchrnous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchronos"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchronosu"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchronuos"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchronus"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchroonus"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynchroous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asyncrhonous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asyncronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynhcronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "asynhronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "aynchronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "aysnchronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "saynchronous"
-    replace: "asynchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "atribute"
+  - triggers:
+    - "atribute"
+    - "atrtibute"
+    - "attibute"
+    - "attirbute"
+    - "attrbiute"
+    - "attrbute"
+    - "attribte"
+    - "attribtue"
+    - "attribue"
+    - "attribuet"
+    - "attriubte"
+    - "attriute"
+    - "tatribute"
     replace: "attribute"
     propagate_case: true
     word: true
 
-  - trigger: "atrtibute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attibute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attirbute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attrbiute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attrbute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attribte"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attribtue"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attribue"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attribuet"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attriubte"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "attriute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "tatribute"
-    replace: "attribute"
-    propagate_case: true
-    word: true
-
-  - trigger: "atocomplete"
+  - triggers:
+    - "atocomplete"
+    - "atuocomplete"
+    - "auocomplete"
+    - "auotcomplete"
+    - "autcomplete"
+    - "autcoomplete"
+    - "autocmoplete"
+    - "autocmplete"
+    - "autocomlete"
+    - "autocomlpete"
+    - "autocompelte"
+    - "autocompete"
+    - "autocomplee"
+    - "autocompleet"
+    - "autocomplte"
+    - "autocompltee"
+    - "autocoplete"
+    - "autocopmlete"
+    - "autoocmplete"
+    - "autoomplete"
+    - "uatocomplete"
     replace: "autocomplete"
     propagate_case: true
     word: true
 
-  - trigger: "atuocomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "auocomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "auotcomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autcomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autcoomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocmoplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocmplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocomlete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocomlpete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocompelte"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocompete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocomplee"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocompleet"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocomplte"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocompltee"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocoplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autocopmlete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autoocmplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "autoomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "uatocomplete"
-    replace: "autocomplete"
-    propagate_case: true
-    word: true
-
-  - trigger: "atofocus"
+  - triggers:
+    - "atofocus"
+    - "atuofocus"
+    - "auofocus"
+    - "auotfocus"
+    - "autfocus"
+    - "autfoocus"
+    - "autofcous"
+    - "autofcus"
+    - "autofocs"
+    - "autofocsu"
+    - "autofoucs"
+    - "autofous"
+    - "autoocus"
+    - "autoofcus"
+    - "uatofocus"
     replace: "autofocus"
     propagate_case: true
     word: true
 
-  - trigger: "atuofocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "auofocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "auotfocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autfocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autfoocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofcous"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofcus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofocs"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofocsu"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofoucs"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autofous"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autoocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "autoofcus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "uatofocus"
-    replace: "autofocus"
-    propagate_case: true
-    word: true
-
-  - trigger: "aatar"
+  - triggers:
+    - "aatar"
+    - "aavtar"
+    - "avaar"
+    - "avaatr"
+    - "avatr"
+    - "avatra"
+    - "avtaar"
+    - "avtar"
+    - "vaatar"
     replace: "avatar"
     propagate_case: true
     word: true
 
-  - trigger: "aavtar"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avaar"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avaatr"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avatr"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avatra"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avtaar"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "avtar"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "vaatar"
-    replace: "avatar"
-    propagate_case: true
-    word: true
-
-  - trigger: "aait"
+  - triggers:
+    - "aait"
+    - "aawit"
+    - "awat"
+    - "awati"
+    - "awiat"
+    - "awit"
+    - "waait"
     replace: "await"
     propagate_case: true
     word: true
 
-  - trigger: "aawit"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "awat"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "awati"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "awiat"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "awit"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "waait"
-    replace: "await"
-    propagate_case: true
-    word: true
-
-  - trigger: "abckground"
+  - triggers:
+    - "abckground"
+    - "bacgkround"
+    - "bacground"
+    - "backgorund"
+    - "backgound"
+    - "backgrond"
+    - "backgronud"
+    - "backgroud"
+    - "backgroudn"
+    - "backgrund"
+    - "backgruond"
+    - "backrgound"
+    - "backround"
+    - "bakcground"
+    - "bakground"
+    - "bcakground"
+    - "bckground"
     replace: "background"
     propagate_case: true
     word: true
 
-  - trigger: "bacgkround"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "bacground"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgorund"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgound"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgrond"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgronud"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgroud"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgroudn"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgrund"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backgruond"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backrgound"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "backround"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "bakcground"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "bakground"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "bcakground"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "bckground"
-    replace: "background"
-    propagate_case: true
-    word: true
-
-  - trigger: "abcklog"
+  - triggers:
+    - "abcklog"
+    - "backlg"
+    - "backlgo"
+    - "backog"
+    - "backolg"
+    - "baclkog"
+    - "baclog"
+    - "bakclog"
+    - "baklog"
+    - "bcaklog"
+    - "bcklog"
     replace: "backlog"
     propagate_case: true
     word: true
 
-  - trigger: "backlg"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "backlgo"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "backog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "backolg"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "baclkog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "baclog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "bakclog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "baklog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "bcaklog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "bcklog"
-    replace: "backlog"
-    propagate_case: true
-    word: true
-
-  - trigger: "abdge"
+  - triggers:
+    - "abdge"
+    - "badeg"
+    - "bagde"
+    - "bage"
+    - "bdage"
+    - "bdge"
     replace: "badge"
     propagate_case: true
     word: true
 
-  - trigger: "bade"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "badeg"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "bagde"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "bage"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "bdage"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "bdge"
-    replace: "badge"
-    propagate_case: true
-    word: true
-
-  - trigger: "bolean"
+  - triggers:
+    - "bolean"
+    - "boloean"
+    - "booean"
+    - "booelan"
+    - "boolaen"
+    - "boolan"
+    - "boolen"
+    - "boolena"
+    - "obolean"
     replace: "boolean"
     propagate_case: true
     word: true
 
-  - trigger: "boloean"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "booean"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "booelan"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "boolaen"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "boolan"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "boolen"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "boolena"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "obolean"
-    replace: "boolean"
-    propagate_case: true
-    word: true
-
-  - trigger: "boder"
+  - triggers:
+    - "boder"
+    - "bodrer"
+    - "bordr"
+    - "bordre"
+    - "boredr"
+    - "brder"
+    - "broder"
+    - "obrder"
     replace: "border"
     propagate_case: true
     word: true
 
-  - trigger: "bodrer"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "bordr"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "bordre"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "boredr"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "borer"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "brder"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "broder"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "obrder"
-    replace: "border"
-    propagate_case: true
-    word: true
-
-  - trigger: "banch"
+  - triggers:
+    - "banch"
+    - "barnch"
+    - "bracnh"
+    - "branh"
+    - "branhc"
+    - "brnach"
+    - "brnch"
+    - "rbanch"
     replace: "branch"
     propagate_case: true
     word: true
 
-  - trigger: "barnch"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "brach"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "bracnh"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "branh"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "branhc"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "brnach"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "brnch"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbanch"
-    replace: "branch"
-    propagate_case: true
-    word: true
-
-  - trigger: "beadcrumb"
+  - triggers:
+    - "beadcrumb"
+    - "beradcrumb"
+    - "bradcrumb"
+    - "braedcrumb"
+    - "breacdrumb"
+    - "breacrumb"
+    - "breadcrmb"
+    - "breadcrmub"
+    - "breadcrub"
+    - "breadcrubm"
+    - "breadcumb"
+    - "breadcurmb"
+    - "breadrcumb"
+    - "breadrumb"
+    - "bredacrumb"
+    - "bredcrumb"
+    - "rbeadcrumb"
     replace: "breadcrumb"
     propagate_case: true
     word: true
 
-  - trigger: "beradcrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "bradcrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "braedcrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breacdrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breacrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcrmb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcrmub"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcrub"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcrubm"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadcurmb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadrcumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "breadrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "bredacrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "bredcrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbeadcrumb"
-    replace: "breadcrumb"
-    propagate_case: true
-    word: true
-
-  - trigger: "beakpoint"
+  - triggers:
+    - "beakpoint"
+    - "berakpoint"
+    - "braekpoint"
+    - "brakpoint"
+    - "breakoint"
+    - "breakopint"
+    - "breakpint"
+    - "breakpiont"
+    - "breakpoit"
+    - "breakpoitn"
+    - "breakponit"
+    - "breakpont"
+    - "breapkoint"
+    - "breapoint"
+    - "brekapoint"
+    - "brekpoint"
+    - "rbeakpoint"
     replace: "breakpoint"
     propagate_case: true
     word: true
 
-  - trigger: "berakpoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "braekpoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "brakpoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakopint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakpint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakpiont"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakpoit"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakpoitn"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakponit"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breakpont"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breapkoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "breapoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "brekapoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "brekpoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbeakpoint"
-    replace: "breakpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "bild"
+  - triggers:
+    - "bild"
+    - "biuld"
+    - "buid"
+    - "buidl"
+    - "buld"
+    - "bulid"
+    - "ubild"
     replace: "build"
     propagate_case: true
     word: true
 
-  - trigger: "biuld"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "buid"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "buidl"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "buld"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "bulid"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubild"
-    replace: "build"
-    propagate_case: true
-    word: true
-
-  - trigger: "btton"
+  - triggers:
+    - "btton"
+    - "btuton"
+    - "buton"
+    - "butotn"
+    - "buttn"
+    - "buttno"
+    - "ubtton"
     replace: "button"
     propagate_case: true
     word: true
 
-  - trigger: "btuton"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "buton"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "butotn"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "buttn"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "buttno"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubtton"
-    replace: "button"
-    propagate_case: true
-    word: true
-
-  - trigger: "acllback"
+  - triggers:
+    - "acllback"
+    - "calback"
+    - "calblack"
+    - "callabck"
+    - "callack"
+    - "callbak"
+    - "callbakc"
+    - "callbcak"
+    - "callbck"
+    - "clalback"
+    - "cllback"
     replace: "callback"
     propagate_case: true
     word: true
 
-  - trigger: "calback"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "calblack"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callabck"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callack"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callbak"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callbakc"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callbcak"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "callbck"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "clalback"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "cllback"
-    replace: "callback"
-    propagate_case: true
-    word: true
-
-  - trigger: "acrd"
+  - triggers:
+    - "acrd"
+    - "cadr"
+    - "crad"
     replace: "card"
     propagate_case: true
     word: true
 
-  - trigger: "cadr"
-    replace: "card"
-    propagate_case: true
-    word: true
-
-  - trigger: "crad"
-    replace: "card"
-    propagate_case: true
-    word: true
-
-  - trigger: "acrousel"
+  - triggers:
+    - "acrousel"
+    - "caorusel"
+    - "caousel"
+    - "carosel"
+    - "carosuel"
+    - "carouel"
+    - "carouesl"
+    - "carousl"
+    - "carousle"
+    - "caruosel"
+    - "carusel"
+    - "craousel"
+    - "crousel"
     replace: "carousel"
     propagate_case: true
     word: true
 
-  - trigger: "caorusel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "caousel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carosel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carosuel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carouel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carouesl"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carousl"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carousle"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "caruosel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "carusel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "craousel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "crousel"
-    replace: "carousel"
-    propagate_case: true
-    word: true
-
-  - trigger: "acscade"
+  - triggers:
+    - "acscade"
+    - "cacade"
+    - "cacsade"
+    - "casacde"
+    - "casade"
+    - "cascae"
+    - "cascaed"
+    - "cascdae"
+    - "cascde"
+    - "csacade"
+    - "cscade"
     replace: "cascade"
     propagate_case: true
     word: true
 
-  - trigger: "cacade"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cacsade"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "casacde"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "casade"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cascae"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cascaed"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cascdae"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cascde"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "csacade"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "cscade"
-    replace: "cascade"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceckbox"
+  - triggers:
+    - "ceckbox"
+    - "cehckbox"
+    - "chcekbox"
+    - "chckbox"
+    - "checbkox"
+    - "checbox"
+    - "checkbx"
+    - "checkbxo"
+    - "checkobx"
+    - "checkox"
+    - "chekbox"
+    - "chekcbox"
+    - "hceckbox"
     replace: "checkbox"
     propagate_case: true
     word: true
 
-  - trigger: "cehckbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "chcekbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "chckbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checbkox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkbx"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkbxo"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkobx"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "chekbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "chekcbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "hceckbox"
-    replace: "checkbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceckout"
+  - triggers:
+    - "ceckout"
+    - "cehckout"
+    - "chcekout"
+    - "chckout"
+    - "checkot"
+    - "checkotu"
+    - "checkuot"
+    - "checkut"
+    - "checokut"
+    - "checout"
+    - "chekcout"
+    - "chekout"
+    - "hceckout"
     replace: "checkout"
     propagate_case: true
     word: true
 
-  - trigger: "cehckout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "chcekout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "chckout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkot"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkotu"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkuot"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checkut"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checokut"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "checout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "chekcout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "chekout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "hceckout"
-    replace: "checkout"
-    propagate_case: true
-    word: true
-
-  - trigger: "clne"
+  - triggers:
+    - "clne"
+    - "clnoe"
+    - "cloe"
+    - "cloen"
+    - "colne"
+    - "lcone"
     replace: "clone"
     propagate_case: true
     word: true
 
-  - trigger: "clnoe"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloe"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloen"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "colne"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "cone"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "lcone"
-    replace: "clone"
-    propagate_case: true
-    word: true
-
-  - trigger: "closre"
+  - triggers:
+    - "closre"
+    - "closrue"
+    - "closue"
+    - "closuer"
+    - "cloure"
+    - "clousre"
+    - "clsoure"
+    - "clsure"
+    - "colsure"
+    - "cosure"
+    - "lcosure"
     replace: "closure"
     propagate_case: true
     word: true
 
-  - trigger: "closrue"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "closue"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "closuer"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "clousre"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "clsoure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "clsure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "colsure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "cosure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "lcosure"
-    replace: "closure"
-    propagate_case: true
-    word: true
-
-  - trigger: "clodflare"
+  - triggers:
+    - "clodflare"
+    - "cloduflare"
+    - "cloudfalre"
+    - "cloudfare"
+    - "cloudflae"
+    - "cloudflaer"
+    - "cloudflrae"
+    - "cloudflre"
+    - "cloudlare"
+    - "cloudlfare"
+    - "cloufdlare"
+    - "clouflare"
+    - "cludflare"
+    - "cluodflare"
+    - "coludflare"
+    - "coudflare"
+    - "lcoudflare"
     replace: "cloudflare"
     propagate_case: true
     word: true
 
-  - trigger: "cloduflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudfalre"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudfare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudflae"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudflaer"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudflrae"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudflre"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudlare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloudlfare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloufdlare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "clouflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cludflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cluodflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "coludflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "coudflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lcoudflare"
-    replace: "cloudflare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cloor"
+  - triggers:
+    - "cloor"
+    - "clor"
+    - "colr"
+    - "colro"
+    - "coolr"
+    - "coor"
+    - "oclor"
     replace: "color"
     propagate_case: true
     word: true
 
-  - trigger: "clor"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "colr"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "colro"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "coolr"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "coor"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "oclor"
-    replace: "color"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmmit"
+  - triggers:
+    - "cmmit"
+    - "cmomit"
+    - "comimt"
+    - "comit"
+    - "commt"
+    - "commti"
+    - "ocmmit"
     replace: "commit"
     propagate_case: true
     word: true
 
-  - trigger: "cmomit"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "comimt"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "comit"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "commt"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "commti"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmmit"
-    replace: "commit"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmoponent"
+  - triggers:
+    - "cmoponent"
+    - "cmponent"
+    - "comonent"
+    - "comopnent"
+    - "compnent"
+    - "compnoent"
+    - "compoennt"
+    - "compoent"
+    - "componet"
+    - "componetn"
+    - "componnet"
+    - "componnt"
+    - "copmonent"
+    - "coponent"
+    - "ocmponent"
     replace: "component"
     propagate_case: true
     word: true
 
-  - trigger: "cmponent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "comonent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "comopnent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "compnent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "compnoent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "compoennt"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "compoent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "componet"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "componetn"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "componnet"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "componnt"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "copmonent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "coponent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmponent"
-    replace: "component"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmoposition"
+  - triggers:
+    - "cmoposition"
+    - "cmposition"
+    - "comopsition"
+    - "comosition"
+    - "compoistion"
+    - "compoition"
+    - "composiion"
+    - "composiiton"
+    - "compositin"
+    - "compositino"
+    - "compositoin"
+    - "compositon"
+    - "compostiion"
+    - "compostion"
+    - "compsition"
+    - "compsoition"
+    - "copmosition"
+    - "coposition"
+    - "ocmposition"
     replace: "composition"
     propagate_case: true
     word: true
 
-  - trigger: "cmposition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "comopsition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "comosition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compoistion"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compoition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "composiion"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "composiiton"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compositin"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compositino"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compositoin"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compositon"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compostiion"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compostion"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compsition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "compsoition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "copmosition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "coposition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmposition"
-    replace: "composition"
-    propagate_case: true
-    word: true
-
-  - trigger: "cncurrency"
+  - triggers:
+    - "cncurrency"
+    - "cnocurrency"
+    - "cocnurrency"
+    - "cocurrency"
+    - "concrrency"
+    - "concrurency"
+    - "concurency"
+    - "concurerncy"
+    - "concurrecny"
+    - "concurrecy"
+    - "concurreny"
+    - "concurrenyc"
+    - "concurrncy"
+    - "concurrnecy"
+    - "conucrrency"
+    - "conurrency"
+    - "ocncurrency"
     replace: "concurrency"
     propagate_case: true
     word: true
 
-  - trigger: "cnocurrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "cocnurrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "cocurrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concrrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concrurency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurerncy"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurrecny"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurrecy"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurreny"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurrenyc"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurrncy"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "concurrnecy"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "conucrrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "conurrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocncurrency"
-    replace: "concurrency"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnfig"
+  - triggers:
+    - "cnfig"
+    - "cnofig"
+    - "cofig"
+    - "cofnig"
+    - "confg"
+    - "confgi"
+    - "conifg"
+    - "conig"
+    - "ocnfig"
     replace: "config"
     propagate_case: true
     word: true
 
-  - trigger: "cnofig"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofig"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofnig"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "confg"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "confgi"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "conifg"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "conig"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnfig"
-    replace: "config"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnfiguration"
+  - triggers:
+    - "cnfiguration"
+    - "cnofiguration"
+    - "cofiguration"
+    - "cofniguration"
+    - "confgiuration"
+    - "confguration"
+    - "configration"
+    - "configruation"
+    - "configuartion"
+    - "configuation"
+    - "configuraion"
+    - "configuraiton"
+    - "configuratin"
+    - "configuratino"
+    - "configuratoin"
+    - "configuraton"
+    - "configurtaion"
+    - "configurtion"
+    - "confiugration"
+    - "confiuration"
+    - "conifguration"
+    - "coniguration"
+    - "ocnfiguration"
     replace: "configuration"
     propagate_case: true
     word: true
 
-  - trigger: "cnofiguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofiguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofniguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "confgiuration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "confguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configruation"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuartion"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuation"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuraion"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuraiton"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuratin"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuratino"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuratoin"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configuraton"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configurtaion"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "configurtion"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "confiugration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "confiuration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "conifguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "coniguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnfiguration"
-    replace: "configuration"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnflict"
+  - triggers:
+    - "cnflict"
+    - "cnoflict"
+    - "coflict"
+    - "cofnlict"
+    - "confict"
+    - "confilct"
+    - "conflcit"
+    - "conflct"
+    - "conflit"
+    - "conflitc"
+    - "conlfict"
+    - "conlict"
+    - "ocnflict"
     replace: "conflict"
     propagate_case: true
     word: true
 
-  - trigger: "cnoflict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "coflict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "cofnlict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "confict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "confilct"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conflcit"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conflct"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conflit"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conflitc"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conlfict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "conlict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnflict"
-    replace: "conflict"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnost"
+  - triggers:
+    - "cnost"
+    - "cnst"
+    - "cont"
+    - "conts"
+    - "cosnt"
+    - "ocnst"
     replace: "const"
     propagate_case: true
     word: true
 
-  - trigger: "cnst"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "cont"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "conts"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "cosnt"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "cost"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnst"
-    replace: "const"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnostructor"
+  - triggers:
+    - "cnostructor"
+    - "cnstructor"
+    - "consrtuctor"
+    - "consructor"
+    - "constrctor"
+    - "constrcutor"
+    - "construcor"
+    - "construcotr"
+    - "constructr"
+    - "constructro"
+    - "construtcor"
+    - "construtor"
+    - "constuctor"
+    - "consturctor"
+    - "contructor"
+    - "contsructor"
+    - "cosntructor"
+    - "costructor"
+    - "ocnstructor"
     replace: "constructor"
     propagate_case: true
     word: true
 
-  - trigger: "cnstructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "consrtuctor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "consructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "constrctor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "constrcutor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "construcor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "construcotr"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "constructr"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "constructro"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "construtcor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "construtor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "constuctor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "consturctor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "contructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "contsructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cosntructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "costructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnstructor"
-    replace: "constructor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnotainer"
+  - triggers:
+    - "cnotainer"
+    - "cntainer"
+    - "conainer"
+    - "conatiner"
+    - "contaienr"
+    - "contaier"
+    - "containr"
+    - "containre"
+    - "contaner"
+    - "contanier"
+    - "contianer"
+    - "continer"
+    - "cotainer"
+    - "cotnainer"
+    - "ocntainer"
     replace: "container"
     propagate_case: true
     word: true
 
-  - trigger: "cntainer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "conainer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "conatiner"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "contaienr"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "contaier"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "containr"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "containre"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "contaner"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "contanier"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "contianer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "continer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotainer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotnainer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocntainer"
-    replace: "container"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnotenteditable"
+  - triggers:
+    - "cnotenteditable"
+    - "cntenteditable"
+    - "conenteditable"
+    - "conetnteditable"
+    - "conteneditable"
+    - "contenetditable"
+    - "contentdeitable"
+    - "contentditable"
+    - "contentediable"
+    - "contentediatble"
+    - "contenteditabe"
+    - "contenteditabel"
+    - "contenteditalbe"
+    - "contenteditale"
+    - "contenteditbale"
+    - "contenteditble"
+    - "contentedtable"
+    - "contentedtiable"
+    - "contenteidtable"
+    - "contenteitable"
+    - "conteteditable"
+    - "contetneditable"
+    - "contneteditable"
+    - "contnteditable"
+    - "cotenteditable"
+    - "cotnenteditable"
+    - "ocntenteditable"
     replace: "contenteditable"
     propagate_case: true
     word: true
 
-  - trigger: "cntenteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "conenteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "conetnteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "conteneditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenetditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentdeitable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentediable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentediatble"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditabe"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditabel"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditalbe"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditale"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditbale"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteditble"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentedtable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contentedtiable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteidtable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contenteitable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "conteteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contetneditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contneteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "contnteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotenteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotnenteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocntenteditable"
-    replace: "contenteditable"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnotroller"
+  - triggers:
+    - "cnotroller"
+    - "cntroller"
+    - "conroller"
+    - "conrtoller"
+    - "contoller"
+    - "contorller"
+    - "contrller"
+    - "contrloler"
+    - "controlelr"
+    - "controler"
+    - "controllr"
+    - "controllre"
+    - "cotnroller"
+    - "cotroller"
+    - "ocntroller"
     replace: "controller"
     propagate_case: true
     word: true
 
-  - trigger: "cntroller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "conroller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "conrtoller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "contoller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "contorller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "contrller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "contrloler"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "controlelr"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "controler"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "controllr"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "controllre"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotnroller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotroller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocntroller"
-    replace: "controller"
-    propagate_case: true
-    word: true
-
-  - trigger: "coorutine"
+  - triggers:
+    - "coorutine"
+    - "cooutine"
+    - "corotine"
+    - "corotuine"
+    - "corouine"
+    - "corouitne"
+    - "coroutie"
+    - "coroutien"
+    - "coroutne"
+    - "coroutnie"
+    - "coruotine"
+    - "corutine"
+    - "crooutine"
+    - "croutine"
+    - "ocroutine"
     replace: "coroutine"
     propagate_case: true
     word: true
 
-  - trigger: "cooutine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "corotine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "corotuine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "corouine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "corouitne"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coroutie"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coroutien"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coroutne"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coroutnie"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coruotine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "corutine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "crooutine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "croutine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocroutine"
-    replace: "coroutine"
-    propagate_case: true
-    word: true
-
-  - trigger: "coerage"
+  - triggers:
+    - "coerage"
+    - "coevrage"
+    - "coveage"
+    - "covearge"
+    - "coverae"
+    - "coveraeg"
+    - "covergae"
+    - "coverge"
+    - "covrage"
+    - "covreage"
+    - "cverage"
+    - "cvoerage"
+    - "ocverage"
     replace: "coverage"
     propagate_case: true
     word: true
 
-  - trigger: "coevrage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "coveage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "covearge"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "coverae"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "coveraeg"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "covergae"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "coverge"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "covrage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "covreage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "cverage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "cvoerage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocverage"
-    replace: "coverage"
-    propagate_case: true
-    word: true
-
-  - trigger: "crsor"
+  - triggers:
+    - "crsor"
+    - "crusor"
+    - "curor"
+    - "curosr"
+    - "cursr"
+    - "cursro"
+    - "cusor"
+    - "cusror"
+    - "ucrsor"
     replace: "cursor"
     propagate_case: true
     word: true
 
-  - trigger: "crusor"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "curor"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "curosr"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cursr"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cursro"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cusor"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "cusror"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "ucrsor"
-    replace: "cursor"
-    propagate_case: true
-    word: true
-
-  - trigger: "adshboard"
+  - triggers:
+    - "adshboard"
+    - "dahboard"
+    - "dahsboard"
+    - "dasbhoard"
+    - "dasboard"
+    - "dashbaord"
+    - "dashbard"
+    - "dashboad"
+    - "dashboadr"
+    - "dashborad"
+    - "dashbord"
+    - "dashoard"
+    - "dashobard"
+    - "dsahboard"
+    - "dshboard"
     replace: "dashboard"
     propagate_case: true
     word: true
 
-  - trigger: "dahboard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dahsboard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dasbhoard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dasboard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashbaord"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashbard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashboad"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashboadr"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashborad"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashbord"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashoard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dashobard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsahboard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "dshboard"
-    replace: "dashboard"
-    propagate_case: true
-    word: true
-
-  - trigger: "adta"
+  - triggers:
+    - "adta"
+    - "daat"
+    - "dtaa"
     replace: "data"
     propagate_case: true
     word: true
 
-  - trigger: "daat"
-    replace: "data"
-    propagate_case: true
-    word: true
-
-  - trigger: "dtaa"
-    replace: "data"
-    propagate_case: true
-    word: true
-
-  - trigger: "adtabase"
+  - triggers:
+    - "adtabase"
+    - "daabase"
+    - "daatbase"
+    - "dataabse"
+    - "dataase"
+    - "databae"
+    - "databaes"
+    - "databsae"
+    - "databse"
+    - "datbaase"
+    - "datbase"
+    - "dtaabase"
+    - "dtabase"
     replace: "database"
     propagate_case: true
     word: true
 
-  - trigger: "daabase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "daatbase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "dataabse"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "dataase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "databae"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "databaes"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "databsae"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "databse"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "datbaase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "datbase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "dtaabase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "dtabase"
-    replace: "database"
-    propagate_case: true
-    word: true
-
-  - trigger: "dadlock"
+  - triggers:
+    - "dadlock"
+    - "daedlock"
+    - "deadlck"
+    - "deadlcok"
+    - "deadlok"
+    - "deadlokc"
+    - "deadock"
+    - "deadolck"
+    - "dealdock"
+    - "dealock"
+    - "dedalock"
+    - "dedlock"
+    - "edadlock"
     replace: "deadlock"
     propagate_case: true
     word: true
 
-  - trigger: "daedlock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadlck"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadlcok"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadlok"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadlokc"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "deadolck"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "dealdock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "dealock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "dedalock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "dedlock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "edadlock"
-    replace: "deadlock"
-    propagate_case: true
-    word: true
-
-  - trigger: "dbeounce"
+  - triggers:
+    - "dbeounce"
+    - "dbounce"
+    - "debonce"
+    - "debonuce"
+    - "debouce"
+    - "deboucne"
+    - "deboune"
+    - "debounec"
+    - "debunce"
+    - "debuonce"
+    - "deobunce"
+    - "deounce"
+    - "edbounce"
     replace: "debounce"
     propagate_case: true
     word: true
 
-  - trigger: "dbounce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debonce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debonuce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debouce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "deboucne"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "deboune"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debounec"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debunce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "debuonce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "deobunce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "deounce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "edbounce"
-    replace: "debounce"
-    propagate_case: true
-    word: true
-
-  - trigger: "dbeug"
+  - triggers:
+    - "dbeug"
+    - "dbug"
+    - "debg"
+    - "debgu"
+    - "deubg"
+    - "deug"
+    - "edbug"
     replace: "debug"
     propagate_case: true
     word: true
 
-  - trigger: "dbug"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "debg"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "debgu"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "deubg"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "deug"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "edbug"
-    replace: "debug"
-    propagate_case: true
-    word: true
-
-  - trigger: "dceorator"
+  - triggers:
+    - "dceorator"
+    - "dcorator"
+    - "decoartor"
+    - "decoator"
+    - "decoraor"
+    - "decoraotr"
+    - "decoratr"
+    - "decoratro"
+    - "decortaor"
+    - "decortor"
+    - "decrator"
+    - "decroator"
+    - "deocrator"
+    - "deorator"
+    - "edcorator"
     replace: "decorator"
     propagate_case: true
     word: true
 
-  - trigger: "dcorator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoartor"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoraor"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoraotr"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoratr"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decoratro"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decortaor"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decortor"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decrator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "decroator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "deocrator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "deorator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "edcorator"
-    replace: "decorator"
-    propagate_case: true
-    word: true
-
-  - trigger: "deendency"
+  - triggers:
+    - "deendency"
+    - "deepndency"
+    - "depedency"
+    - "depednency"
+    - "dependecny"
+    - "dependecy"
+    - "dependeny"
+    - "dependenyc"
+    - "dependncy"
+    - "dependnecy"
+    - "depenedncy"
+    - "depenency"
+    - "depndency"
+    - "depnedency"
+    - "dpeendency"
+    - "dpendency"
+    - "edpendency"
     replace: "dependency"
     propagate_case: true
     word: true
 
-  - trigger: "deepndency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depedency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depednency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependecny"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependecy"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependeny"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependenyc"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependncy"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dependnecy"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depenedncy"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depenency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depndency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "depnedency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dpeendency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "dpendency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "edpendency"
-    replace: "dependency"
-    propagate_case: true
-    word: true
-
-  - trigger: "deloy"
+  - triggers:
+    - "deloy"
+    - "delpoy"
+    - "deply"
+    - "deplyo"
+    - "depoly"
+    - "depoy"
+    - "dpeloy"
+    - "dploy"
+    - "edploy"
     replace: "deploy"
     propagate_case: true
     word: true
 
-  - trigger: "delpoy"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "deply"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "deplyo"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "depoly"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "depoy"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "dpeloy"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "dploy"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "edploy"
-    replace: "deploy"
-    propagate_case: true
-    word: true
-
-  - trigger: "deloyment"
+  - triggers:
+    - "deloyment"
+    - "delpoyment"
+    - "deploment"
+    - "deplomyent"
+    - "deployemnt"
+    - "deployent"
+    - "deploymet"
+    - "deploymetn"
+    - "deploymnet"
+    - "deploymnt"
+    - "deplyment"
+    - "deplyoment"
+    - "depolyment"
+    - "depoyment"
+    - "dpeloyment"
+    - "dployment"
+    - "edployment"
     replace: "deployment"
     propagate_case: true
     word: true
 
-  - trigger: "delpoyment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deploment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deplomyent"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deployemnt"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deployent"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deploymet"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deploymetn"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deploymnet"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deploymnt"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deplyment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "deplyoment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "depolyment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "depoyment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "dpeloyment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "dployment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "edployment"
-    replace: "deployment"
-    propagate_case: true
-    word: true
-
-  - trigger: "decribe"
+  - triggers:
+    - "decribe"
+    - "decsribe"
+    - "descibe"
+    - "descirbe"
+    - "descrbe"
+    - "descrbie"
+    - "descrie"
+    - "descrieb"
+    - "desrcibe"
+    - "desribe"
+    - "dscribe"
+    - "dsecribe"
+    - "edscribe"
     replace: "describe"
     propagate_case: true
     word: true
 
-  - trigger: "decsribe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descibe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descirbe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrbe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrbie"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrie"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrieb"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "desrcibe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "desribe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "dscribe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsecribe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "edscribe"
-    replace: "describe"
-    propagate_case: true
-    word: true
-
-  - trigger: "decriptor"
+  - triggers:
+    - "decriptor"
+    - "decsriptor"
+    - "desciptor"
+    - "descirptor"
+    - "descripor"
+    - "descripotr"
+    - "descriptr"
+    - "descriptro"
+    - "descritor"
+    - "descritpor"
+    - "descrpitor"
+    - "descrptor"
+    - "desrciptor"
+    - "desriptor"
+    - "dscriptor"
+    - "dsecriptor"
+    - "edscriptor"
     replace: "descriptor"
     propagate_case: true
     word: true
 
-  - trigger: "decsriptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "desciptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descirptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descripor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descripotr"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descriptr"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descriptro"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descritor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descritpor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrpitor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "descrptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "desrciptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "desriptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "dscriptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsecriptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "edscriptor"
-    replace: "descriptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "deerialization"
+  - triggers:
+    - "deerialization"
+    - "deesrialization"
+    - "deseialization"
+    - "deseiralization"
+    - "deserailization"
+    - "deseralization"
+    - "deseriailzation"
+    - "deseriaization"
+    - "deserialiation"
+    - "deserialiaztion"
+    - "deserializaion"
+    - "deserializaiton"
+    - "deserializatin"
+    - "deserializatino"
+    - "deserializatoin"
+    - "deserializaton"
+    - "deserializtaion"
+    - "deserializtion"
+    - "deserialzation"
+    - "deserialziation"
+    - "deserilaization"
+    - "deserilization"
+    - "desreialization"
+    - "desrialization"
+    - "dseerialization"
+    - "dserialization"
+    - "edserialization"
     replace: "deserialization"
     propagate_case: true
     word: true
 
-  - trigger: "deesrialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deseialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deseiralization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserailization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deseralization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deseriailzation"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deseriaization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserialiation"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserialiaztion"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializaion"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializaiton"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializatin"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializatino"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializatoin"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializaton"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializtaion"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserializtion"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserialzation"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserialziation"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserilaization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deserilization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "desreialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "desrialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "dseerialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "dserialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "edserialization"
-    replace: "deserialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "deign"
+  - triggers:
+    - "deisgn"
+    - "desgin"
+    - "desgn"
+    - "desin"
+    - "desing"
+    - "dseign"
+    - "dsign"
+    - "edsign"
     replace: "design"
     propagate_case: true
     word: true
 
-  - trigger: "deisgn"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "desgin"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "desgn"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "desin"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "desing"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "dseign"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsign"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "edsign"
-    replace: "design"
-    propagate_case: true
-    word: true
-
-  - trigger: "diective"
+  - triggers:
+    - "diective"
+    - "dierctive"
+    - "dircetive"
+    - "dirctive"
+    - "direcitve"
+    - "direcive"
+    - "directie"
+    - "directiev"
+    - "directve"
+    - "directvie"
+    - "diretcive"
+    - "diretive"
+    - "drective"
+    - "driective"
+    - "idrective"
     replace: "directive"
     propagate_case: true
     word: true
 
-  - trigger: "dierctive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "dircetive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "dirctive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "direcitve"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "direcive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "directie"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "directiev"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "directve"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "directvie"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "diretcive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "diretive"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "drective"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "driective"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "idrective"
-    replace: "directive"
-    propagate_case: true
-    word: true
-
-  - trigger: "diplay"
+  - triggers:
+    - "diplay"
+    - "dipslay"
+    - "dislay"
+    - "dislpay"
+    - "dispaly"
+    - "dispay"
+    - "disply"
+    - "displya"
+    - "dsiplay"
+    - "dsplay"
+    - "idsplay"
     replace: "display"
     propagate_case: true
     word: true
 
-  - trigger: "dipslay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dislay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dislpay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispaly"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "disply"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "displya"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsiplay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsplay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "idsplay"
-    replace: "display"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcker"
+  - triggers:
+    - "dcker"
+    - "dcoker"
+    - "docekr"
+    - "docer"
+    - "dockr"
+    - "dockre"
+    - "dokcer"
+    - "doker"
+    - "odcker"
     replace: "docker"
     propagate_case: true
     word: true
 
-  - trigger: "dcoker"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "docekr"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "docer"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "dockr"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "dockre"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "dokcer"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "doker"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "odcker"
-    replace: "docker"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcostring"
+  - triggers:
+    - "dcostring"
+    - "dcstring"
+    - "docsring"
+    - "docsrting"
+    - "docsting"
+    - "docstirng"
+    - "docstrig"
+    - "docstrign"
+    - "docstrng"
+    - "docstrnig"
+    - "doctring"
+    - "doctsring"
+    - "dosctring"
+    - "dostring"
+    - "odcstring"
     replace: "docstring"
     propagate_case: true
     word: true
 
-  - trigger: "dcstring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docsring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docsrting"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docsting"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docstirng"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docstrig"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docstrign"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docstrng"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "docstrnig"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctsring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "dosctring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "dostring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "odcstring"
-    replace: "docstring"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcotype"
+  - triggers:
+    - "dcotype"
+    - "dctype"
+    - "doctpe"
+    - "doctpye"
+    - "doctye"
+    - "doctyep"
+    - "docype"
+    - "docytpe"
+    - "dotcype"
+    - "dotype"
+    - "odctype"
     replace: "doctype"
     propagate_case: true
     word: true
 
-  - trigger: "dctype"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctpe"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctpye"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctye"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "doctyep"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "docype"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "docytpe"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "dotcype"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "dotype"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "odctype"
-    replace: "doctype"
-    propagate_case: true
-    word: true
-
-  - trigger: "dopdown"
+  - triggers:
+    - "dopdown"
+    - "dorpdown"
+    - "drodown"
+    - "drodpown"
+    - "dropdon"
+    - "dropdonw"
+    - "dropdwn"
+    - "dropdwon"
+    - "dropodwn"
+    - "dropown"
+    - "drpdown"
+    - "drpodown"
+    - "rdopdown"
     replace: "dropdown"
     propagate_case: true
     word: true
 
-  - trigger: "dorpdown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "drodown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "drodpown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropdon"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropdonw"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropdwn"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropdwon"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropodwn"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "dropown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "drpdown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "drpodown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "rdopdown"
-    replace: "dropdown"
-    propagate_case: true
-    word: true
-
-  - trigger: "aesing"
+  - triggers:
+    - "aesing"
+    - "eaing"
+    - "eaisng"
+    - "easig"
+    - "easign"
+    - "easng"
+    - "easnig"
+    - "esaing"
+    - "esing"
     replace: "easing"
     propagate_case: true
     word: true
 
-  - trigger: "eaing"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "eaisng"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "easig"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "easign"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "easng"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "easnig"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "esaing"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "esing"
-    replace: "easing"
-    propagate_case: true
-    word: true
-
-  - trigger: "ealsticsearch"
+  - triggers:
+    - "ealsticsearch"
+    - "easticsearch"
+    - "elasicsearch"
+    - "elasitcsearch"
+    - "elastcisearch"
+    - "elastcsearch"
+    - "elasticearch"
+    - "elasticesarch"
+    - "elasticsaerch"
+    - "elasticsarch"
+    - "elasticseach"
+    - "elasticseacrh"
+    - "elasticsearh"
+    - "elasticsearhc"
+    - "elasticserach"
+    - "elasticserch"
+    - "elastiscearch"
+    - "elastisearch"
+    - "elaticsearch"
+    - "elatsicsearch"
+    - "elsaticsearch"
+    - "elsticsearch"
+    - "leasticsearch"
     replace: "elasticsearch"
     propagate_case: true
     word: true
 
-  - trigger: "easticsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasicsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasitcsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elastcisearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elastcsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticesarch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticsaerch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticsarch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticseach"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticseacrh"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticsearh"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticsearhc"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticserach"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elasticserch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elastiscearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elastisearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elaticsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elatsicsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elsaticsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "elsticsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "leasticsearch"
-    replace: "elasticsearch"
-    propagate_case: true
-    word: true
-
-  - trigger: "eelment"
+  - triggers:
+    - "eelment"
+    - "eement"
+    - "eleemnt"
+    - "eleent"
+    - "elemet"
+    - "elemetn"
+    - "elemnet"
+    - "elemnt"
+    - "elmeent"
+    - "elment"
+    - "leement"
     replace: "element"
     propagate_case: true
     word: true
 
-  - trigger: "eement"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "eleemnt"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "eleent"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elemet"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elemetn"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elemnet"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elemnt"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elmeent"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "elment"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "leement"
-    replace: "element"
-    propagate_case: true
-    word: true
-
-  - trigger: "ecapsulation"
+  - triggers:
+    - "ecapsulation"
+    - "ecnapsulation"
+    - "enacpsulation"
+    - "enapsulation"
+    - "encapslation"
+    - "encapsluation"
+    - "encapsualtion"
+    - "encapsuation"
+    - "encapsulaion"
+    - "encapsulaiton"
+    - "encapsulatin"
+    - "encapsulatino"
+    - "encapsulatoin"
+    - "encapsulaton"
+    - "encapsultaion"
+    - "encapsultion"
+    - "encapulation"
+    - "encapuslation"
+    - "encaspulation"
+    - "encasulation"
+    - "encpasulation"
+    - "encpsulation"
+    - "necapsulation"
     replace: "encapsulation"
     propagate_case: true
     word: true
 
-  - trigger: "ecnapsulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "enacpsulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "enapsulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapslation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsluation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsualtion"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsuation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulaion"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulaiton"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulatin"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulatino"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulatoin"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsulaton"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsultaion"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapsultion"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encapuslation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encaspulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encasulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encpasulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "encpsulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "necapsulation"
-    replace: "encapsulation"
-    propagate_case: true
-    word: true
-
-  - trigger: "ednpoint"
+  - triggers:
+    - "ednpoint"
+    - "edpoint"
+    - "endoint"
+    - "endopint"
+    - "endpint"
+    - "endpiont"
+    - "endpoit"
+    - "endpoitn"
+    - "endponit"
+    - "endpont"
+    - "enpdoint"
+    - "enpoint"
+    - "nedpoint"
     replace: "endpoint"
     propagate_case: true
     word: true
 
-  - trigger: "edpoint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endoint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endopint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endpint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endpiont"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endpoit"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endpoitn"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endponit"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "endpont"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "enpdoint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "enpoint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "nedpoint"
-    replace: "endpoint"
-    propagate_case: true
-    word: true
-
-  - trigger: "enironment"
+  - triggers:
+    - "enironment"
+    - "enivronment"
+    - "envionment"
+    - "enviornment"
+    - "envirnment"
+    - "envirnoment"
+    - "enviroment"
+    - "enviromnent"
+    - "environemnt"
+    - "environent"
+    - "environmet"
+    - "environmetn"
+    - "environmnet"
+    - "environmnt"
+    - "envrionment"
+    - "envronment"
+    - "evironment"
+    - "evnironment"
+    - "nevironment"
     replace: "environment"
     propagate_case: true
     word: true
 
-  - trigger: "enivronment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "envionment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "enviornment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "envirnment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "envirnoment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "enviroment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "enviromnent"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environemnt"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environent"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environmet"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environmetn"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environmnet"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "environmnt"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "envrionment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "envronment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "evironment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "evnironment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "nevironment"
-    replace: "environment"
-    propagate_case: true
-    word: true
-
-  - trigger: "eror"
+  - triggers:
+    - "eror"
+    - "erorr"
+    - "errr"
+    - "errro"
+    - "reror"
     replace: "error"
     propagate_case: true
     word: true
 
-  - trigger: "erorr"
-    replace: "error"
-    propagate_case: true
-    word: true
-
-  - trigger: "errr"
-    replace: "error"
-    propagate_case: true
-    word: true
-
-  - trigger: "errro"
-    replace: "error"
-    propagate_case: true
-    word: true
-
-  - trigger: "reror"
-    replace: "error"
-    propagate_case: true
-    word: true
-
-  - trigger: "elint"
+  - triggers:
+    - "elint"
+    - "elsint"
+    - "esilnt"
+    - "esint"
+    - "eslit"
+    - "eslitn"
+    - "eslnit"
+    - "eslnt"
+    - "selint"
     replace: "eslint"
     propagate_case: true
     word: true
 
-  - trigger: "elsint"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "esilnt"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "esint"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslit"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslitn"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslnit"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslnt"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "selint"
-    replace: "eslint"
-    propagate_case: true
-    word: true
-
-  - trigger: "eception"
+  - triggers:
+    - "eception"
+    - "ecxeption"
+    - "excepion"
+    - "excepiton"
+    - "exceptin"
+    - "exceptino"
+    - "exceptoin"
+    - "excepton"
+    - "excetion"
+    - "excetpion"
+    - "excpetion"
+    - "excption"
+    - "execption"
+    - "exeption"
+    - "xeception"
     replace: "exception"
     propagate_case: true
     word: true
 
-  - trigger: "ecxeption"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excepion"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excepiton"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "exceptin"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "exceptino"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "exceptoin"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excepton"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excetion"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excetpion"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excpetion"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "excption"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "execption"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "exeption"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "xeception"
-    replace: "exception"
-    propagate_case: true
-    word: true
-
-  - trigger: "epect"
+  - triggers:
+    - "epect"
+    - "epxect"
+    - "exect"
+    - "exepct"
+    - "expcet"
+    - "expct"
+    - "expet"
+    - "expetc"
+    - "xepect"
     replace: "expect"
     propagate_case: true
     word: true
 
-  - trigger: "epxect"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "exect"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "exepct"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "expcet"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "expct"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "expet"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "expetc"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "xepect"
-    replace: "expect"
-    propagate_case: true
-    word: true
-
-  - trigger: "eport"
+  - triggers:
+    - "eport"
+    - "epxort"
+    - "exoprt"
+    - "exort"
+    - "expot"
+    - "expotr"
+    - "exprot"
+    - "exprt"
+    - "xeport"
     replace: "export"
     propagate_case: true
     word: true
 
-  - trigger: "epxort"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "exoprt"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "exort"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "expot"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "expotr"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "exprot"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "exprt"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "xeport"
-    replace: "export"
-    propagate_case: true
-    word: true
-
-  - trigger: "afcade"
+  - triggers:
+    - "afcade"
+    - "faacde"
+    - "faade"
+    - "facae"
+    - "facaed"
+    - "facdae"
+    - "facde"
+    - "fcaade"
+    - "fcade"
     replace: "facade"
     propagate_case: true
     word: true
 
-  - trigger: "faacde"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "faade"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "facae"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "facaed"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "facdae"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "facde"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcaade"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcade"
-    replace: "facade"
-    propagate_case: true
-    word: true
-
-  - trigger: "afctory"
+  - triggers:
+    - "afctory"
+    - "facory"
+    - "facotry"
+    - "factoy"
+    - "factoyr"
+    - "factroy"
+    - "factry"
+    - "fatcory"
+    - "fatory"
+    - "fcatory"
+    - "fctory"
     replace: "factory"
     propagate_case: true
     word: true
 
-  - trigger: "facory"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "facotry"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "factoy"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "factoyr"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "factroy"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "factry"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "fatcory"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "fatory"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcatory"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "fctory"
-    replace: "factory"
-    propagate_case: true
-    word: true
-
-  - trigger: "afvicon"
+  - triggers:
+    - "afvicon"
+    - "faicon"
+    - "faivcon"
+    - "favcion"
+    - "favcon"
+    - "favicn"
+    - "favicno"
+    - "faviocn"
+    - "favion"
+    - "fvaicon"
+    - "fvicon"
     replace: "favicon"
     propagate_case: true
     word: true
 
-  - trigger: "faicon"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "faivcon"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "favcion"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "favcon"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "favicn"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "favicno"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "faviocn"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "favion"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "fvaicon"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "fvicon"
-    replace: "favicon"
-    propagate_case: true
-    word: true
-
-  - trigger: "eftch"
+  - triggers:
+    - "eftch"
+    - "fech"
+    - "fecth"
+    - "feth"
+    - "fethc"
+    - "ftch"
+    - "ftech"
     replace: "fetch"
     propagate_case: true
     word: true
 
-  - trigger: "fech"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "fecth"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "feth"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "fethc"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "ftch"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "ftech"
-    replace: "fetch"
-    propagate_case: true
-    word: true
-
-  - trigger: "feildset"
+  - triggers:
+    - "feildset"
+    - "feldset"
+    - "fiedlset"
+    - "fiedset"
+    - "fieldest"
+    - "fieldet"
+    - "fieldst"
+    - "fieldste"
+    - "fielsdet"
+    - "fielset"
+    - "fildset"
+    - "filedset"
+    - "ifeldset"
     replace: "fieldset"
     propagate_case: true
     word: true
 
-  - trigger: "feldset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiedlset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiedset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fieldest"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fieldet"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fieldst"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fieldste"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fielsdet"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fielset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fildset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "filedset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifeldset"
-    replace: "fieldset"
-    propagate_case: true
-    word: true
-
-  - trigger: "fgcaption"
+  - triggers:
+    - "fgcaption"
+    - "fgicaption"
+    - "ficaption"
+    - "ficgaption"
+    - "figacption"
+    - "figaption"
+    - "figcapion"
+    - "figcapiton"
+    - "figcaptin"
+    - "figcaptino"
+    - "figcaptoin"
+    - "figcapton"
+    - "figcation"
+    - "figcatpion"
+    - "figcpation"
+    - "figcption"
+    - "ifgcaption"
     replace: "figcaption"
     propagate_case: true
     word: true
 
-  - trigger: "fgicaption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "ficaption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "ficgaption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figacption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figaption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcapion"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcapiton"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcaptin"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcaptino"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcaptoin"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcapton"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcation"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcatpion"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcpation"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "figcption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifgcaption"
-    replace: "figcaption"
-    propagate_case: true
-    word: true
-
-  - trigger: "filer"
+  - triggers:
+    - "filetr"
+    - "filtr"
+    - "filtre"
+    - "fiter"
+    - "fitler"
+    - "fliter"
+    - "flter"
+    - "iflter"
     replace: "filter"
     propagate_case: true
     word: true
 
-  - trigger: "filetr"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "filtr"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "filtre"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiter"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "fitler"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "fliter"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "flter"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "iflter"
-    replace: "filter"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiture"
+  - triggers:
+    - "fiture"
+    - "fitxure"
+    - "fixtre"
+    - "fixtrue"
+    - "fixtue"
+    - "fixtuer"
+    - "fixure"
+    - "fixutre"
+    - "fxiture"
+    - "fxture"
+    - "ifxture"
     replace: "fixture"
     propagate_case: true
     word: true
 
-  - trigger: "fitxure"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixtre"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixtrue"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixtue"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixtuer"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixure"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fixutre"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fxiture"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "fxture"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifxture"
-    replace: "fixture"
-    propagate_case: true
-    word: true
-
-  - trigger: "felx"
+  - triggers:
+    - "felx"
+    - "flxe"
+    - "lfex"
     replace: "flex"
     propagate_case: true
     word: true
 
-  - trigger: "flxe"
-    replace: "flex"
-    propagate_case: true
-    word: true
-
-  - trigger: "lfex"
-    replace: "flex"
-    propagate_case: true
-    word: true
-
-  - trigger: "felxbox"
+  - triggers:
+    - "felxbox"
+    - "fexbox"
+    - "flebox"
+    - "flebxox"
+    - "flexbx"
+    - "flexbxo"
+    - "flexobx"
+    - "flexox"
+    - "flxbox"
+    - "flxebox"
+    - "lfexbox"
     replace: "flexbox"
     propagate_case: true
     word: true
 
-  - trigger: "fexbox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flebox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flebxox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flexbx"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flexbxo"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flexobx"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flexox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flxbox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "flxebox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "lfexbox"
-    replace: "flexbox"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnot"
+  - triggers:
+    - "fnot"
+    - "fotn"
+    - "ofnt"
     replace: "font"
     propagate_case: true
     word: true
 
-  - trigger: "fotn"
-    replace: "font"
-    propagate_case: true
-    word: true
-
-  - trigger: "ofnt"
-    replace: "font"
-    propagate_case: true
-    word: true
-
-  - trigger: "fooer"
+  - triggers:
+    - "fooer"
+    - "fooetr"
+    - "footr"
+    - "footre"
+    - "foter"
+    - "fotoer"
+    - "ofoter"
     replace: "footer"
     propagate_case: true
     word: true
 
-  - trigger: "fooetr"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "footr"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "footre"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "foter"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "fotoer"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "ofoter"
-    replace: "footer"
-    propagate_case: true
-    word: true
-
-  - trigger: "foeground"
+  - triggers:
+    - "foeground"
+    - "foerground"
+    - "foregorund"
+    - "foregound"
+    - "foregrond"
+    - "foregronud"
+    - "foregroud"
+    - "foregroudn"
+    - "foregrund"
+    - "foregruond"
+    - "forergound"
+    - "foreround"
+    - "forgeround"
+    - "forground"
+    - "freground"
+    - "froeground"
+    - "ofreground"
     replace: "foreground"
     propagate_case: true
     word: true
 
-  - trigger: "foerground"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregorund"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregound"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregrond"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregronud"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregroud"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregroudn"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregrund"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foregruond"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "forergound"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "foreround"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "forgeround"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "forground"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "freground"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "froeground"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "ofreground"
-    replace: "foreground"
-    propagate_case: true
-    word: true
-
-  - trigger: "famework"
+  - triggers:
+    - "famework"
+    - "farmework"
+    - "fraemwork"
+    - "fraework"
+    - "frameork"
+    - "frameowrk"
+    - "framewok"
+    - "framewokr"
+    - "framewrk"
+    - "framewrok"
+    - "framweork"
+    - "framwork"
+    - "frmaework"
+    - "frmework"
+    - "rfamework"
     replace: "framework"
     propagate_case: true
     word: true
 
-  - trigger: "farmework"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraemwork"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraework"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "frameork"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "frameowrk"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framewok"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framewokr"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framewrk"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framewrok"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framweork"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "framwork"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "frmaework"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "frmework"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "rfamework"
-    replace: "framework"
-    propagate_case: true
-    word: true
-
-  - trigger: "fontend"
+  - triggers:
+    - "fontend"
+    - "forntend"
+    - "frnotend"
+    - "frntend"
+    - "fronend"
+    - "fronetnd"
+    - "frontedn"
+    - "frontnd"
+    - "frontned"
+    - "frotend"
+    - "frotnend"
+    - "rfontend"
     replace: "frontend"
     propagate_case: true
     word: true
 
-  - trigger: "forntend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frnotend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frntend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "fronend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "fronetnd"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "fronted"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frontedn"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frontnd"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frontned"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frotend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "frotnend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "rfontend"
-    replace: "frontend"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnction"
+  - triggers:
+    - "fnction"
+    - "fnuction"
+    - "fucntion"
+    - "fuction"
+    - "funcion"
+    - "funciton"
+    - "functin"
+    - "functino"
+    - "functoin"
+    - "functon"
+    - "funtcion"
+    - "funtion"
+    - "ufnction"
     replace: "function"
     propagate_case: true
     word: true
 
-  - trigger: "fnuction"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "fucntion"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuction"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "funcion"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "funciton"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "functin"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "functino"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "functoin"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "functon"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "funtcion"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "funtion"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "ufnction"
-    replace: "function"
-    propagate_case: true
-    word: true
-
-  - trigger: "agteway"
+  - triggers:
+    - "agteway"
+    - "gaetway"
+    - "gaeway"
+    - "gateawy"
+    - "gateay"
+    - "gatewy"
+    - "gatewya"
+    - "gatway"
+    - "gatweay"
+    - "gtaeway"
+    - "gteway"
     replace: "gateway"
     propagate_case: true
     word: true
 
-  - trigger: "gaetway"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gaeway"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gateawy"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gateay"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gatewy"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gatewya"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gatway"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gatweay"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gtaeway"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "gteway"
-    replace: "gateway"
-    propagate_case: true
-    word: true
-
-  - trigger: "egnerator"
+  - triggers:
+    - "egnerator"
+    - "geenrator"
+    - "geerator"
+    - "geneartor"
+    - "geneator"
+    - "generaor"
+    - "generaotr"
+    - "generatr"
+    - "generatro"
+    - "genertaor"
+    - "genertor"
+    - "genrator"
+    - "genreator"
+    - "gneerator"
+    - "gnerator"
     replace: "generator"
     propagate_case: true
     word: true
 
-  - trigger: "geenrator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "geerator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "geneartor"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "geneator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "generaor"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "generaotr"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "generatr"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "generatro"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "genertaor"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "genertor"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "genrator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "genreator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "gneerator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "gnerator"
-    replace: "generator"
-    propagate_case: true
-    word: true
-
-  - trigger: "gadient"
+  - triggers:
+    - "gadient"
+    - "gardient"
+    - "gradeint"
+    - "gradent"
+    - "gradiet"
+    - "gradietn"
+    - "gradinet"
+    - "gradint"
+    - "graident"
+    - "graient"
+    - "grdaient"
+    - "grdient"
+    - "rgadient"
     replace: "gradient"
     propagate_case: true
     word: true
 
-  - trigger: "gardient"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradeint"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradent"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradiet"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradietn"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradinet"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradint"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "graident"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "graient"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "grdaient"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "grdient"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgadient"
-    replace: "gradient"
-    propagate_case: true
-    word: true
-
-  - trigger: "gafana"
+  - triggers:
+    - "gafana"
+    - "garfana"
+    - "graafna"
+    - "graana"
+    - "grafaa"
+    - "grafaan"
+    - "grafna"
+    - "grafnaa"
+    - "grfaana"
+    - "grfana"
+    - "rgafana"
     replace: "grafana"
     propagate_case: true
     word: true
 
-  - trigger: "garfana"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "graafna"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "graana"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grafaa"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grafaan"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grafna"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grafnaa"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grfaana"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "grfana"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgafana"
-    replace: "grafana"
-    propagate_case: true
-    word: true
-
-  - trigger: "gaphql"
+  - triggers:
+    - "gaphql"
+    - "garphql"
+    - "grahpql"
+    - "grahql"
+    - "graphl"
+    - "graphlq"
+    - "grapqhl"
+    - "grapql"
+    - "grpahql"
+    - "grphql"
+    - "rgaphql"
     replace: "graphql"
     propagate_case: true
     word: true
 
-  - trigger: "garphql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grahpql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grahql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "graphl"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "graphlq"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grapqhl"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grapql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grpahql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "grphql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgaphql"
-    replace: "graphql"
-    propagate_case: true
-    word: true
-
-  - trigger: "gird"
+  - triggers:
+    - "grdi"
+    - "rgid"
     replace: "grid"
     propagate_case: true
     word: true
 
-  - trigger: "grdi"
-    replace: "grid"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgid"
-    replace: "grid"
-    propagate_case: true
-    word: true
-
-  - trigger: "gard"
+  - triggers:
+    - "gard"
+    - "gaurd"
+    - "guad"
+    - "guadr"
+    - "gurad"
+    - "gurd"
+    - "ugard"
     replace: "guard"
     propagate_case: true
     word: true
 
-  - trigger: "gaurd"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "guad"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "guadr"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "gurad"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "gurd"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "ugard"
-    replace: "guard"
-    propagate_case: true
-    word: true
-
-  - trigger: "gnicorn"
+  - triggers:
+    - "gnicorn"
+    - "gnuicorn"
+    - "guicorn"
+    - "guincorn"
+    - "gunciorn"
+    - "guncorn"
+    - "gunicon"
+    - "guniconr"
+    - "gunicrn"
+    - "gunicron"
+    - "guniocrn"
+    - "guniorn"
+    - "ugnicorn"
     replace: "gunicorn"
     propagate_case: true
     word: true
 
-  - trigger: "gnuicorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guicorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guincorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "gunciorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guncorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "gunicon"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guniconr"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "gunicrn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "gunicron"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guniocrn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "guniorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "ugnicorn"
-    replace: "gunicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "diempotent"
+  - triggers:
+    - "diempotent"
+    - "idemoptent"
+    - "idemotent"
+    - "idempoent"
+    - "idempoetnt"
+    - "idempotet"
+    - "idempotetn"
+    - "idempotnet"
+    - "idempotnt"
+    - "idemptent"
+    - "idemptoent"
+    - "idepmotent"
+    - "idepotent"
+    - "idmepotent"
+    - "idmpotent"
+    - "iedmpotent"
+    - "iempotent"
     replace: "idempotent"
     propagate_case: true
     word: true
 
-  - trigger: "idemoptent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idemotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempoent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempoetnt"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempotet"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempotetn"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempotnet"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idempotnt"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idemptent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idemptoent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idepmotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idepotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idmepotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "idmpotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "iedmpotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "iempotent"
-    replace: "idempotent"
-    propagate_case: true
-    word: true
-
-  - trigger: "immtable"
+  - triggers:
+    - "immtable"
+    - "immtuable"
+    - "immuable"
+    - "immuatble"
+    - "immutabe"
+    - "immutabel"
+    - "immutalbe"
+    - "immutale"
+    - "immutbale"
+    - "immutble"
+    - "imumtable"
+    - "imutable"
+    - "mimutable"
     replace: "immutable"
     propagate_case: true
     word: true
 
-  - trigger: "immtuable"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immuable"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immuatble"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutabe"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutabel"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutalbe"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutale"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutbale"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "immutble"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "imumtable"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "imutable"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "mimutable"
-    replace: "immutable"
-    propagate_case: true
-    word: true
-
-  - trigger: "imlements"
+  - triggers:
+    - "imlements"
+    - "imlpements"
+    - "impelments"
+    - "impements"
+    - "impleemnts"
+    - "impleents"
+    - "implemens"
+    - "implemenst"
+    - "implemetns"
+    - "implemets"
+    - "implemnets"
+    - "implemnts"
+    - "implmeents"
+    - "implments"
+    - "iplements"
+    - "ipmlements"
+    - "miplements"
     replace: "implements"
     propagate_case: true
     word: true
 
-  - trigger: "imlpements"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "impelments"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "impements"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleemnts"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "impleents"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemens"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemenst"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemetns"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemets"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemnets"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implemnts"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implmeents"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "implments"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "iplements"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmlements"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "miplements"
-    replace: "implements"
-    propagate_case: true
-    word: true
-
-  - trigger: "imoprt"
+  - triggers:
+    - "imoprt"
+    - "imort"
+    - "impot"
+    - "impotr"
+    - "improt"
+    - "imprt"
+    - "ipmort"
+    - "iport"
+    - "miport"
     replace: "import"
     propagate_case: true
     word: true
 
-  - trigger: "imort"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "impot"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "impotr"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "improt"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "imprt"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmort"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "iport"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "miport"
-    replace: "import"
-    propagate_case: true
-    word: true
-
-  - trigger: "identation"
+  - triggers:
+    - "identation"
+    - "idnentation"
+    - "indenation"
+    - "indenattion"
+    - "indentaion"
+    - "indentaiton"
+    - "indentatin"
+    - "indentatino"
+    - "indentatoin"
+    - "indentaton"
+    - "indenttaion"
+    - "indenttion"
+    - "indetation"
+    - "indetnation"
+    - "indnetation"
+    - "indntation"
+    - "inedntation"
+    - "inentation"
+    - "nidentation"
     replace: "indentation"
     propagate_case: true
     word: true
 
-  - trigger: "idnentation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indenation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indenattion"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentaion"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentaiton"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentatin"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentatino"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentatoin"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indentaton"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indenttaion"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indenttion"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indetation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indetnation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indnetation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "indntation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "inedntation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "inentation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "nidentation"
-    replace: "indentation"
-    propagate_case: true
-    word: true
-
-  - trigger: "iheritance"
+  - triggers:
+    - "iheritance"
+    - "ihneritance"
+    - "inehritance"
+    - "ineritance"
+    - "inheirtance"
+    - "inheitance"
+    - "inheriance"
+    - "inheriatnce"
+    - "inheritace"
+    - "inheritacne"
+    - "inheritane"
+    - "inheritanec"
+    - "inheritnace"
+    - "inheritnce"
+    - "inhertance"
+    - "inhertiance"
+    - "inhreitance"
+    - "inhritance"
+    - "niheritance"
     replace: "inheritance"
     propagate_case: true
     word: true
 
-  - trigger: "ihneritance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inehritance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "ineritance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheirtance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheitance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheriance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheriatnce"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritace"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritacne"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritane"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritanec"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritnace"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inheritnce"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inhertance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inhertiance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inhreitance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "inhritance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "niheritance"
-    replace: "inheritance"
-    propagate_case: true
-    word: true
-
-  - trigger: "ijectable"
+  - triggers:
+    - "ijectable"
+    - "ijnectable"
+    - "inectable"
+    - "inejctable"
+    - "injcetable"
+    - "injctable"
+    - "injecable"
+    - "injecatble"
+    - "injectabe"
+    - "injectabel"
+    - "injectalbe"
+    - "injectale"
+    - "injectbale"
+    - "injectble"
+    - "injetable"
+    - "injetcable"
+    - "nijectable"
     replace: "injectable"
     propagate_case: true
     word: true
 
-  - trigger: "ijnectable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "inectable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "inejctable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injcetable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injctable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injecable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injecatble"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectabe"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectabel"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectalbe"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectale"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectbale"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injectble"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injetable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "injetcable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "nijectable"
-    replace: "injectable"
-    propagate_case: true
-    word: true
-
-  - trigger: "inpt"
+  - triggers:
+    - "inpt"
+    - "inptu"
+    - "inupt"
+    - "inut"
+    - "ipnut"
+    - "iput"
+    - "niput"
     replace: "input"
     propagate_case: true
     word: true
 
-  - trigger: "inptu"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "inupt"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "inut"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipnut"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "iput"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "niput"
-    replace: "input"
-    propagate_case: true
-    word: true
-
-  - trigger: "inerceptor"
+  - triggers:
+    - "inerceptor"
+    - "inetrceptor"
+    - "inteceptor"
+    - "intecreptor"
+    - "intercepor"
+    - "intercepotr"
+    - "interceptr"
+    - "interceptro"
+    - "intercetor"
+    - "intercetpor"
+    - "intercpetor"
+    - "intercptor"
+    - "interecptor"
+    - "intereptor"
+    - "intrceptor"
+    - "intreceptor"
+    - "iterceptor"
+    - "itnerceptor"
+    - "niterceptor"
     replace: "interceptor"
     propagate_case: true
     word: true
 
-  - trigger: "inetrceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "inteceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intecreptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercepor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercepotr"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "interceptr"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "interceptro"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercetor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercetpor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercpetor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intercptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "interecptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intereptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intrceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "intreceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "itnerceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "niterceptor"
-    replace: "interceptor"
-    propagate_case: true
-    word: true
-
-  - trigger: "inerface"
+  - triggers:
+    - "inerface"
+    - "inetrface"
+    - "inteface"
+    - "intefrace"
+    - "interace"
+    - "interafce"
+    - "interfae"
+    - "interfaec"
+    - "interfcae"
+    - "interfce"
+    - "intreface"
+    - "intrface"
+    - "iterface"
+    - "itnerface"
+    - "niterface"
     replace: "interface"
     propagate_case: true
     word: true
 
-  - trigger: "inetrface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "inteface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "intefrace"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interace"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interafce"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interfae"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interfaec"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interfcae"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "interfce"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "intreface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "intrface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "itnerface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "niterface"
-    replace: "interface"
-    propagate_case: true
-    word: true
-
-  - trigger: "inerpreter"
+  - triggers:
+    - "inerpreter"
+    - "inetrpreter"
+    - "intepreter"
+    - "inteprreter"
+    - "interperter"
+    - "interpeter"
+    - "interpreer"
+    - "interpreetr"
+    - "interpretr"
+    - "interpretre"
+    - "interprteer"
+    - "interprter"
+    - "interreter"
+    - "interrpeter"
+    - "intrepreter"
+    - "intrpreter"
+    - "iterpreter"
+    - "itnerpreter"
+    - "niterpreter"
     replace: "interpreter"
     propagate_case: true
     word: true
 
-  - trigger: "inetrpreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "intepreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "inteprreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interperter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interpeter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interpreer"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interpreetr"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interpretr"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interpretre"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interprteer"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interprter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "interrpeter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "intrepreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "intrpreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterpreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "itnerpreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "niterpreter"
-    replace: "interpreter"
-    propagate_case: true
-    word: true
-
-  - trigger: "isse"
+  - triggers:
+    - "isse"
+    - "isseu"
+    - "isue"
+    - "isuse"
+    - "sisue"
     replace: "issue"
     propagate_case: true
     word: true
 
-  - trigger: "isseu"
-    replace: "issue"
-    propagate_case: true
-    word: true
-
-  - trigger: "isue"
-    replace: "issue"
-    propagate_case: true
-    word: true
-
-  - trigger: "isuse"
-    replace: "issue"
-    propagate_case: true
-    word: true
-
-  - trigger: "sisue"
-    replace: "issue"
-    propagate_case: true
-    word: true
-
-  - trigger: "ierable"
+  - triggers:
+    - "ierable"
+    - "ietrable"
+    - "iteable"
+    - "itearble"
+    - "iterabe"
+    - "iterabel"
+    - "iteralbe"
+    - "iterale"
+    - "iterbale"
+    - "iterble"
+    - "itrable"
+    - "itreable"
+    - "tierable"
     replace: "iterable"
     propagate_case: true
     word: true
 
-  - trigger: "ietrable"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteable"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "itearble"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterabe"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterabel"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteralbe"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterale"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterbale"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "iterble"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "itrable"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "itreable"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "tierable"
-    replace: "iterable"
-    propagate_case: true
-    word: true
-
-  - trigger: "ierator"
+  - triggers:
+    - "ierator"
+    - "ietrator"
+    - "iteartor"
+    - "iteator"
+    - "iteraor"
+    - "iteraotr"
+    - "iteratr"
+    - "iteratro"
+    - "itertaor"
+    - "itertor"
+    - "itrator"
+    - "itreator"
+    - "tierator"
     replace: "iterator"
     propagate_case: true
     word: true
 
-  - trigger: "ietrator"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteartor"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteator"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteraor"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteraotr"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteratr"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "iteratro"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "itertaor"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "itertor"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "itrator"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "itreator"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "tierator"
-    replace: "iterator"
-    propagate_case: true
-    word: true
-
-  - trigger: "ajvascript"
+  - triggers:
+    - "ajvascript"
+    - "jaascript"
+    - "jaavscript"
+    - "javacript"
+    - "javacsript"
+    - "javascipt"
+    - "javascirpt"
+    - "javascrit"
+    - "javascritp"
+    - "javascrpit"
+    - "javascrpt"
+    - "javasrcipt"
+    - "javasript"
+    - "javsacript"
+    - "javscript"
+    - "jvaascript"
+    - "jvascript"
     replace: "javascript"
     propagate_case: true
     word: true
 
-  - trigger: "jaascript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "jaavscript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javacript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javacsript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascipt"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascirpt"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascrit"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascritp"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascrpit"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javascrpt"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javasrcipt"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javasript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javsacript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "javscript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "jvaascript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "jvascript"
-    replace: "javascript"
-    propagate_case: true
-    word: true
-
-  - trigger: "ekyframe"
+  - triggers:
+    - "ekyframe"
+    - "keframe"
+    - "kefyrame"
+    - "keyfame"
+    - "keyfarme"
+    - "keyfrae"
+    - "keyfraem"
+    - "keyfrmae"
+    - "keyfrme"
+    - "keyrame"
+    - "keyrfame"
+    - "kyeframe"
+    - "kyframe"
     replace: "keyframe"
     propagate_case: true
     word: true
 
-  - trigger: "keframe"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "kefyrame"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfame"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfarme"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfrae"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfraem"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfrmae"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyfrme"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyrame"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "keyrfame"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "kyeframe"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "kyframe"
-    replace: "keyframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "kbernetes"
+  - triggers:
+    - "kbernetes"
+    - "kbuernetes"
+    - "kubenetes"
+    - "kubenretes"
+    - "kuberentes"
+    - "kuberetes"
+    - "kubernees"
+    - "kuberneets"
+    - "kubernets"
+    - "kubernetse"
+    - "kuberntees"
+    - "kuberntes"
+    - "kubrenetes"
+    - "kubrnetes"
+    - "kuebrnetes"
+    - "kuernetes"
+    - "ukbernetes"
     replace: "kubernetes"
     propagate_case: true
     word: true
 
-  - trigger: "kbuernetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubenetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubenretes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuberentes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuberetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubernees"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuberneets"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubernets"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubernetse"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuberntees"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuberntes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubrenetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kubrnetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuebrnetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "kuernetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "ukbernetes"
-    replace: "kubernetes"
-    propagate_case: true
-    word: true
-
-  - trigger: "almbda"
+  - triggers:
+    - "almbda"
+    - "labda"
+    - "labmda"
+    - "lamba"
+    - "lambad"
+    - "lamda"
+    - "lamdba"
+    - "lmabda"
+    - "lmbda"
     replace: "lambda"
     propagate_case: true
     word: true
 
-  - trigger: "labda"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "labmda"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lamba"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lambad"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lamda"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lamdba"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lmabda"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "lmbda"
-    replace: "lambda"
-    propagate_case: true
-    word: true
-
-  - trigger: "alyout"
+  - triggers:
+    - "alyout"
+    - "laout"
+    - "laoyut"
+    - "layot"
+    - "layotu"
+    - "layuot"
+    - "layut"
+    - "lyaout"
+    - "lyout"
     replace: "layout"
     propagate_case: true
     word: true
 
-  - trigger: "laout"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "laoyut"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "layot"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "layotu"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "layuot"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "layut"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "lyaout"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "lyout"
-    replace: "layout"
-    propagate_case: true
-    word: true
-
-  - trigger: "ilbrary"
+  - triggers:
+    - "ilbrary"
+    - "lbirary"
+    - "lbrary"
+    - "libarry"
+    - "libary"
+    - "libray"
+    - "librayr"
+    - "librray"
+    - "librry"
+    - "lirary"
+    - "lirbary"
     replace: "library"
     propagate_case: true
     word: true
 
-  - trigger: "lbirary"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "lbrary"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "libarry"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "libary"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "libray"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "librayr"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "librray"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "librry"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "lirary"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "lirbary"
-    replace: "library"
-    propagate_case: true
-    word: true
-
-  - trigger: "ilfecycle"
+  - triggers:
+    - "ilfecycle"
+    - "lfecycle"
+    - "lfiecycle"
+    - "liecycle"
+    - "liefcycle"
+    - "lifceycle"
+    - "lifcycle"
+    - "lifeccle"
+    - "lifeccyle"
+    - "lifecyce"
+    - "lifecycel"
+    - "lifecylce"
+    - "lifecyle"
+    - "lifeyccle"
+    - "lifeycle"
     replace: "lifecycle"
     propagate_case: true
     word: true
 
-  - trigger: "lfecycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lfiecycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "liecycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "liefcycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifceycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifcycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifeccle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifeccyle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifecyce"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifecycel"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifecylce"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifecyle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifeyccle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "lifeycle"
-    replace: "lifecycle"
-    propagate_case: true
-    word: true
-
-  - trigger: "ilst"
+  - triggers:
+    - "ilst"
+    - "lits"
+    - "lsit"
     replace: "list"
     propagate_case: true
     word: true
 
-  - trigger: "lits"
-    replace: "list"
-    propagate_case: true
-    word: true
-
-  - trigger: "lsit"
-    replace: "list"
-    propagate_case: true
-    word: true
-
-  - trigger: "lading"
+  - triggers:
+    - "laoding"
+    - "loadig"
+    - "loadign"
+    - "loadng"
+    - "loadnig"
+    - "loaidng"
+    - "loaing"
+    - "lodaing"
+    - "loding"
+    - "olading"
     replace: "loading"
     propagate_case: true
     word: true
 
-  - trigger: "laoding"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loadig"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loadign"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loadng"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loadnig"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loaidng"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loaing"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "lodaing"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "loding"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "olading"
-    replace: "loading"
-    propagate_case: true
-    word: true
-
-  - trigger: "amnifest"
+  - triggers:
+    - "amnifest"
+    - "maifest"
+    - "mainfest"
+    - "manfest"
+    - "manfiest"
+    - "maniefst"
+    - "maniest"
+    - "manifet"
+    - "manifets"
+    - "manifset"
+    - "manifst"
+    - "mnaifest"
+    - "mnifest"
     replace: "manifest"
     propagate_case: true
     word: true
 
-  - trigger: "maifest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "mainfest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manfest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manfiest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "maniefst"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "maniest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manifet"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manifets"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manifset"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "manifst"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnaifest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnifest"
-    replace: "manifest"
-    propagate_case: true
-    word: true
-
-  - trigger: "amrgin"
+  - triggers:
+    - "amrgin"
+    - "magin"
+    - "magrin"
+    - "margn"
+    - "margni"
+    - "marign"
+    - "marin"
+    - "mragin"
+    - "mrgin"
     replace: "margin"
     propagate_case: true
     word: true
 
-  - trigger: "magin"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "magrin"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "margn"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "margni"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "marign"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "marin"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mragin"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mrgin"
-    replace: "margin"
-    propagate_case: true
-    word: true
-
-  - trigger: "emrge"
+  - triggers:
+    - "emrge"
+    - "mege"
+    - "megre"
+    - "mereg"
+    - "mrege"
+    - "mrge"
     replace: "merge"
     propagate_case: true
     word: true
 
-  - trigger: "mege"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "megre"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "mere"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "mereg"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "mrege"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "mrge"
-    replace: "merge"
-    propagate_case: true
-    word: true
-
-  - trigger: "emtaclass"
+  - triggers:
+    - "emtaclass"
+    - "meaclass"
+    - "meatclass"
+    - "metacalss"
+    - "metacass"
+    - "metaclas"
+    - "metaclsas"
+    - "metaclss"
+    - "metalass"
+    - "metalcass"
+    - "metcalass"
+    - "metclass"
+    - "mtaclass"
+    - "mteaclass"
     replace: "metaclass"
     propagate_case: true
     word: true
 
-  - trigger: "meaclass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "meatclass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metacalss"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metacass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metaclas"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metaclsas"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metaclss"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metalass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metalcass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metcalass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "metclass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtaclass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "mteaclass"
-    replace: "metaclass"
-    propagate_case: true
-    word: true
-
-  - trigger: "emtadata"
+  - triggers:
+    - "emtadata"
+    - "meadata"
+    - "meatdata"
+    - "metaadta"
+    - "metaata"
+    - "metadaa"
+    - "metadaat"
+    - "metadta"
+    - "metadtaa"
+    - "metdaata"
+    - "metdata"
+    - "mtadata"
+    - "mteadata"
     replace: "metadata"
     propagate_case: true
     word: true
 
-  - trigger: "meadata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "meatdata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metaadta"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metaata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metadaa"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metadaat"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metadta"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metadtaa"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metdaata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "metdata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtadata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "mteadata"
-    replace: "metadata"
-    propagate_case: true
-    word: true
-
-  - trigger: "imcroservice"
+  - triggers:
+    - "imcroservice"
+    - "mciroservice"
+    - "mcroservice"
+    - "micorservice"
+    - "micoservice"
+    - "microervice"
+    - "microesrvice"
+    - "microserice"
+    - "microserivce"
+    - "microservce"
+    - "microservcie"
+    - "microservie"
+    - "microserviec"
+    - "microsevice"
+    - "microsevrice"
+    - "microsrevice"
+    - "microsrvice"
+    - "micrservice"
+    - "micrsoervice"
+    - "mircoservice"
+    - "miroservice"
     replace: "microservice"
     propagate_case: true
     word: true
 
-  - trigger: "mciroservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "mcroservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "micorservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "micoservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microervice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microesrvice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microserice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microserivce"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microservce"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microservcie"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microservie"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microserviec"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microsevice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microsevrice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microsrevice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "microsrvice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "micrservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "micrsoervice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "mircoservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "miroservice"
-    replace: "microservice"
-    propagate_case: true
-    word: true
-
-  - trigger: "imddleware"
+  - triggers:
+    - "imddleware"
+    - "mddleware"
+    - "mdidleware"
+    - "middelware"
+    - "middeware"
+    - "middleare"
+    - "middleawre"
+    - "middlewae"
+    - "middlewaer"
+    - "middlewrae"
+    - "middlewre"
+    - "middlware"
+    - "middlweare"
+    - "midldeware"
+    - "midleware"
     replace: "middleware"
     propagate_case: true
     word: true
 
-  - trigger: "mddleware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "mdidleware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middelware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middeware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middleare"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middleawre"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlewae"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlewaer"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlewrae"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlewre"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "middlweare"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "midldeware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "midleware"
-    replace: "middleware"
-    propagate_case: true
-    word: true
-
-  - trigger: "imgration"
+  - triggers:
+    - "imgration"
+    - "mgiration"
+    - "mgration"
+    - "migartion"
+    - "migation"
+    - "migraion"
+    - "migraiton"
+    - "migratin"
+    - "migratino"
+    - "migratoin"
+    - "migraton"
+    - "migrtaion"
+    - "migrtion"
+    - "miration"
+    - "mirgation"
     replace: "migration"
     propagate_case: true
     word: true
 
-  - trigger: "mgiration"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "mgration"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migartion"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migation"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migraion"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migraiton"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migratin"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migratino"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migratoin"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migraton"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migrtaion"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "migrtion"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "miration"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "mirgation"
-    replace: "migration"
-    propagate_case: true
-    word: true
-
-  - trigger: "imlestone"
+  - triggers:
+    - "imlestone"
+    - "mielstone"
+    - "miestone"
+    - "milesone"
+    - "milesotne"
+    - "milestne"
+    - "milestnoe"
+    - "milestoe"
+    - "milestoen"
+    - "miletone"
+    - "miletsone"
+    - "milsetone"
+    - "milstone"
+    - "mlestone"
+    - "mliestone"
     replace: "milestone"
     propagate_case: true
     word: true
 
-  - trigger: "mielstone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "miestone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milesone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milesotne"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milestne"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milestnoe"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milestoe"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milestoen"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "miletone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "miletsone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milsetone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "milstone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "mlestone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "mliestone"
-    replace: "milestone"
-    propagate_case: true
-    word: true
-
-  - trigger: "imnification"
+  - triggers:
+    - "imnification"
+    - "miification"
+    - "miinfication"
+    - "minfication"
+    - "minfiication"
+    - "minifcation"
+    - "minifciation"
+    - "minifiaction"
+    - "minifiation"
+    - "minificaion"
+    - "minificaiton"
+    - "minificatin"
+    - "minificatino"
+    - "minificatoin"
+    - "minificaton"
+    - "minifictaion"
+    - "minifiction"
+    - "miniication"
+    - "miniifcation"
+    - "mnification"
+    - "mniification"
     replace: "minification"
     propagate_case: true
     word: true
 
-  - trigger: "miification"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "miinfication"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minfication"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minfiication"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifcation"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifciation"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifiaction"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifiation"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificaion"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificaiton"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificatin"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificatino"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificatoin"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minificaton"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifictaion"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "minifiction"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "miniication"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "miniifcation"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnification"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "mniification"
-    replace: "minification"
-    propagate_case: true
-    word: true
-
-  - trigger: "imxin"
+  - triggers:
+    - "imxin"
+    - "miin"
+    - "miixn"
+    - "mixn"
+    - "mixni"
+    - "mxiin"
+    - "mxin"
     replace: "mixin"
     propagate_case: true
     word: true
 
-  - trigger: "miin"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "miixn"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mixn"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mixni"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mxiin"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mxin"
-    replace: "mixin"
-    propagate_case: true
-    word: true
-
-  - trigger: "mcok"
+  - triggers:
+    - "mcok"
+    - "mokc"
+    - "omck"
     replace: "mock"
     propagate_case: true
     word: true
 
-  - trigger: "mokc"
-    replace: "mock"
-    propagate_case: true
-    word: true
-
-  - trigger: "omck"
-    replace: "mock"
-    propagate_case: true
-    word: true
-
-  - trigger: "mdoule"
+  - triggers:
+    - "mdoule"
+    - "mdule"
+    - "modle"
+    - "modlue"
+    - "modue"
+    - "moduel"
+    - "moudle"
+    - "moule"
+    - "omdule"
     replace: "module"
     propagate_case: true
     word: true
 
-  - trigger: "mdule"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "modle"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "modlue"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "modue"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "moduel"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "moudle"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "moule"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "omdule"
-    replace: "module"
-    propagate_case: true
-    word: true
-
-  - trigger: "mngodb"
+  - triggers:
+    - "mngodb"
+    - "mnogodb"
+    - "mognodb"
+    - "mogodb"
+    - "mongdb"
+    - "mongdob"
+    - "mongob"
+    - "mongobd"
+    - "monodb"
+    - "monogdb"
+    - "omngodb"
     replace: "mongodb"
     propagate_case: true
     word: true
 
-  - trigger: "mnogodb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mognodb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mogodb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mongdb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mongdob"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mongob"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mongobd"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "monodb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "monogdb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "omngodb"
-    replace: "mongodb"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnolith"
+  - triggers:
+    - "mnolith"
+    - "mnoolith"
+    - "monlith"
+    - "monloith"
+    - "monoilth"
+    - "monoith"
+    - "monolih"
+    - "monoliht"
+    - "monolth"
+    - "monoltih"
+    - "moolith"
+    - "moonlith"
+    - "omnolith"
     replace: "monolith"
     propagate_case: true
     word: true
 
-  - trigger: "mnoolith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monlith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monloith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monoilth"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monoith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monolih"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monoliht"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monolth"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "monoltih"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "moolith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "moonlith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "omnolith"
-    replace: "monolith"
-    propagate_case: true
-    word: true
-
-  - trigger: "mpyy"
+  - triggers:
+    - "mpyy"
+    - "myyp"
+    - "ympy"
     replace: "mypy"
     propagate_case: true
     word: true
 
-  - trigger: "myyp"
-    replace: "mypy"
-    propagate_case: true
-    word: true
-
-  - trigger: "ympy"
-    replace: "mypy"
-    propagate_case: true
-    word: true
-
-  - trigger: "anmespace"
+  - triggers:
+    - "anmespace"
+    - "naemspace"
+    - "naespace"
+    - "namepace"
+    - "namepsace"
+    - "namesace"
+    - "namesapce"
+    - "namespae"
+    - "namespaec"
+    - "namespcae"
+    - "namespce"
+    - "namsepace"
+    - "namspace"
+    - "nmaespace"
+    - "nmespace"
     replace: "namespace"
     propagate_case: true
     word: true
 
-  - trigger: "naemspace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "naespace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namepace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namepsace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namesace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namesapce"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namespae"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namespaec"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namespcae"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namespce"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namsepace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "namspace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "nmaespace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "nmespace"
-    replace: "namespace"
-    propagate_case: true
-    word: true
-
-  - trigger: "anvigation"
+  - triggers:
+    - "anvigation"
+    - "naigation"
+    - "naivgation"
+    - "navgation"
+    - "navgiation"
+    - "naviagtion"
+    - "naviation"
+    - "navigaion"
+    - "navigaiton"
+    - "navigatin"
+    - "navigatino"
+    - "navigatoin"
+    - "navigaton"
+    - "navigtaion"
+    - "navigtion"
+    - "nvaigation"
+    - "nvigation"
     replace: "navigation"
     propagate_case: true
     word: true
 
-  - trigger: "naigation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "naivgation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navgation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navgiation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "naviagtion"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "naviation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigaion"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigaiton"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigatin"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigatino"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigatoin"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigaton"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigtaion"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "navigtion"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "nvaigation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "nvigation"
-    replace: "navigation"
-    propagate_case: true
-    word: true
-
-  - trigger: "enutral"
+  - triggers:
+    - "enutral"
+    - "netral"
+    - "netural"
+    - "neurtal"
+    - "neutal"
+    - "neutarl"
+    - "neutrl"
+    - "neutrla"
+    - "nuetral"
+    - "nutral"
     replace: "neutral"
     propagate_case: true
     word: true
 
-  - trigger: "netral"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "netural"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neural"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neurtal"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neutal"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neutarl"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neutrl"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "neutrla"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuetral"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "nutral"
-    replace: "neutral"
-    propagate_case: true
-    word: true
-
-  - trigger: "gninx"
+  - triggers:
+    - "gninx"
+    - "ngix"
+    - "ngixn"
+    - "ngnix"
+    - "ngnx"
+    - "nignx"
+    - "ninx"
     replace: "nginx"
     propagate_case: true
     word: true
 
-  - trigger: "ngix"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "ngixn"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "ngnix"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "ngnx"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "nignx"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "ninx"
-    replace: "nginx"
-    propagate_case: true
-    word: true
-
-  - trigger: "noification"
+  - triggers:
+    - "noification"
+    - "noitfication"
+    - "notfication"
+    - "notfiication"
+    - "notifcation"
+    - "notifciation"
+    - "notifiaction"
+    - "notifiation"
+    - "notificaion"
+    - "notificaiton"
+    - "notificatin"
+    - "notificatino"
+    - "notificatoin"
+    - "notificaton"
+    - "notifictaion"
+    - "notifiction"
+    - "notiication"
+    - "notiifcation"
+    - "ntification"
+    - "ntoification"
+    - "ontification"
     replace: "notification"
     propagate_case: true
     word: true
 
-  - trigger: "noitfication"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notfication"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notfiication"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifcation"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifciation"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifiaction"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifiation"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificaion"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificaiton"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificatin"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificatino"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificatoin"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notificaton"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifictaion"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notifiction"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notiication"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "notiifcation"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "ntification"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "ntoification"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "ontification"
-    replace: "notification"
-    propagate_case: true
-    word: true
-
-  - trigger: "nlul"
+  - triggers:
+    - "nlul"
+    - "nul"
+    - "unll"
     replace: "null"
     propagate_case: true
     word: true
 
-  - trigger: "nul"
-    replace: "null"
-    propagate_case: true
-    word: true
-
-  - trigger: "unll"
-    replace: "null"
-    propagate_case: true
-    word: true
-
-  - trigger: "nmber"
+  - triggers:
+    - "nmber"
+    - "nmuber"
+    - "nuber"
+    - "nubmer"
+    - "numbr"
+    - "numbre"
+    - "numebr"
+    - "numer"
+    - "unmber"
     replace: "number"
     propagate_case: true
     word: true
 
-  - trigger: "nmuber"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuber"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "nubmer"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "numbr"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "numbre"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "numebr"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "numer"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "unmber"
-    replace: "number"
-    propagate_case: true
-    word: true
-
-  - trigger: "boservable"
+  - triggers:
+    - "boservable"
+    - "obervable"
+    - "obesrvable"
+    - "obserable"
+    - "obseravble"
+    - "observabe"
+    - "observabel"
+    - "observalbe"
+    - "observale"
+    - "observbale"
+    - "observble"
+    - "obsevable"
+    - "obsevrable"
+    - "obsrevable"
+    - "obsrvable"
+    - "osbervable"
+    - "oservable"
     replace: "observable"
     propagate_case: true
     word: true
 
-  - trigger: "obervable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obesrvable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obserable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obseravble"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observabe"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observabel"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observalbe"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observale"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observbale"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "observble"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsevable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsevrable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsrevable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsrvable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "osbervable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "oservable"
-    replace: "observable"
-    propagate_case: true
-    word: true
-
-  - trigger: "boserver"
+  - triggers:
+    - "boserver"
+    - "oberver"
+    - "obesrver"
+    - "obserer"
+    - "obserevr"
+    - "observr"
+    - "observre"
+    - "obsever"
+    - "obsevrer"
+    - "obsrever"
+    - "obsrver"
+    - "osberver"
+    - "oserver"
     replace: "observer"
     propagate_case: true
     word: true
 
-  - trigger: "oberver"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obesrver"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obserer"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obserevr"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "observr"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "observre"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsever"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsevrer"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsrever"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "obsrver"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "osberver"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "oserver"
-    replace: "observer"
-    propagate_case: true
-    word: true
-
-  - trigger: "oacity"
+  - triggers:
+    - "oacity"
+    - "oapcity"
+    - "opaciy"
+    - "opaciyt"
+    - "opactiy"
+    - "opacty"
+    - "opaicty"
+    - "opaity"
+    - "opcaity"
+    - "opcity"
+    - "poacity"
     replace: "opacity"
     propagate_case: true
     word: true
 
-  - trigger: "oapcity"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opaciy"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opaciyt"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opactiy"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opacty"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opaicty"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opaity"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opcaity"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "opcity"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "poacity"
-    replace: "opacity"
-    propagate_case: true
-    word: true
-
-  - trigger: "ochestration"
+  - triggers:
+    - "ochestration"
+    - "ocrhestration"
+    - "orcehstration"
+    - "orcestration"
+    - "orchesration"
+    - "orchesrtation"
+    - "orchestartion"
+    - "orchestation"
+    - "orchestraion"
+    - "orchestraiton"
+    - "orchestratin"
+    - "orchestratino"
+    - "orchestratoin"
+    - "orchestraton"
+    - "orchestrtaion"
+    - "orchestrtion"
+    - "orchetration"
+    - "orchetsration"
+    - "orchsetration"
+    - "orchstration"
+    - "orhcestration"
+    - "orhestration"
+    - "rochestration"
     replace: "orchestration"
     propagate_case: true
     word: true
 
-  - trigger: "ocrhestration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orcehstration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orcestration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchesration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchesrtation"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestartion"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestation"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestraion"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestraiton"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestratin"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestratino"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestratoin"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestraton"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestrtaion"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchestrtion"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchetration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchetsration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchsetration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orchstration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orhcestration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "orhestration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "rochestration"
-    replace: "orchestration"
-    propagate_case: true
-    word: true
-
-  - trigger: "otline"
+  - triggers:
+    - "otline"
+    - "otuline"
+    - "ouline"
+    - "oultine"
+    - "outilne"
+    - "outine"
+    - "outlien"
+    - "outlne"
+    - "outlnie"
+    - "uotline"
     replace: "outline"
     propagate_case: true
     word: true
 
-  - trigger: "otuline"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "ouline"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "oultine"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outilne"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outine"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outlie"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outlien"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outlne"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "outlnie"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "uotline"
-    replace: "outline"
-    propagate_case: true
-    word: true
-
-  - trigger: "oerload"
+  - triggers:
+    - "oerload"
+    - "oevrload"
+    - "oveload"
+    - "ovelroad"
+    - "overlad"
+    - "overlaod"
+    - "overlod"
+    - "overloda"
+    - "overoad"
+    - "overolad"
+    - "ovreload"
+    - "ovrload"
+    - "voerload"
     replace: "overload"
     propagate_case: true
     word: true
 
-  - trigger: "oevrload"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "oveload"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovelroad"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overlad"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overlaod"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overlod"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overloda"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overoad"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "overolad"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovreload"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovrload"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "voerload"
-    replace: "overload"
-    propagate_case: true
-    word: true
-
-  - trigger: "oerride"
+  - triggers:
+    - "oerride"
+    - "oevrride"
+    - "overide"
+    - "overirde"
+    - "overrde"
+    - "overrdie"
+    - "overrie"
+    - "overried"
+    - "ovreride"
+    - "ovrride"
+    - "voerride"
     replace: "override"
     propagate_case: true
     word: true
 
-  - trigger: "oevrride"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overide"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overirde"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overrde"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overrdie"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overrie"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "overried"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovreride"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovrride"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "voerride"
-    replace: "override"
-    propagate_case: true
-    word: true
-
-  - trigger: "apckage"
+  - triggers:
+    - "apckage"
+    - "pacage"
+    - "pacakge"
+    - "packae"
+    - "packaeg"
+    - "packgae"
+    - "packge"
+    - "pakage"
+    - "pakcage"
+    - "pcakage"
+    - "pckage"
     replace: "package"
     propagate_case: true
     word: true
 
-  - trigger: "pacage"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "pacakge"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "packae"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "packaeg"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "packgae"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "packge"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "pakage"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "pakcage"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "pcakage"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "pckage"
-    replace: "package"
-    propagate_case: true
-    word: true
-
-  - trigger: "apdding"
+  - triggers:
+    - "apdding"
+    - "paddig"
+    - "paddign"
+    - "paddng"
+    - "paddnig"
+    - "padidng"
+    - "pading"
+    - "pdading"
+    - "pdding"
     replace: "padding"
     propagate_case: true
     word: true
 
-  - trigger: "paddig"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "paddign"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "paddng"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "paddnig"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "padidng"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "pading"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "pdading"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "pdding"
-    replace: "padding"
-    propagate_case: true
-    word: true
-
-  - trigger: "apgination"
+  - triggers:
+    - "apgination"
+    - "pagiantion"
+    - "pagiation"
+    - "paginaion"
+    - "paginaiton"
+    - "paginatin"
+    - "paginatino"
+    - "paginatoin"
+    - "paginaton"
+    - "pagintaion"
+    - "pagintion"
+    - "pagnation"
+    - "pagniation"
+    - "paignation"
+    - "paination"
+    - "pgaination"
+    - "pgination"
     replace: "pagination"
     propagate_case: true
     word: true
 
-  - trigger: "pagiantion"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pagiation"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginaion"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginaiton"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginatin"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginatino"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginatoin"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paginaton"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pagintaion"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pagintion"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pagnation"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pagniation"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paignation"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "paination"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pgaination"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "pgination"
-    replace: "pagination"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprallelism"
+  - triggers:
+    - "aprallelism"
+    - "paallelism"
+    - "paarllelism"
+    - "paralelism"
+    - "paralellism"
+    - "paralleilsm"
+    - "paralleism"
+    - "parallelim"
+    - "parallelims"
+    - "parallelsim"
+    - "parallelsm"
+    - "parallleism"
+    - "paralllism"
+    - "parlalelism"
+    - "parllelism"
+    - "praallelism"
+    - "prallelism"
     replace: "parallelism"
     propagate_case: true
     word: true
 
-  - trigger: "paallelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paarllelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralellism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralleilsm"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralleism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parallelim"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parallelims"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parallelsim"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parallelsm"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parallleism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralllism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlalelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "parllelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "praallelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "prallelism"
-    replace: "parallelism"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprameter"
+  - triggers:
+    - "aprameter"
+    - "paameter"
+    - "paarmeter"
+    - "paraemter"
+    - "paraeter"
+    - "parameer"
+    - "parameetr"
+    - "parametr"
+    - "parametre"
+    - "paramteer"
+    - "paramter"
+    - "parmaeter"
+    - "parmeter"
+    - "praameter"
+    - "prameter"
     replace: "parameter"
     propagate_case: true
     word: true
 
-  - trigger: "paameter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "paarmeter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "paraemter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "paraeter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parameer"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parameetr"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parametr"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parametre"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "paramteer"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "paramter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parmaeter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "parmeter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "praameter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "prameter"
-    replace: "parameter"
-    propagate_case: true
-    word: true
-
-  - trigger: "ippeline"
+  - triggers:
+    - "ippeline"
+    - "pieline"
+    - "piepline"
+    - "pipeilne"
+    - "pipeine"
+    - "pipelie"
+    - "pipelien"
+    - "pipelne"
+    - "pipelnie"
+    - "pipleine"
+    - "pipline"
+    - "ppeline"
+    - "ppieline"
     replace: "pipeline"
     propagate_case: true
     word: true
 
-  - trigger: "pieline"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "piepline"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipeilne"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipeine"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipelie"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipelien"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipelne"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipelnie"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipleine"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "pipline"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "ppeline"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "ppieline"
-    replace: "pipeline"
-    propagate_case: true
-    word: true
-
-  - trigger: "lpaceholder"
+  - triggers:
+    - "lpaceholder"
+    - "paceholder"
+    - "palceholder"
+    - "placehlder"
+    - "placehloder"
+    - "placehoder"
+    - "placehodler"
+    - "placeholdr"
+    - "placeholdre"
+    - "placeholedr"
+    - "placeholer"
+    - "placeohlder"
+    - "placeolder"
+    - "placheolder"
+    - "placholder"
+    - "plaecholder"
+    - "plaeholder"
+    - "plcaeholder"
+    - "plceholder"
     replace: "placeholder"
     propagate_case: true
     word: true
 
-  - trigger: "paceholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "palceholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placehlder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placehloder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placehoder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placehodler"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeholdr"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeholdre"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeholedr"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeholer"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeohlder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placeolder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placheolder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "placholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "plaecholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "plaeholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "plcaeholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "plceholder"
-    replace: "placeholder"
-    propagate_case: true
-    word: true
-
-  - trigger: "oplyfill"
+  - triggers:
+    - "oplyfill"
+    - "ployfill"
+    - "plyfill"
+    - "polfill"
+    - "polfyill"
+    - "polyfil"
+    - "polyflil"
+    - "polyfll"
+    - "polyifll"
+    - "polyill"
+    - "poyfill"
+    - "poylfill"
     replace: "polyfill"
     propagate_case: true
     word: true
 
-  - trigger: "ployfill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "plyfill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polfill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polfyill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyfil"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyflil"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyfll"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyifll"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "poyfill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "poylfill"
-    replace: "polyfill"
-    propagate_case: true
-    word: true
-
-  - trigger: "oplymorphism"
+  - triggers:
+    - "oplymorphism"
+    - "ploymorphism"
+    - "plymorphism"
+    - "polmorphism"
+    - "polmyorphism"
+    - "polymophism"
+    - "polymoprhism"
+    - "polymorhism"
+    - "polymorhpism"
+    - "polymorphim"
+    - "polymorphims"
+    - "polymorphsim"
+    - "polymorphsm"
+    - "polymorpihsm"
+    - "polymorpism"
+    - "polymrophism"
+    - "polymrphism"
+    - "polyomrphism"
+    - "polyorphism"
+    - "poylmorphism"
+    - "poymorphism"
     replace: "polymorphism"
     propagate_case: true
     word: true
 
-  - trigger: "ploymorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "plymorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polmorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polmyorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymophism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymoprhism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorhism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorhpism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorphim"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorphims"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorphsim"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorphsm"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorpihsm"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymorpism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymrophism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polymrphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyomrphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "polyorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "poylmorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "poymorphism"
-    replace: "polymorphism"
-    propagate_case: true
-    word: true
-
-  - trigger: "opsition"
+  - triggers:
+    - "opsition"
+    - "poistion"
+    - "poition"
+    - "posiion"
+    - "posiiton"
+    - "positin"
+    - "positino"
+    - "positoin"
+    - "positon"
+    - "postiion"
+    - "postion"
+    - "psition"
+    - "psoition"
     replace: "position"
     propagate_case: true
     word: true
 
-  - trigger: "poistion"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "poition"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "posiion"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "posiiton"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "positin"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "positino"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "positoin"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "positon"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "postiion"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "postion"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "psition"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "psoition"
-    replace: "position"
-    propagate_case: true
-    word: true
-
-  - trigger: "opstgresql"
+  - triggers:
+    - "opstgresql"
+    - "posgresql"
+    - "posgtresql"
+    - "postgersql"
+    - "postgesql"
+    - "postgreql"
+    - "postgreqsl"
+    - "postgresl"
+    - "postgreslq"
+    - "postgrseql"
+    - "postgrsql"
+    - "postresql"
+    - "postrgesql"
+    - "potgresql"
+    - "potsgresql"
+    - "psotgresql"
+    - "pstgresql"
     replace: "postgresql"
     propagate_case: true
     word: true
 
-  - trigger: "posgresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "posgtresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgersql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgesql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgreql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgreqsl"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgresl"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgreslq"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgrseql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postgrsql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "postrgesql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "potgresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "potsgresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "psotgresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "pstgresql"
-    replace: "postgresql"
-    propagate_case: true
-    word: true
-
-  - trigger: "perttier"
+  - triggers:
+    - "perttier"
+    - "pettier"
+    - "pretier"
+    - "pretiter"
+    - "pretteir"
+    - "pretter"
+    - "prettir"
+    - "prettire"
+    - "prtetier"
+    - "prttier"
+    - "rpettier"
     replace: "prettier"
     propagate_case: true
     word: true
 
-  - trigger: "pettier"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "pretier"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "pretiter"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "pretteir"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "pretter"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "prettir"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "prettire"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "prtetier"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "prttier"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpettier"
-    replace: "prettier"
-    propagate_case: true
-    word: true
-
-  - trigger: "pimary"
+  - triggers:
+    - "pimary"
+    - "pirmary"
+    - "priamry"
+    - "priary"
+    - "primay"
+    - "primayr"
+    - "primray"
+    - "primry"
+    - "prmary"
+    - "prmiary"
+    - "rpimary"
     replace: "primary"
     propagate_case: true
     word: true
 
-  - trigger: "pirmary"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "priamry"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "priary"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "primay"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "primayr"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "primray"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "primry"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmary"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmiary"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpimary"
-    replace: "primary"
-    propagate_case: true
-    word: true
-
-  - trigger: "poduction"
+  - triggers:
+    - "poduction"
+    - "porduction"
+    - "prdouction"
+    - "prduction"
+    - "prodction"
+    - "prodcution"
+    - "producion"
+    - "produciton"
+    - "productin"
+    - "productino"
+    - "productoin"
+    - "producton"
+    - "produtcion"
+    - "prodution"
+    - "prouction"
+    - "proudction"
+    - "rpoduction"
     replace: "production"
     propagate_case: true
     word: true
 
-  - trigger: "porduction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prdouction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prduction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prodction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prodcution"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "producion"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "produciton"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "productin"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "productino"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "productoin"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "producton"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "produtcion"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prodution"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "prouction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "proudction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoduction"
-    replace: "production"
-    propagate_case: true
-    word: true
-
-  - trigger: "pofile"
+  - triggers:
+    - "pofile"
+    - "porfile"
+    - "prfile"
+    - "prfoile"
+    - "profie"
+    - "profiel"
+    - "profle"
+    - "proflie"
+    - "proifle"
+    - "proile"
+    - "rpofile"
     replace: "profile"
     propagate_case: true
     word: true
 
-  - trigger: "porfile"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "prfile"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "prfoile"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "profie"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "profiel"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "profle"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "proflie"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "proifle"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "proile"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpofile"
-    replace: "profile"
-    propagate_case: true
-    word: true
-
-  - trigger: "pometheus"
+  - triggers:
+    - "pometheus"
+    - "pormetheus"
+    - "prmetheus"
+    - "prmoetheus"
+    - "proemtheus"
+    - "proetheus"
+    - "promeheus"
+    - "promehteus"
+    - "prometehus"
+    - "prometeus"
+    - "promethes"
+    - "promethesu"
+    - "promethues"
+    - "promethus"
+    - "promteheus"
+    - "promtheus"
+    - "rpometheus"
     replace: "prometheus"
     propagate_case: true
     word: true
 
-  - trigger: "pormetheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmetheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmoetheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "proemtheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "proetheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promeheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promehteus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "prometehus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "prometeus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promethes"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promethesu"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promethues"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promethus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promteheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "promtheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpometheus"
-    replace: "prometheus"
-    propagate_case: true
-    word: true
-
-  - trigger: "pomise"
+  - triggers:
+    - "pomise"
+    - "pormise"
+    - "prmise"
+    - "prmoise"
+    - "proimse"
+    - "proise"
+    - "promie"
+    - "promies"
+    - "promse"
+    - "promsie"
+    - "rpomise"
     replace: "promise"
     propagate_case: true
     word: true
 
-  - trigger: "pormise"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmise"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmoise"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "proimse"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "proise"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "promie"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "promies"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "promse"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "promsie"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpomise"
-    replace: "promise"
-    propagate_case: true
-    word: true
-
-  - trigger: "portotype"
+  - triggers:
+    - "portotype"
+    - "pototype"
+    - "proottype"
+    - "prootype"
+    - "prototpe"
+    - "prototpye"
+    - "prototye"
+    - "prototyep"
+    - "protoype"
+    - "protoytpe"
+    - "prottoype"
+    - "prottype"
+    - "prtootype"
+    - "prtotype"
+    - "rpototype"
     replace: "prototype"
     propagate_case: true
     word: true
 
-  - trigger: "pototype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "proottype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prootype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prototpe"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prototpye"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prototye"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prototyep"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "protoype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "protoytpe"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prottoype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prottype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prtootype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "prtotype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpototype"
-    replace: "prototype"
-    propagate_case: true
-    word: true
-
-  - trigger: "pesudo"
+  - triggers:
+    - "pesudo"
+    - "peudo"
+    - "psedo"
+    - "pseduo"
+    - "pseuo"
+    - "pseuod"
+    - "psudo"
+    - "psuedo"
+    - "speudo"
     replace: "pseudo"
     propagate_case: true
     word: true
 
-  - trigger: "peudo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psedo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pseduo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pseuo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pseuod"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psudo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "psuedo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "speudo"
-    replace: "pseudo"
-    propagate_case: true
-    word: true
-
-  - trigger: "plul"
+  - triggers:
+    - "plul"
+    - "pul"
+    - "upll"
     replace: "pull"
     propagate_case: true
     word: true
 
-  - trigger: "pul"
-    replace: "pull"
-    propagate_case: true
-    word: true
-
-  - trigger: "upll"
-    replace: "pull"
-    propagate_case: true
-    word: true
-
-  - trigger: "psuh"
+  - triggers:
+    - "psuh"
+    - "puhs"
+    - "upsh"
     replace: "push"
     propagate_case: true
     word: true
 
-  - trigger: "puhs"
-    replace: "push"
-    propagate_case: true
-    word: true
-
-  - trigger: "upsh"
-    replace: "push"
-    propagate_case: true
-    word: true
-
-  - trigger: "pdantic"
+  - triggers:
+    - "pdantic"
+    - "pdyantic"
+    - "pyadntic"
+    - "pyantic"
+    - "pydanic"
+    - "pydanitc"
+    - "pydantc"
+    - "pydantci"
+    - "pydatic"
+    - "pydatnic"
+    - "pydnatic"
+    - "pydntic"
+    - "ypdantic"
     replace: "pydantic"
     propagate_case: true
     word: true
 
-  - trigger: "pdyantic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyadntic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyantic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydanic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydanitc"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydantc"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydantci"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydatic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydatnic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydnatic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "pydntic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "ypdantic"
-    replace: "pydantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "plint"
+  - triggers:
+    - "plint"
+    - "plyint"
+    - "pyilnt"
+    - "pyint"
+    - "pylit"
+    - "pylitn"
+    - "pylnit"
+    - "pylnt"
+    - "yplint"
     replace: "pylint"
     propagate_case: true
     word: true
 
-  - trigger: "plyint"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyilnt"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyint"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pylit"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pylitn"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pylnit"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "pylnt"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "yplint"
-    replace: "pylint"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptest"
+  - triggers:
+    - "ptest"
+    - "ptyest"
+    - "pyest"
+    - "pyetst"
+    - "pytet"
+    - "pytets"
+    - "pytset"
+    - "pytst"
+    - "yptest"
     replace: "pytest"
     propagate_case: true
     word: true
 
-  - trigger: "ptyest"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyest"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pyetst"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pytet"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pytets"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pytset"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "pytst"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "yptest"
-    replace: "pytest"
-    propagate_case: true
-    word: true
-
-  - trigger: "arbbitmq"
+  - triggers:
+    - "arbbitmq"
+    - "rabbimq"
+    - "rabbimtq"
+    - "rabbitq"
+    - "rabbitqm"
+    - "rabbtimq"
+    - "rabbtmq"
+    - "rabibtmq"
+    - "rabitmq"
+    - "rbabitmq"
+    - "rbbitmq"
     replace: "rabbitmq"
     propagate_case: true
     word: true
 
-  - trigger: "rabbimq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabbimtq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabbitq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabbitqm"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabbtimq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabbtmq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabibtmq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rabitmq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbabitmq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbbitmq"
-    replace: "rabbitmq"
-    propagate_case: true
-    word: true
-
-  - trigger: "ardius"
+  - triggers:
+    - "ardius"
+    - "radis"
+    - "radisu"
+    - "raduis"
+    - "radus"
+    - "raidus"
+    - "raius"
+    - "rdaius"
+    - "rdius"
     replace: "radius"
     propagate_case: true
     word: true
 
-  - trigger: "radis"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "radisu"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "raduis"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "radus"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "raidus"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "raius"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "rdaius"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "rdius"
-    replace: "radius"
-    propagate_case: true
-    word: true
-
-  - trigger: "eradonly"
+  - triggers:
+    - "eradonly"
+    - "radonly"
+    - "raedonly"
+    - "readnly"
+    - "readnoly"
+    - "readolny"
+    - "readoly"
+    - "readony"
+    - "readonyl"
+    - "reaodnly"
+    - "reaonly"
+    - "redaonly"
+    - "redonly"
     replace: "readonly"
     propagate_case: true
     word: true
 
-  - trigger: "radonly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "raedonly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readnly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readnoly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readolny"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readoly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readony"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "readonyl"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "reaodnly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "reaonly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "redaonly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "redonly"
-    replace: "readonly"
-    propagate_case: true
-    word: true
-
-  - trigger: "erbase"
+  - triggers:
+    - "erbase"
+    - "rbase"
+    - "rbease"
+    - "reabse"
+    - "rease"
+    - "rebae"
+    - "rebaes"
+    - "rebsae"
+    - "rebse"
     replace: "rebase"
     propagate_case: true
     word: true
 
-  - trigger: "rbase"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbease"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "reabse"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rease"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rebae"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rebaes"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rebsae"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "rebse"
-    replace: "rebase"
-    propagate_case: true
-    word: true
-
-  - trigger: "ercursion"
+  - triggers:
+    - "ercursion"
+    - "rceursion"
+    - "rcursion"
+    - "recrsion"
+    - "recrusion"
+    - "recurion"
+    - "recurison"
+    - "recursin"
+    - "recursino"
+    - "recursoin"
+    - "recurson"
+    - "recusion"
+    - "recusrion"
+    - "reucrsion"
+    - "reursion"
     replace: "recursion"
     propagate_case: true
     word: true
 
-  - trigger: "rceursion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcursion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recrsion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recrusion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recurion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recurison"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursin"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursino"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursoin"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recurson"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recusion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "recusrion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "reucrsion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "reursion"
-    replace: "recursion"
-    propagate_case: true
-    word: true
-
-  - trigger: "ercursive"
+  - triggers:
+    - "ercursive"
+    - "rceursive"
+    - "rcursive"
+    - "recrsive"
+    - "recrusive"
+    - "recurisve"
+    - "recurive"
+    - "recursie"
+    - "recursiev"
+    - "recursve"
+    - "recursvie"
+    - "recusive"
+    - "recusrive"
+    - "reucrsive"
+    - "reursive"
     replace: "recursive"
     propagate_case: true
     word: true
 
-  - trigger: "rceursive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcursive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recrsive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recrusive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recurisve"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recurive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursie"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursiev"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursve"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recursvie"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recusive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "recusrive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "reucrsive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "reursive"
-    replace: "recursive"
-    propagate_case: true
-    word: true
-
-  - trigger: "erdis"
+  - triggers:
+    - "erdis"
+    - "rdeis"
+    - "rdis"
+    - "reds"
+    - "redsi"
+    - "reids"
+    - "reis"
     replace: "redis"
     propagate_case: true
     word: true
 
-  - trigger: "rdeis"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "rdis"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "reds"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "redsi"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "reids"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "reis"
-    replace: "redis"
-    propagate_case: true
-    word: true
-
-  - trigger: "erfactor"
+  - triggers:
+    - "erfactor"
+    - "reafctor"
+    - "refacor"
+    - "refacotr"
+    - "refactr"
+    - "refactro"
+    - "refatcor"
+    - "refator"
+    - "refcator"
+    - "refctor"
+    - "rfactor"
+    - "rfeactor"
     replace: "refactor"
     propagate_case: true
     word: true
 
-  - trigger: "reactor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "reafctor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refacor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refacotr"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refactr"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refactro"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refatcor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refator"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refcator"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "refctor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "rfactor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "rfeactor"
-    replace: "refactor"
-    propagate_case: true
-    word: true
-
-  - trigger: "erlease"
+  - triggers:
+    - "erlease"
+    - "reease"
+    - "reelase"
+    - "relaese"
+    - "relase"
+    - "releae"
+    - "releaes"
+    - "relesae"
+    - "relese"
+    - "rlease"
+    - "rleease"
     replace: "release"
     propagate_case: true
     word: true
 
-  - trigger: "reease"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "reelase"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "relaese"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "relase"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "releae"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "releaes"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "relesae"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "relese"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "rlease"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "rleease"
-    replace: "release"
-    propagate_case: true
-    word: true
-
-  - trigger: "ermote"
+  - triggers:
+    - "ermote"
+    - "remoe"
+    - "remoet"
+    - "remte"
+    - "remtoe"
+    - "reomte"
+    - "reote"
+    - "rmeote"
+    - "rmote"
     replace: "remote"
     propagate_case: true
     word: true
 
-  - trigger: "remoe"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "remoet"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "remte"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "remtoe"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "reomte"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "reote"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmeote"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "rmote"
-    replace: "remote"
-    propagate_case: true
-    word: true
-
-  - trigger: "ernder"
+  - triggers:
+    - "ernder"
+    - "reder"
+    - "redner"
+    - "rendr"
+    - "rendre"
+    - "renedr"
+    - "rener"
+    - "rnder"
+    - "rneder"
     replace: "render"
     propagate_case: true
     word: true
 
-  - trigger: "reder"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "redner"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "rendr"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "rendre"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "renedr"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "rener"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "rnder"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "rneder"
-    replace: "render"
-    propagate_case: true
-    word: true
-
-  - trigger: "erpository"
+  - triggers:
+    - "erpository"
+    - "reopsitory"
+    - "reository"
+    - "repoistory"
+    - "repoitory"
+    - "reposiory"
+    - "reposiotry"
+    - "repositoy"
+    - "repositoyr"
+    - "repositroy"
+    - "repositry"
+    - "repostiory"
+    - "repostory"
+    - "repsitory"
+    - "repsoitory"
+    - "rpeository"
+    - "rpository"
     replace: "repository"
     propagate_case: true
     word: true
 
-  - trigger: "reopsitory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "reository"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repoistory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repoitory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "reposiory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "reposiotry"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repositoy"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repositoyr"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repositroy"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repositry"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repostiory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repostory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repsitory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "repsoitory"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpeository"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpository"
-    replace: "repository"
-    propagate_case: true
-    word: true
-
-  - trigger: "erquest"
+  - triggers:
+    - "erquest"
+    - "reqest"
+    - "reqeust"
+    - "requet"
+    - "requets"
+    - "requset"
+    - "requst"
+    - "reuest"
+    - "reuqest"
+    - "rqeuest"
+    - "rquest"
     replace: "request"
     propagate_case: true
     word: true
 
-  - trigger: "reqest"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "reqeust"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "requet"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "requets"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "requset"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "requst"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "reuest"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "reuqest"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "rqeuest"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "rquest"
-    replace: "request"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersolver"
+  - triggers:
+    - "ersolver"
+    - "reolver"
+    - "reoslver"
+    - "reslover"
+    - "reslver"
+    - "resoler"
+    - "resolevr"
+    - "resolvr"
+    - "resolvre"
+    - "resover"
+    - "resovler"
+    - "rseolver"
+    - "rsolver"
     replace: "resolver"
     propagate_case: true
     word: true
 
-  - trigger: "reolver"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "reoslver"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "reslover"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "reslver"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resoler"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resolevr"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resolvr"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resolvre"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resover"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "resovler"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseolver"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsolver"
-    replace: "resolver"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersponse"
+  - triggers:
+    - "ersponse"
+    - "reponse"
+    - "repsonse"
+    - "resonse"
+    - "resopnse"
+    - "respnose"
+    - "respnse"
+    - "respone"
+    - "respones"
+    - "respose"
+    - "resposne"
+    - "rseponse"
+    - "rsponse"
     replace: "response"
     propagate_case: true
     word: true
 
-  - trigger: "reponse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "repsonse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "resonse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "resopnse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "respnose"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "respnse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "respone"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "respones"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "respose"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "resposne"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseponse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsponse"
-    replace: "response"
-    propagate_case: true
-    word: true
-
-  - trigger: "ersponsive"
+  - triggers:
+    - "ersponsive"
+    - "reponsive"
+    - "repsonsive"
+    - "resonsive"
+    - "resopnsive"
+    - "respnosive"
+    - "respnsive"
+    - "responisve"
+    - "responive"
+    - "responsie"
+    - "responsiev"
+    - "responsve"
+    - "responsvie"
+    - "resposive"
+    - "resposnive"
+    - "rseponsive"
+    - "rsponsive"
     replace: "responsive"
     propagate_case: true
     word: true
 
-  - trigger: "reponsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "repsonsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "resonsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "resopnsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "respnosive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "respnsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responisve"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responsie"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responsiev"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responsve"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "responsvie"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "resposive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "resposnive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "rseponsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsponsive"
-    replace: "responsive"
-    propagate_case: true
-    word: true
-
-  - trigger: "erturn"
+  - triggers:
+    - "erturn"
+    - "retrn"
+    - "retrun"
+    - "retun"
+    - "retunr"
+    - "reurn"
+    - "reutrn"
+    - "rteurn"
+    - "rturn"
     replace: "return"
     propagate_case: true
     word: true
 
-  - trigger: "retrn"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "retrun"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "retun"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "retunr"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "reurn"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "reutrn"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "rteurn"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "rturn"
-    replace: "return"
-    propagate_case: true
-    word: true
-
-  - trigger: "rntime"
+  - triggers:
+    - "rntime"
+    - "rnutime"
+    - "runime"
+    - "runitme"
+    - "runtie"
+    - "runtiem"
+    - "runtme"
+    - "runtmie"
+    - "rutime"
+    - "rutnime"
+    - "urntime"
     replace: "runtime"
     propagate_case: true
     word: true
 
-  - trigger: "rnutime"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runime"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runitme"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runtie"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runtiem"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runtme"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "runtmie"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "rutime"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "rutnime"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "urntime"
-    replace: "runtime"
-    propagate_case: true
-    word: true
-
-  - trigger: "astisfies"
+  - triggers:
+    - "astisfies"
+    - "saisfies"
+    - "saitsfies"
+    - "satifies"
+    - "satifsies"
+    - "satisfeis"
+    - "satisfes"
+    - "satisfis"
+    - "satisfise"
+    - "satisies"
+    - "satisifes"
+    - "satsfies"
+    - "satsifies"
+    - "staisfies"
+    - "stisfies"
     replace: "satisfies"
     propagate_case: true
     word: true
 
-  - trigger: "saisfies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "saitsfies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satifies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satifsies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisfeis"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisfes"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisfis"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisfise"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satisifes"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satsfies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "satsifies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "staisfies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "stisfies"
-    replace: "satisfies"
-    propagate_case: true
-    word: true
-
-  - trigger: "csaffold"
+  - triggers:
+    - "csaffold"
+    - "sacffold"
+    - "saffold"
+    - "scaffld"
+    - "scafflod"
+    - "scaffod"
+    - "scaffodl"
+    - "scafofld"
+    - "scafold"
+    - "scfafold"
+    - "scffold"
     replace: "scaffold"
     propagate_case: true
     word: true
 
-  - trigger: "sacffold"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "saffold"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scaffld"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scafflod"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scaffod"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scaffodl"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scafofld"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scafold"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scfafold"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "scffold"
-    replace: "scaffold"
-    propagate_case: true
-    word: true
-
-  - trigger: "csroll"
+  - triggers:
+    - "csroll"
+    - "scoll"
+    - "scorll"
+    - "scrll"
+    - "scrlol"
+    - "scrol"
+    - "srcoll"
+    - "sroll"
     replace: "scroll"
     propagate_case: true
     word: true
 
-  - trigger: "scoll"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "scorll"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrll"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrlol"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrol"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "srcoll"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "sroll"
-    replace: "scroll"
-    propagate_case: true
-    word: true
-
-  - trigger: "esarch"
+  - triggers:
+    - "esarch"
+    - "saerch"
+    - "sarch"
+    - "seach"
+    - "seacrh"
+    - "searh"
+    - "searhc"
+    - "serach"
+    - "serch"
     replace: "search"
     propagate_case: true
     word: true
 
-  - trigger: "saerch"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "sarch"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "seach"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "seacrh"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "searh"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "searhc"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "serach"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "serch"
-    replace: "search"
-    propagate_case: true
-    word: true
-
-  - trigger: "escondary"
+  - triggers:
+    - "escondary"
+    - "sceondary"
+    - "scondary"
+    - "secndary"
+    - "secnodary"
+    - "secodary"
+    - "secodnary"
+    - "seconadry"
+    - "seconary"
+    - "seconday"
+    - "secondayr"
+    - "secondray"
+    - "secondry"
+    - "seocndary"
+    - "seondary"
     replace: "secondary"
     propagate_case: true
     word: true
 
-  - trigger: "sceondary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "scondary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secndary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secnodary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secodary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secodnary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "seconadry"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "seconary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "seconday"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secondayr"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secondray"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "secondry"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "seocndary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "seondary"
-    replace: "secondary"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslect"
+  - triggers:
+    - "eslect"
+    - "seect"
+    - "seelct"
+    - "selcet"
+    - "selct"
+    - "selet"
+    - "seletc"
+    - "slect"
+    - "sleect"
     replace: "select"
     propagate_case: true
     word: true
 
-  - trigger: "seect"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "seelct"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "selcet"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "selct"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "selet"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "seletc"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "slect"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "sleect"
-    replace: "select"
-    propagate_case: true
-    word: true
-
-  - trigger: "eslector"
+  - triggers:
+    - "eslector"
+    - "seector"
+    - "seelctor"
+    - "selcetor"
+    - "selctor"
+    - "selecor"
+    - "selecotr"
+    - "selectr"
+    - "selectro"
+    - "seletcor"
+    - "seletor"
+    - "slector"
+    - "sleector"
     replace: "selector"
     propagate_case: true
     word: true
 
-  - trigger: "seector"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "seelctor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selcetor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selctor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selecor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selecotr"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selectr"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "selectro"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "seletcor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "seletor"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "slector"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "sleector"
-    replace: "selector"
-    propagate_case: true
-    word: true
-
-  - trigger: "esmantic"
+  - triggers:
+    - "esmantic"
+    - "seamntic"
+    - "seantic"
+    - "semanic"
+    - "semanitc"
+    - "semantc"
+    - "semantci"
+    - "sematic"
+    - "sematnic"
+    - "semnatic"
+    - "semntic"
+    - "smantic"
+    - "smeantic"
     replace: "semantic"
     propagate_case: true
     word: true
 
-  - trigger: "seamntic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "seantic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semanic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semanitc"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semantc"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semantci"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "sematic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "sematnic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semnatic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "semntic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "smantic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "smeantic"
-    replace: "semantic"
-    propagate_case: true
-    word: true
-
-  - trigger: "esrialization"
+  - triggers:
+    - "esrialization"
+    - "seialization"
+    - "seiralization"
+    - "serailization"
+    - "seralization"
+    - "seriailzation"
+    - "seriaization"
+    - "serialiation"
+    - "serialiaztion"
+    - "serializaion"
+    - "serializaiton"
+    - "serializatin"
+    - "serializatino"
+    - "serializatoin"
+    - "serializaton"
+    - "serializtaion"
+    - "serializtion"
+    - "serialzation"
+    - "serialziation"
+    - "serilaization"
+    - "serilization"
+    - "sreialization"
+    - "srialization"
     replace: "serialization"
     propagate_case: true
     word: true
 
-  - trigger: "seialization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "seiralization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serailization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "seralization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "seriailzation"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "seriaization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialiation"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialiaztion"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializaion"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializaiton"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializatin"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializatino"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializatoin"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializaton"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializtaion"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializtion"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialzation"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialziation"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serilaization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "serilization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "sreialization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "srialization"
-    replace: "serialization"
-    propagate_case: true
-    word: true
-
-  - trigger: "esrializer"
+  - triggers:
+    - "esrializer"
+    - "seializer"
+    - "seiralizer"
+    - "serailizer"
+    - "seralizer"
+    - "seriailzer"
+    - "seriaizer"
+    - "serialier"
+    - "serialiezr"
+    - "serializr"
+    - "serializre"
+    - "serialzer"
+    - "serialzier"
+    - "serilaizer"
+    - "serilizer"
+    - "sreializer"
+    - "srializer"
     replace: "serializer"
     propagate_case: true
     word: true
 
-  - trigger: "seializer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "seiralizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serailizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "seralizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "seriailzer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "seriaizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialier"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialiezr"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializr"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serializre"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialzer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serialzier"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serilaizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "serilizer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "sreializer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "srializer"
-    replace: "serializer"
-    propagate_case: true
-    word: true
-
-  - trigger: "esrvice"
+  - triggers:
+    - "esrvice"
+    - "serice"
+    - "serivce"
+    - "servce"
+    - "servcie"
+    - "servie"
+    - "serviec"
+    - "sevice"
+    - "sevrice"
+    - "srevice"
+    - "srvice"
     replace: "service"
     propagate_case: true
     word: true
 
-  - trigger: "serice"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "serivce"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "servce"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "servcie"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "servie"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "serviec"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "sevice"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "sevrice"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "srevice"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "srvice"
-    replace: "service"
-    propagate_case: true
-    word: true
-
-  - trigger: "esttings"
+  - triggers:
+    - "esttings"
+    - "setings"
+    - "setitngs"
+    - "settigns"
+    - "settigs"
+    - "settins"
+    - "settinsg"
+    - "settngs"
+    - "settnigs"
+    - "stetings"
+    - "sttings"
     replace: "settings"
     propagate_case: true
     word: true
 
-  - trigger: "setings"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "setitngs"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settigns"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settigs"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settins"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settinsg"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settngs"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "settnigs"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "stetings"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "sttings"
-    replace: "settings"
-    propagate_case: true
-    word: true
-
-  - trigger: "hsadow"
+  - triggers:
+    - "hsadow"
+    - "sadow"
+    - "sahdow"
+    - "shadw"
+    - "shadwo"
+    - "shaodw"
+    - "shaow"
+    - "shdaow"
+    - "shdow"
     replace: "shadow"
     propagate_case: true
     word: true
 
-  - trigger: "sadow"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "sahdow"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shadw"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shadwo"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shaodw"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shaow"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shdaow"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "shdow"
-    replace: "shadow"
-    propagate_case: true
-    word: true
-
-  - trigger: "isdebar"
+  - triggers:
+    - "isdebar"
+    - "sdebar"
+    - "sdiebar"
+    - "sidbar"
+    - "sidbear"
+    - "sideabr"
+    - "sidear"
+    - "sidebr"
+    - "sidebra"
+    - "siebar"
+    - "siedbar"
     replace: "sidebar"
     propagate_case: true
     word: true
 
-  - trigger: "sdebar"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sdiebar"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sidbar"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sidbear"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sideabr"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sidear"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sidebr"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "sidebra"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "siebar"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "siedbar"
-    replace: "sidebar"
-    propagate_case: true
-    word: true
-
-  - trigger: "isngleton"
+  - triggers:
+    - "isngleton"
+    - "sigleton"
+    - "signleton"
+    - "singelton"
+    - "singeton"
+    - "singleon"
+    - "singleotn"
+    - "singletn"
+    - "singletno"
+    - "singlteon"
+    - "singlton"
+    - "sinleton"
+    - "sinlgeton"
+    - "sngleton"
+    - "snigleton"
     replace: "singleton"
     propagate_case: true
     word: true
 
-  - trigger: "sigleton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "signleton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singelton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singeton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singleon"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singleotn"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singletn"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singletno"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singlteon"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "singlton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "sinleton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "sinlgeton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "sngleton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "snigleton"
-    replace: "singleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "kseleton"
+  - triggers:
+    - "kseleton"
+    - "sekleton"
+    - "seleton"
+    - "skeelton"
+    - "skeeton"
+    - "skeleon"
+    - "skeleotn"
+    - "skeletn"
+    - "skeletno"
+    - "skelteon"
+    - "skelton"
+    - "skleeton"
+    - "skleton"
     replace: "skeleton"
     propagate_case: true
     word: true
 
-  - trigger: "sekleton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "seleton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeelton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeeton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeleon"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeleotn"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeletn"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skeletno"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skelteon"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skelton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skleeton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "skleton"
-    replace: "skeleton"
-    propagate_case: true
-    word: true
-
-  - trigger: "lsider"
+  - triggers:
+    - "lsider"
+    - "silder"
+    - "slder"
+    - "sldier"
+    - "slidr"
+    - "slidre"
+    - "sliedr"
+    - "slier"
     replace: "slider"
     propagate_case: true
     word: true
 
-  - trigger: "sider"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "silder"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "slder"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "sldier"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "slidr"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "slidre"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "sliedr"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "slier"
-    replace: "slider"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsapshot"
+  - triggers:
+    - "nsapshot"
+    - "sanpshot"
+    - "sapshot"
+    - "snaphot"
+    - "snaphsot"
+    - "snapsht"
+    - "snapshto"
+    - "snapsoht"
+    - "snapsot"
+    - "snashot"
+    - "snasphot"
+    - "snpashot"
+    - "snpshot"
     replace: "snapshot"
     propagate_case: true
     word: true
 
-  - trigger: "sanpshot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapshot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snaphot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snaphsot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snapsht"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snapshto"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snapsoht"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snapsot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snashot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snasphot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snpashot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "snpshot"
-    replace: "snapshot"
-    propagate_case: true
-    word: true
-
-  - trigger: "psacing"
+  - triggers:
+    - "psacing"
+    - "sacing"
+    - "sapcing"
+    - "spacig"
+    - "spacign"
+    - "spacng"
+    - "spacnig"
+    - "spaicng"
+    - "spaing"
+    - "spcaing"
+    - "spcing"
     replace: "spacing"
     propagate_case: true
     word: true
 
-  - trigger: "sacing"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapcing"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spacig"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spacign"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spacng"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spacnig"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spaicng"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spaing"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spcaing"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "spcing"
-    replace: "spacing"
-    propagate_case: true
-    word: true
-
-  - trigger: "psinner"
+  - triggers:
+    - "psinner"
+    - "sipnner"
+    - "spinenr"
+    - "spiner"
+    - "spinnr"
+    - "spinnre"
+    - "spniner"
+    - "spnner"
     replace: "spinner"
     propagate_case: true
     word: true
 
-  - trigger: "sinner"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "sipnner"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spinenr"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spiner"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spinnr"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spinnre"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spniner"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "spnner"
-    replace: "spinner"
-    propagate_case: true
-    word: true
-
-  - trigger: "psrint"
+  - triggers:
+    - "psrint"
+    - "spint"
+    - "spirnt"
+    - "spritn"
+    - "sprnit"
+    - "sprnt"
+    - "srint"
+    - "srpint"
     replace: "sprint"
     propagate_case: true
     word: true
 
-  - trigger: "spint"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "spirnt"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "sprit"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "spritn"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "sprnit"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "sprnt"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "srint"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "srpint"
-    replace: "sprint"
-    propagate_case: true
-    word: true
-
-  - trigger: "saging"
+  - triggers:
+    - "saging"
+    - "satging"
+    - "stagig"
+    - "stagign"
+    - "stagng"
+    - "stagnig"
+    - "staigng"
+    - "staing"
+    - "stgaing"
+    - "stging"
+    - "tsaging"
     replace: "staging"
     propagate_case: true
     word: true
 
-  - trigger: "satging"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stagig"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stagign"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stagng"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stagnig"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "staigng"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "staing"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stgaing"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "stging"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsaging"
-    replace: "staging"
-    propagate_case: true
-    word: true
-
-  - trigger: "sash"
+  - triggers:
+    - "satsh"
+    - "stah"
+    - "stahs"
+    - "stsah"
+    - "stsh"
+    - "tsash"
     replace: "stash"
     propagate_case: true
     word: true
 
-  - trigger: "satsh"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "stah"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "stahs"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "stsah"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "stsh"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsash"
-    replace: "stash"
-    propagate_case: true
-    word: true
-
-  - trigger: "sate"
+  - triggers:
+    - "satte"
+    - "stae"
+    - "staet"
+    - "sttae"
+    - "stte"
+    - "tsate"
     replace: "state"
     propagate_case: true
     word: true
 
-  - trigger: "satte"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "stae"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "staet"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "sttae"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "stte"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsate"
-    replace: "state"
-    propagate_case: true
-    word: true
-
-  - trigger: "sattus"
+  - triggers:
+    - "sattus"
+    - "satus"
+    - "stats"
+    - "statsu"
+    - "staus"
+    - "stauts"
+    - "sttaus"
+    - "sttus"
+    - "tsatus"
     replace: "status"
     propagate_case: true
     word: true
 
-  - trigger: "satus"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "stats"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "statsu"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "staus"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "stauts"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "sttaus"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "sttus"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsatus"
-    replace: "status"
-    propagate_case: true
-    word: true
-
-  - trigger: "sepper"
+  - triggers:
+    - "sepper"
+    - "setpper"
+    - "stepepr"
+    - "steper"
+    - "steppr"
+    - "steppre"
+    - "stpeper"
+    - "stpper"
+    - "tsepper"
     replace: "stepper"
     propagate_case: true
     word: true
 
-  - trigger: "setpper"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "stepepr"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "steper"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "steppr"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "steppre"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "stpeper"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "stpper"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsepper"
-    replace: "stepper"
-    propagate_case: true
-    word: true
-
-  - trigger: "srategy"
+  - triggers:
+    - "srategy"
+    - "srtategy"
+    - "startegy"
+    - "stategy"
+    - "straegy"
+    - "straetgy"
+    - "stratey"
+    - "strateyg"
+    - "stratgey"
+    - "stratgy"
+    - "strtaegy"
+    - "strtegy"
+    - "tsrategy"
     replace: "strategy"
     propagate_case: true
     word: true
 
-  - trigger: "srtategy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "startegy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "stategy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "straegy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "straetgy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "stratey"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "strateyg"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "stratgey"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "stratgy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "strtaegy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "strtegy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsrategy"
-    replace: "strategy"
-    propagate_case: true
-    word: true
-
-  - trigger: "sring"
+  - triggers:
+    - "sring"
+    - "srting"
+    - "stirng"
+    - "strig"
+    - "strign"
+    - "strng"
+    - "strnig"
+    - "tsring"
     replace: "string"
     propagate_case: true
     word: true
 
-  - trigger: "srting"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "sting"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "stirng"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "strig"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "strign"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "strng"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "strnig"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsring"
-    replace: "string"
-    propagate_case: true
-    word: true
-
-  - trigger: "stbu"
+  - triggers:
+    - "stbu"
+    - "sutb"
+    - "tsub"
     replace: "stub"
     propagate_case: true
     word: true
 
-  - trigger: "sutb"
-    replace: "stub"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsub"
-    replace: "stub"
-    propagate_case: true
-    word: true
-
-  - trigger: "stlesheet"
+  - triggers:
+    - "stlesheet"
+    - "stlyesheet"
+    - "styelsheet"
+    - "styesheet"
+    - "styleheet"
+    - "stylehseet"
+    - "styleseet"
+    - "stylesehet"
+    - "styleshet"
+    - "styleshete"
+    - "stylseheet"
+    - "stylsheet"
+    - "sylesheet"
+    - "sytlesheet"
+    - "tsylesheet"
     replace: "stylesheet"
     propagate_case: true
     word: true
 
-  - trigger: "stlyesheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styelsheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styesheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styleheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "stylehseet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styleseet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "stylesehet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styleshet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "styleshete"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "stylseheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "stylsheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "sylesheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "sytlesheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsylesheet"
-    replace: "stylesheet"
-    propagate_case: true
-    word: true
-
-  - trigger: "spabase"
+  - triggers:
+    - "spabase"
+    - "spuabase"
+    - "suabase"
+    - "suapbase"
+    - "supaabse"
+    - "supaase"
+    - "supabae"
+    - "supabaes"
+    - "supabsae"
+    - "supabse"
+    - "supbaase"
+    - "supbase"
+    - "uspabase"
     replace: "supabase"
     propagate_case: true
     word: true
 
-  - trigger: "spuabase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "suabase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "suapbase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supaabse"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supaase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supabae"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supabaes"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supabsae"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supabse"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supbaase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "supbase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "uspabase"
-    replace: "supabase"
-    propagate_case: true
-    word: true
-
-  - trigger: "snchronous"
+  - triggers:
+    - "snchronous"
+    - "snychronous"
+    - "sychronous"
+    - "sycnhronous"
+    - "synchonous"
+    - "synchornous"
+    - "synchrnoous"
+    - "synchrnous"
+    - "synchronos"
+    - "synchronosu"
+    - "synchronuos"
+    - "synchronus"
+    - "synchroonus"
+    - "synchroous"
+    - "syncrhonous"
+    - "syncronous"
+    - "synhcronous"
+    - "synhronous"
+    - "ysnchronous"
     replace: "synchronous"
     propagate_case: true
     word: true
 
-  - trigger: "snychronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "sychronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "sycnhronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchonous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchornous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchrnoous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchrnous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchronos"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchronosu"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchronuos"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchronus"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchroonus"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synchroous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "syncrhonous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "syncronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synhcronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "synhronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "ysnchronous"
-    replace: "synchronous"
-    propagate_case: true
-    word: true
-
-  - trigger: "sstem"
+  - triggers:
+    - "sstem"
+    - "ssytem"
+    - "sysem"
+    - "sysetm"
+    - "systm"
+    - "systme"
+    - "sytem"
+    - "sytsem"
+    - "ysstem"
     replace: "system"
     propagate_case: true
     word: true
 
-  - trigger: "ssytem"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "sysem"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "sysetm"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "systm"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "systme"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "sytem"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "sytsem"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "ysstem"
-    replace: "system"
-    propagate_case: true
-    word: true
-
-  - trigger: "atble"
+  - triggers:
+    - "atble"
+    - "tabe"
+    - "tabel"
+    - "talbe"
+    - "tbale"
+    - "tble"
     replace: "table"
     propagate_case: true
     word: true
 
-  - trigger: "tabe"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "tabel"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "talbe"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "tale"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "tbale"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "tble"
-    replace: "table"
-    propagate_case: true
-    word: true
-
-  - trigger: "etmplate"
+  - triggers:
+    - "etmplate"
+    - "temlate"
+    - "temlpate"
+    - "tempalte"
+    - "tempate"
+    - "templae"
+    - "templaet"
+    - "templtae"
+    - "templte"
+    - "teplate"
+    - "tepmlate"
+    - "tmeplate"
+    - "tmplate"
     replace: "template"
     propagate_case: true
     word: true
 
-  - trigger: "temlate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "temlpate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "tempalte"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "tempate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "templae"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "templaet"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "templtae"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "templte"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "teplate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "tepmlate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "tmeplate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "tmplate"
-    replace: "template"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrraform"
+  - triggers:
+    - "etrraform"
+    - "teraform"
+    - "terarform"
+    - "terrafom"
+    - "terrafomr"
+    - "terrafrm"
+    - "terrafrom"
+    - "terraofrm"
+    - "terraorm"
+    - "terrfaorm"
+    - "terrform"
+    - "treraform"
+    - "trraform"
     replace: "terraform"
     propagate_case: true
     word: true
 
-  - trigger: "teraform"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terarform"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrafom"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrafomr"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrafrm"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrafrom"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terraofrm"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terraorm"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrfaorm"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "terrform"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "treraform"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "trraform"
-    replace: "terraform"
-    propagate_case: true
-    word: true
-
-  - trigger: "etst"
+  - triggers:
+    - "etst"
+    - "tets"
+    - "tset"
     replace: "test"
     propagate_case: true
     word: true
 
-  - trigger: "tets"
-    replace: "test"
-    propagate_case: true
-    word: true
-
-  - trigger: "tset"
-    replace: "test"
-    propagate_case: true
-    word: true
-
-  - trigger: "etxtarea"
+  - triggers:
+    - "etxtarea"
+    - "tetarea"
+    - "tetxarea"
+    - "texarea"
+    - "texatrea"
+    - "textaea"
+    - "textaera"
+    - "textara"
+    - "textarae"
+    - "textraea"
+    - "textrea"
+    - "txetarea"
+    - "txtarea"
     replace: "textarea"
     propagate_case: true
     word: true
 
-  - trigger: "tetarea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "tetxarea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "texarea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "texatrea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textaea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textaera"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textara"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textarae"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textraea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "textrea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "txetarea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "txtarea"
-    replace: "textarea"
-    propagate_case: true
-    word: true
-
-  - trigger: "hteme"
+  - triggers:
+    - "hteme"
+    - "tehme"
+    - "teme"
+    - "theem"
+    - "thme"
+    - "thmee"
     replace: "theme"
     propagate_case: true
     word: true
 
-  - trigger: "tehme"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "teme"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "thee"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "theem"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "thme"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "thmee"
-    replace: "theme"
-    propagate_case: true
-    word: true
-
-  - trigger: "htrottle"
+  - triggers:
+    - "htrottle"
+    - "thorttle"
+    - "thottle"
+    - "throtle"
+    - "throtlte"
+    - "throtte"
+    - "throttel"
+    - "thrtotle"
+    - "thrttle"
+    - "trhottle"
+    - "trottle"
     replace: "throttle"
     propagate_case: true
     word: true
 
-  - trigger: "thorttle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "thottle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "throtle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "throtlte"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "throtte"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "throttel"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "thrtotle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "thrttle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "trhottle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "trottle"
-    replace: "throttle"
-    propagate_case: true
-    word: true
-
-  - trigger: "itcket"
+  - triggers:
+    - "itcket"
+    - "tciket"
+    - "tcket"
+    - "ticekt"
+    - "ticet"
+    - "tickt"
+    - "tickte"
+    - "tikcet"
+    - "tiket"
     replace: "ticket"
     propagate_case: true
     word: true
 
-  - trigger: "tciket"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "tcket"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "ticekt"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "ticet"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "tickt"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "tickte"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "tikcet"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "tiket"
-    replace: "ticket"
-    propagate_case: true
-    word: true
-
-  - trigger: "otast"
+  - triggers:
+    - "otast"
+    - "taost"
+    - "tast"
+    - "toat"
+    - "toats"
+    - "tosat"
     replace: "toast"
     propagate_case: true
     word: true
 
-  - trigger: "taost"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "tast"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "toat"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "toats"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "tosat"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "tost"
-    replace: "toast"
-    propagate_case: true
-    word: true
-
-  - trigger: "otggle"
+  - triggers:
+    - "otggle"
+    - "tggle"
+    - "tgogle"
+    - "togge"
+    - "toggel"
+    - "togle"
+    - "toglge"
     replace: "toggle"
     propagate_case: true
     word: true
 
-  - trigger: "tggle"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "tgogle"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "togge"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "toggel"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "togle"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "toglge"
-    replace: "toggle"
-    propagate_case: true
-    word: true
-
-  - trigger: "otken"
+  - triggers:
+    - "otken"
+    - "tken"
+    - "tkoen"
+    - "toekn"
+    - "toen"
+    - "tokn"
+    - "tokne"
     replace: "token"
     propagate_case: true
     word: true
 
-  - trigger: "tken"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "tkoen"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "toekn"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "toen"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "tokn"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "tokne"
-    replace: "token"
-    propagate_case: true
-    word: true
-
-  - trigger: "otoltip"
+  - triggers:
+    - "otoltip"
+    - "tolotip"
+    - "toltip"
+    - "toolip"
+    - "toolitp"
+    - "tooltp"
+    - "tooltpi"
+    - "tootip"
+    - "tootlip"
     replace: "tooltip"
     propagate_case: true
     word: true
 
-  - trigger: "tolotip"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "toltip"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "toolip"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "toolitp"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "tooltp"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "tooltpi"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "tootip"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "tootlip"
-    replace: "tooltip"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtansform"
+  - triggers:
+    - "rtansform"
+    - "tansform"
+    - "tarnsform"
+    - "tranform"
+    - "tranfsorm"
+    - "transfom"
+    - "transfomr"
+    - "transfrm"
+    - "transfrom"
+    - "transofrm"
+    - "transorm"
+    - "trasform"
+    - "trasnform"
+    - "trnasform"
+    - "trnsform"
     replace: "transform"
     propagate_case: true
     word: true
 
-  - trigger: "tansform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "tarnsform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranfsorm"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transfom"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transfomr"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transfrm"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transfrom"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transofrm"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "transorm"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasnform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnasform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnsform"
-    replace: "transform"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtansition"
+  - triggers:
+    - "rtansition"
+    - "tansition"
+    - "tarnsition"
+    - "tranistion"
+    - "tranition"
+    - "transiion"
+    - "transiiton"
+    - "transitin"
+    - "transitino"
+    - "transitoin"
+    - "transiton"
+    - "transtiion"
+    - "transtion"
+    - "trasition"
+    - "trasnition"
+    - "trnasition"
+    - "trnsition"
     replace: "transition"
     propagate_case: true
     word: true
 
-  - trigger: "tansition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "tarnsition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranistion"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transiion"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transiiton"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transitin"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transitino"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transitoin"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transiton"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transtiion"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "transtion"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasnition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnasition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnsition"
-    replace: "transition"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtansparent"
+  - triggers:
+    - "rtansparent"
+    - "tansparent"
+    - "tarnsparent"
+    - "tranparent"
+    - "tranpsarent"
+    - "transaprent"
+    - "transarent"
+    - "transpaent"
+    - "transpaernt"
+    - "transparet"
+    - "transparetn"
+    - "transparnet"
+    - "transparnt"
+    - "transpraent"
+    - "transprent"
+    - "trasnparent"
+    - "trasparent"
+    - "trnasparent"
+    - "trnsparent"
     replace: "transparent"
     propagate_case: true
     word: true
 
-  - trigger: "tansparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "tarnsparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "tranpsarent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transaprent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transarent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transpaent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transpaernt"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transparet"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transparetn"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transparnet"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transparnt"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transpraent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "transprent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasnparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "trasparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnasparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnsparent"
-    replace: "transparent"
-    propagate_case: true
-    word: true
-
-  - trigger: "tpye"
+  - triggers:
+    - "tpye"
+    - "tyep"
+    - "ytpe"
     replace: "type"
     propagate_case: true
     word: true
 
-  - trigger: "tyep"
-    replace: "type"
-    propagate_case: true
-    word: true
-
-  - trigger: "ytpe"
-    replace: "type"
-    propagate_case: true
-    word: true
-
-  - trigger: "tpography"
+  - triggers:
+    - "tpography"
+    - "tpyography"
+    - "tyography"
+    - "tyopgraphy"
+    - "typgoraphy"
+    - "typgraphy"
+    - "typogaphy"
+    - "typogarphy"
+    - "typograhpy"
+    - "typograhy"
+    - "typograpy"
+    - "typograpyh"
+    - "typogrpahy"
+    - "typogrphy"
+    - "typoraphy"
+    - "typorgaphy"
+    - "ytpography"
     replace: "typography"
     propagate_case: true
     word: true
 
-  - trigger: "tpyography"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "tyography"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "tyopgraphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typgoraphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typgraphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typogaphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typogarphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typograhpy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typograhy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typograpy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typograpyh"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typogrpahy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typogrphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typoraphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "typorgaphy"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "ytpography"
-    replace: "typography"
-    propagate_case: true
-    word: true
-
-  - trigger: "nudefined"
+  - triggers:
+    - "nudefined"
+    - "udefined"
+    - "udnefined"
+    - "undefied"
+    - "undefiend"
+    - "undefind"
+    - "undefinde"
+    - "undefned"
+    - "undefnied"
+    - "undeifned"
+    - "undeined"
+    - "undfeined"
+    - "undfined"
+    - "unedfined"
+    - "unefined"
     replace: "undefined"
     propagate_case: true
     word: true
 
-  - trigger: "udefined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "udnefined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefied"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefiend"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefind"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefinde"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefned"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undefnied"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undeifned"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undeined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undfeined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "undfined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "unedfined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "unefined"
-    replace: "undefined"
-    propagate_case: true
-    word: true
-
-  - trigger: "uicorn"
+  - triggers:
+    - "uicorn"
+    - "uivcorn"
+    - "uvciorn"
+    - "uvcorn"
+    - "uvicon"
+    - "uviconr"
+    - "uvicrn"
+    - "uvicron"
+    - "uviocrn"
+    - "uviorn"
+    - "vuicorn"
     replace: "uvicorn"
     propagate_case: true
     word: true
 
-  - trigger: "uivcorn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uvciorn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uvcorn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uvicon"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uviconr"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uvicrn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uvicron"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uviocrn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "uviorn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "vuicorn"
-    replace: "uvicorn"
-    propagate_case: true
-    word: true
-
-  - trigger: "avriable"
+  - triggers:
+    - "avriable"
+    - "vaiable"
+    - "vairable"
+    - "varable"
+    - "varaible"
+    - "variabe"
+    - "variabel"
+    - "varialbe"
+    - "variale"
+    - "varibale"
+    - "varible"
+    - "vraiable"
+    - "vriable"
     replace: "variable"
     propagate_case: true
     word: true
 
-  - trigger: "vaiable"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "vairable"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "varable"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "varaible"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "variabe"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "variabel"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "varialbe"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "variale"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "varibale"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "varible"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "vraiable"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "vriable"
-    replace: "variable"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrcel"
+  - triggers:
+    - "evrcel"
+    - "vecel"
+    - "vecrel"
+    - "vercl"
+    - "vercle"
+    - "verecl"
+    - "verel"
+    - "vrcel"
+    - "vrecel"
     replace: "vercel"
     propagate_case: true
     word: true
 
-  - trigger: "vecel"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "vecrel"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "vercl"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "vercle"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "verecl"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "verel"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrcel"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrecel"
-    replace: "vercel"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivewport"
+  - triggers:
+    - "ivewport"
+    - "veiwport"
+    - "vewport"
+    - "vieport"
+    - "viepwort"
+    - "viewoprt"
+    - "viewort"
+    - "viewpot"
+    - "viewpotr"
+    - "viewprot"
+    - "viewprt"
+    - "viweport"
+    - "viwport"
     replace: "viewport"
     propagate_case: true
     word: true
 
-  - trigger: "veiwport"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "vewport"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "vieport"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viepwort"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewoprt"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewort"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewpot"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewpotr"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewprot"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viewprt"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viweport"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "viwport"
-    replace: "viewport"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivrtualenv"
+  - triggers:
+    - "ivrtualenv"
+    - "virtalenv"
+    - "virtaulenv"
+    - "virtuaelnv"
+    - "virtuaenv"
+    - "virtualev"
+    - "virtualevn"
+    - "virtualnev"
+    - "virtualnv"
+    - "virtulaenv"
+    - "virtulenv"
+    - "virualenv"
+    - "virutalenv"
+    - "vitrualenv"
+    - "vitualenv"
+    - "vritualenv"
+    - "vrtualenv"
     replace: "virtualenv"
     propagate_case: true
     word: true
 
-  - trigger: "virtalenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtaulenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtuaelnv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtuaenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtualev"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtualevn"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtualnev"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtualnv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtulaenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virtulenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virualenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "virutalenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "vitrualenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "vitualenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "vritualenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrtualenv"
-    replace: "virtualenv"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivsibility"
+  - triggers:
+    - "ivsibility"
+    - "viibility"
+    - "viisbility"
+    - "visbiility"
+    - "visbility"
+    - "visibiilty"
+    - "visibiity"
+    - "visibiliy"
+    - "visibiliyt"
+    - "visibiltiy"
+    - "visibilty"
+    - "visibliity"
+    - "visiblity"
+    - "visiiblity"
+    - "visiility"
+    - "vsibility"
+    - "vsiibility"
     replace: "visibility"
     propagate_case: true
     word: true
 
-  - trigger: "viibility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "viisbility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visbiility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visbility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibiilty"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibiity"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibiliy"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibiliyt"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibiltiy"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibilty"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visibliity"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visiblity"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visiiblity"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "visiility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsibility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsiibility"
-    replace: "visibility"
-    propagate_case: true
-    word: true
-
-  - trigger: "ewbpack"
+  - triggers:
+    - "ewbpack"
+    - "wbepack"
+    - "wbpack"
+    - "weback"
+    - "webapck"
+    - "webpak"
+    - "webpakc"
+    - "webpcak"
+    - "webpck"
+    - "wepack"
+    - "wepback"
     replace: "webpack"
     propagate_case: true
     word: true
 
-  - trigger: "wbepack"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "wbpack"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "weback"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "webapck"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "webpak"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "webpakc"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "webpcak"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "webpck"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "wepack"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "wepback"
-    replace: "webpack"
-    propagate_case: true
-    word: true
-
-  - trigger: "iwreframe"
+  - triggers:
+    - "iwreframe"
+    - "wieframe"
+    - "wierframe"
+    - "wirefame"
+    - "wirefarme"
+    - "wirefrae"
+    - "wirefraem"
+    - "wirefrmae"
+    - "wirefrme"
+    - "wirerame"
+    - "wirerfame"
+    - "wirferame"
+    - "wirframe"
+    - "wreframe"
+    - "wrieframe"
     replace: "wireframe"
     propagate_case: true
     word: true
 
-  - trigger: "wieframe"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wierframe"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefame"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefarme"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefrae"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefraem"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefrmae"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirefrme"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirerame"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirerfame"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirferame"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wirframe"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wreframe"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrieframe"
-    replace: "wireframe"
-    propagate_case: true
-    word: true
-
-  - trigger: "rwapper"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wapper"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "warpper"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrapepr"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wraper"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrappr"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrappre"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrpaper"
-    replace: "wrapper"
-    propagate_case: true
-    word: true
-
-  - trigger: "wrpper"
+  - triggers:
+    - "rwapper"
+    - "wapper"
+    - "warpper"
+    - "wrapepr"
+    - "wraper"
+    - "wrappr"
+    - "wrappre"
+    - "wrpaper"
+    - "wrpper"
     replace: "wrapper"
     propagate_case: true
     word: true

--- a/packages/refuos-italiano/0.1.0/README.md
+++ b/packages/refuos-italiano/0.1.0/README.md
@@ -1,0 +1,19 @@
+# Refuos Italiano
+
+Real-time autocorrection for everyday Italian words, powered by [Espanso](https://espanso.org).
+
+## What it fixes
+
+Transpositions, missing double letters, and dropped characters — for example:
+
+| You type   | Corrected to |
+|------------|--------------|
+| `acnhe`    | `anche`      |
+| `comunqeu` | `comunque`   |
+| `perche`   | `perché`     |
+
+~2,500 rules in total.
+
+## Source
+
+<https://github.com/heavybeard/refuos>

--- a/packages/refuos-italiano/0.1.0/README.md
+++ b/packages/refuos-italiano/0.1.0/README.md
@@ -10,7 +10,7 @@ Transpositions, missing double letters, and dropped characters — for example:
 |------------|--------------|
 | `acnhe`    | `anche`      |
 | `comunqeu` | `comunque`   |
-| `perche`   | `perché`     |
+| `probelma` | `problema`   |
 
 ~2,500 rules in total.
 

--- a/packages/refuos-italiano/0.1.0/_manifest.yml
+++ b/packages/refuos-italiano/0.1.0/_manifest.yml
@@ -1,0 +1,7 @@
+name: "refuos-italiano"
+title: "Refuos Italiano"
+description: "Real-time autocorrection for everyday Italian words. Fixes typos like acnhe→anche, comunqeu→comunque."
+version: "0.1.0"
+author: "Andrea Cognini"
+tags: ["italian", "autocorrect", "typo", "italiano"]
+homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-italiano/0.1.0/_manifest.yml
+++ b/packages/refuos-italiano/0.1.0/_manifest.yml
@@ -3,5 +3,5 @@ title: "Refuos Italiano"
 description: "Real-time autocorrection for everyday Italian words. Fixes typos like acnhe→anche, comunqeu→comunque."
 version: "0.1.0"
 author: "Andrea Cognini"
-tags: ["italian", "autocorrect", "typo", "italiano"]
+tags: ["italian", "autocorrect", "typo", "italiano", "languages", "spell-correction", "typofixer"]
 homepage: "https://github.com/heavybeard/refuos"

--- a/packages/refuos-italiano/0.1.0/package.yml
+++ b/packages/refuos-italiano/0.1.0/package.yml
@@ -1,0 +1,13221 @@
+# Refuos - Italiano
+# Everyday Italian words
+# https://github.com/heavybeard/refuos
+# Auto-generated - regenerate with: python3 generate_espanso.py
+
+matches:
+
+  - trigger: "abbaimo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abbamo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abbiao"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abbiaom"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abbimao"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abbimo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abiamo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "abibamo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "babiamo"
+    replace: "abbiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "acqa"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "acqau"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "acua"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "acuqa"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "aqcua"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "aqua"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "caqua"
+    replace: "acqua"
+    propagate_case: true
+    word: true
+
+  - trigger: "adeso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "adesos"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "adseso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "adsso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "aedsso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "aesso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "daesso"
+    replace: "adesso"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggionramento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioramento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggioranmento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornaemnto"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornaento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornameno"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornamenot"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornametno"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornameto"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornamneto"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornamnto"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornmaento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggiornmento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggirnamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggironamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggoirnamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aggornamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "agigornamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "agiornamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "gagiornamento"
+    replace: "aggiornamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "aitare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aituare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiuatre"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutae"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutaer"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutrae"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aiutre"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "auitare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "autare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iautare"
+    replace: "aiutare"
+    propagate_case: true
+    word: true
+
+  - trigger: "alemno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "aleno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "almeo"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "almeon"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "almneo"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "almno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ameno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "amleno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "lameno"
+    replace: "almeno"
+    propagate_case: true
+    word: true
+
+  - trigger: "alot"
+    replace: "alto"
+    propagate_case: true
+    word: true
+
+  - trigger: "atlo"
+    replace: "alto"
+    propagate_case: true
+    word: true
+
+  - trigger: "lato"
+    replace: "alto"
+    propagate_case: true
+    word: true
+
+  - trigger: "aico"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "aimco"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "amcio"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "amco"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "amio"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "amioc"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "maico"
+    replace: "amico"
+    propagate_case: true
+    word: true
+
+  - trigger: "ache"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "acnhe"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "ance"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "anceh"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "anhce"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "anhe"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "nache"
+    replace: "anche"
+    propagate_case: true
+    word: true
+
+  - trigger: "acnora"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "acora"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancoa"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancoar"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancra"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "ancroa"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "anocra"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "anora"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "nacora"
+    replace: "ancora"
+    propagate_case: true
+    word: true
+
+  - trigger: "adare"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "adnare"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "anadre"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "anare"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "andae"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "andaer"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "andrae"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "andre"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadare"
+    replace: "andare"
+    propagate_case: true
+    word: true
+
+  - trigger: "adate"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "adnate"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "anadte"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "anate"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "andaet"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "andtae"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "andte"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadate"
+    replace: "andate"
+    propagate_case: true
+    word: true
+
+  - trigger: "adiamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "adniamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andaimo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andiao"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andiaom"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andimao"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "andimo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "aniamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "anidamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nadiamo"
+    replace: "andiamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ano"
+    replace: "anno"
+    propagate_case: true
+    word: true
+
+  - trigger: "anon"
+    replace: "anno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nano"
+    replace: "anno"
+    propagate_case: true
+    word: true
+
+  - trigger: "apena"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "apepna"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "appea"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "appean"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "appna"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "appnea"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "papena"
+    replace: "appena"
+    propagate_case: true
+    word: true
+
+  - trigger: "appntamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appnutamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appunamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appunatmento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntaemnto"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntaento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntameno"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntamenot"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntametno"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntameto"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntamneto"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntamnto"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntmaento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "appuntmento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "apputamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "apputnamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "apuntamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "apupntamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "papuntamento"
+    replace: "appuntamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "apire"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "apirre"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprie"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprier"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprre"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprrie"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "arire"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "arpire"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "parire"
+    replace: "aprire"
+    propagate_case: true
+    word: true
+
+  - trigger: "arirvederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arivederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrievderci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivdeerci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivderci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivedeci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivedecri"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivederi"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivederic"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivedrci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrivedreci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveedrci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arriveerci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrvederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "arrviederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "rarivederci"
+    replace: "arrivederci"
+    propagate_case: true
+    word: true
+
+  - trigger: "apettare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "apsettare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "asepttare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "asettare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspetatre"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettae"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettaer"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettrae"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspettre"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "asptetare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspttare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapettare"
+    replace: "aspettare"
+    propagate_case: true
+    word: true
+
+  - trigger: "atenzione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "atetnzione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenizone"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzine"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzinoe"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzioe"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzioen"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzoine"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attenzone"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attezione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "atteznione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attnezione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "attnzione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "tatenzione"
+    replace: "attenzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "atraverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "atrtaverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attarverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attaverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attraerso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attraevrso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attravero"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attraveros"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attraveso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attravesro"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attravreso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attravrso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attrvaerso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "attrverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "tatraverso"
+    replace: "attraverso"
+    propagate_case: true
+    word: true
+
+  - trigger: "aere"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "aevre"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "avee"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "aveer"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "avre"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "avree"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vaere"
+    replace: "avere"
+    propagate_case: true
+    word: true
+
+  - trigger: "aete"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "aevte"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "aveet"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "avte"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "avtee"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "vaete"
+    replace: "avete"
+    propagate_case: true
+    word: true
+
+  - trigger: "abmbino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "babino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "babmino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bambio"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bambion"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bambnio"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bambno"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bamibno"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bamino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bmabino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "bmbino"
+    replace: "bambino"
+    propagate_case: true
+    word: true
+
+  - trigger: "abssa"
+    replace: "bassa"
+    propagate_case: true
+    word: true
+
+  - trigger: "basa"
+    replace: "bassa"
+    propagate_case: true
+    word: true
+
+  - trigger: "basas"
+    replace: "bassa"
+    propagate_case: true
+    word: true
+
+  - trigger: "bsasa"
+    replace: "bassa"
+    propagate_case: true
+    word: true
+
+  - trigger: "bssa"
+    replace: "bassa"
+    propagate_case: true
+    word: true
+
+  - trigger: "bela"
+    replace: "bella"
+    propagate_case: true
+    word: true
+
+  - trigger: "belal"
+    replace: "bella"
+    propagate_case: true
+    word: true
+
+  - trigger: "blela"
+    replace: "bella"
+    propagate_case: true
+    word: true
+
+  - trigger: "blla"
+    replace: "bella"
+    propagate_case: true
+    word: true
+
+  - trigger: "eblla"
+    replace: "bella"
+    propagate_case: true
+    word: true
+
+  - trigger: "belo"
+    replace: "bello"
+    propagate_case: true
+    word: true
+
+  - trigger: "belol"
+    replace: "bello"
+    propagate_case: true
+    word: true
+
+  - trigger: "blelo"
+    replace: "bello"
+    propagate_case: true
+    word: true
+
+  - trigger: "bllo"
+    replace: "bello"
+    propagate_case: true
+    word: true
+
+  - trigger: "ebllo"
+    replace: "bello"
+    propagate_case: true
+    word: true
+
+  - trigger: "been"
+    replace: "bene"
+    propagate_case: true
+    word: true
+
+  - trigger: "bnee"
+    replace: "bene"
+    propagate_case: true
+    word: true
+
+  - trigger: "ebne"
+    replace: "bene"
+    propagate_case: true
+    word: true
+
+  - trigger: "beer"
+    replace: "bere"
+    propagate_case: true
+    word: true
+
+  - trigger: "bree"
+    replace: "bere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ebre"
+    replace: "bere"
+    propagate_case: true
+    word: true
+
+  - trigger: "bcca"
+    replace: "bocca"
+    propagate_case: true
+    word: true
+
+  - trigger: "bcoca"
+    replace: "bocca"
+    propagate_case: true
+    word: true
+
+  - trigger: "boca"
+    replace: "bocca"
+    propagate_case: true
+    word: true
+
+  - trigger: "bocac"
+    replace: "bocca"
+    propagate_case: true
+    word: true
+
+  - trigger: "obcca"
+    replace: "bocca"
+    propagate_case: true
+    word: true
+
+  - trigger: "brtta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "brtuta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "bruta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "brutat"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "burtta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "butta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbutta"
+    replace: "brutta"
+    propagate_case: true
+    word: true
+
+  - trigger: "brtto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "brtuto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "bruto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "brutot"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "burtto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "butto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "rbutto"
+    replace: "brutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "bona"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "bouna"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "buna"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "bunoa"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoa"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoan"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubona"
+    replace: "buona"
+    propagate_case: true
+    word: true
+
+  - trigger: "bonasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "bounasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "bunasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "bunoasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoansera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonaera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonaesra"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonasea"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonasear"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonasra"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonasrea"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonsaera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonsera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubonasera"
+    replace: "buonasera"
+    propagate_case: true
+    word: true
+
+  - trigger: "bongiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "boungiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "bungiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "bunogiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buogiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buogniorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongiono"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongionro"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongioro"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongioron"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongirno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongirono"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongoirno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buongorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buonigorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoniorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubongiorno"
+    replace: "buongiorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "bono"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "bouno"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "buno"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "bunoo"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoo"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "buoon"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "ubono"
+    replace: "buono"
+    propagate_case: true
+    word: true
+
+  - trigger: "acmbiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabmiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambaimento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiaemnto"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiaento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiameno"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiamenot"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiametno"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiameto"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiamneto"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiamnto"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambimaento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambimento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "camiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "camibamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmabiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmbiamento"
+    replace: "cambiamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "acmbiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cabmiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambaire"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiae"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambiaer"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambirae"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cambire"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "camiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "camibare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmabiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmbiare"
+    replace: "cambiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "acpire"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "caipre"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "caire"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "capie"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "capier"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "capre"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "caprie"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpaire"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "cpire"
+    replace: "capire"
+    propagate_case: true
+    word: true
+
+  - trigger: "acra"
+    replace: "cara"
+    propagate_case: true
+    word: true
+
+  - trigger: "caar"
+    replace: "cara"
+    propagate_case: true
+    word: true
+
+  - trigger: "craa"
+    replace: "cara"
+    propagate_case: true
+    word: true
+
+  - trigger: "acro"
+    replace: "caro"
+    propagate_case: true
+    word: true
+
+  - trigger: "caor"
+    replace: "caro"
+    propagate_case: true
+    word: true
+
+  - trigger: "crao"
+    replace: "caro"
+    propagate_case: true
+    word: true
+
+  - trigger: "acsa"
+    replace: "casa"
+    propagate_case: true
+    word: true
+
+  - trigger: "caas"
+    replace: "casa"
+    propagate_case: true
+    word: true
+
+  - trigger: "csaa"
+    replace: "casa"
+    propagate_case: true
+    word: true
+
+  - trigger: "acso"
+    replace: "caso"
+    propagate_case: true
+    word: true
+
+  - trigger: "caos"
+    replace: "caso"
+    propagate_case: true
+    word: true
+
+  - trigger: "csao"
+    replace: "caso"
+    propagate_case: true
+    word: true
+
+  - trigger: "acttiva"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "catitva"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cativa"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattia"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattiav"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattva"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattvia"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "ctativa"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "cttiva"
+    replace: "cattiva"
+    propagate_case: true
+    word: true
+
+  - trigger: "acttivo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "catitvo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cativo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattio"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattiov"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattvio"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cattvo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ctativo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cttivo"
+    replace: "cattivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceramente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceratmente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certaemnte"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certaente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certamene"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certamenet"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certamete"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certametne"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certamnete"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certamnte"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certmaente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "certmente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "cetamente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "cetramente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "cretamente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "crtamente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "ecrtamente"
+    replace: "certamente"
+    propagate_case: true
+    word: true
+
+  - trigger: "ceh"
+    replace: "che"
+    propagate_case: true
+    word: true
+
+  - trigger: "hce"
+    replace: "che"
+    propagate_case: true
+    word: true
+
+  - trigger: "cih"
+    replace: "chi"
+    propagate_case: true
+    word: true
+
+  - trigger: "hci"
+    replace: "chi"
+    propagate_case: true
+    word: true
+
+  - trigger: "chaimare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chamare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaamre"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiaare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamae"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamaer"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamrae"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiamre"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimaare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chimare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciamare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihamare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciamare"
+    replace: "chiamare"
+    propagate_case: true
+    word: true
+
+  - trigger: "chidere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiduere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiudee"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiudeer"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiudre"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiudree"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiuedre"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chiuere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chudere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "chuidere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "cihudere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciudere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "hciudere"
+    replace: "chiudere"
+    propagate_case: true
+    word: true
+
+  - trigger: "caio"
+    replace: "ciao"
+    propagate_case: true
+    word: true
+
+  - trigger: "cioa"
+    replace: "ciao"
+    propagate_case: true
+    word: true
+
+  - trigger: "icao"
+    replace: "ciao"
+    propagate_case: true
+    word: true
+
+  - trigger: "caiscuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cascuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciacsuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciacuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciascno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciascnuo"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciascuo"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciascuon"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciasucno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciasuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cisacuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ciscuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "icascuno"
+    replace: "ciascuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "cllaborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "clolaborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "colaborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "colalborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboarre"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborae"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboraer"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborrae"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborre"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collabrare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collabroare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaobrare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaorare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collbaorare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "collborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocllaborare"
+    replace: "collaborare"
+    propagate_case: true
+    word: true
+
+  - trigger: "cllaborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "clolaborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "colaborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "colalborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboarzione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboraione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaboraizone"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazine"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazinoe"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazioe"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazioen"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazoine"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborazone"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborzaione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaborzione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collabrazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collabroazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaobrazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collaorazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collbaorazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "collborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocllaborazione"
+    replace: "collaborazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmoe"
+    replace: "come"
+    propagate_case: true
+    word: true
+
+  - trigger: "coem"
+    replace: "come"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocme"
+    replace: "come"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmounicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmunicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnuicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuincazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuncazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunciazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniaczione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicaione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicaizone"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazine"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazinoe"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazioe"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazioen"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazoine"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunicazone"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniczaione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuniczione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "coumnicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "counicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmunicazione"
+    replace: "comunicazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmounque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "cmunque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comnuque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunqe"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunqeu"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunue"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comunuqe"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuqnue"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "comuque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "coumnque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "counque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocmunque"
+    replace: "comunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "cno"
+    replace: "con"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocn"
+    replace: "con"
+    propagate_case: true
+    word: true
+
+  - trigger: "cndizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnodizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "codizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "codnizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condiizone"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizine"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizinoe"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizioe"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizioen"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizoine"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condizone"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condziione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "condzione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "conidzione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "conizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocndizione"
+    replace: "condizione"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnooscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnoscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conocenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conocsenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conoscena"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conoscenaz"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conosceza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conoscezna"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conoscneza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conoscnza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conosecnza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conosenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "conscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "consocenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "coonscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "cooscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocnoscenza"
+    replace: "conoscenza"
+    propagate_case: true
+    word: true
+
+  - trigger: "cnotro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "cntro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "conro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "conrto"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "conto"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "contor"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotnro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "cotro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocntro"
+    replace: "contro"
+    propagate_case: true
+    word: true
+
+  - trigger: "copo"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "copro"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "coro"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corop"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cropo"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "crpo"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrpo"
+    replace: "corpo"
+    propagate_case: true
+    word: true
+
+  - trigger: "corot"
+    replace: "corto"
+    propagate_case: true
+    word: true
+
+  - trigger: "coto"
+    replace: "corto"
+    propagate_case: true
+    word: true
+
+  - trigger: "croto"
+    replace: "corto"
+    propagate_case: true
+    word: true
+
+  - trigger: "crto"
+    replace: "corto"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocrto"
+    replace: "corto"
+    propagate_case: true
+    word: true
+
+  - trigger: "coas"
+    replace: "cosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "csoa"
+    replace: "cosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "ocsa"
+    replace: "cosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "cedere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "cerdere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "crdeere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "crdere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "credee"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "credeer"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "credre"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "credree"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "creedre"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "creere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "rcedere"
+    replace: "credere"
+    propagate_case: true
+    word: true
+
+  - trigger: "core"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "coure"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "cuoe"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "cuoer"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "cure"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "curoe"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "ucore"
+    replace: "cuore"
+    propagate_case: true
+    word: true
+
+  - trigger: "adre"
+    replace: "dare"
+    propagate_case: true
+    word: true
+
+  - trigger: "daer"
+    replace: "dare"
+    propagate_case: true
+    word: true
+
+  - trigger: "drae"
+    replace: "dare"
+    propagate_case: true
+    word: true
+
+  - trigger: "advvero"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davero"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davevro"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davveo"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davveor"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davvreo"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "davvro"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvavero"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvvero"
+    replace: "davvero"
+    propagate_case: true
+    word: true
+
+  - trigger: "dceisione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcisione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "deciione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "deciisone"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisine"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisinoe"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisioe"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisioen"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisoine"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decisone"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decsiione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "decsione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "deicsione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "deisione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "edcisione"
+    replace: "decisione"
+    propagate_case: true
+    word: true
+
+  - trigger: "denro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "denrto"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "dento"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "dentor"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "detnro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "detro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "dnetro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "dntro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "edntro"
+    replace: "dentro"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcie"
+    replace: "dice"
+    propagate_case: true
+    word: true
+
+  - trigger: "diec"
+    replace: "dice"
+    propagate_case: true
+    word: true
+
+  - trigger: "idce"
+    replace: "dice"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcii"
+    replace: "dici"
+    propagate_case: true
+    word: true
+
+  - trigger: "diic"
+    replace: "dici"
+    propagate_case: true
+    word: true
+
+  - trigger: "idci"
+    replace: "dici"
+    propagate_case: true
+    word: true
+
+  - trigger: "dciamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dciiamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicaimo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "diciao"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "diciaom"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicimao"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicimo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "diiamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "diicamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "idciamo"
+    replace: "diciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcio"
+    replace: "dico"
+    propagate_case: true
+    word: true
+
+  - trigger: "dioc"
+    replace: "dico"
+    propagate_case: true
+    word: true
+
+  - trigger: "idco"
+    replace: "dico"
+    propagate_case: true
+    word: true
+
+  - trigger: "dciono"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcono"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicno"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicnoo"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicoo"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dicoon"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "diocno"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "diono"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "idcono"
+    replace: "dicono"
+    propagate_case: true
+    word: true
+
+  - trigger: "dfficile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dfificile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "diffciile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "diffcile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "difficie"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "difficiel"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "difficle"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "difficlie"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "diffiicle"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "diffiile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dificile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dififcile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "idfficile"
+    replace: "difficile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dier"
+    replace: "dire"
+    propagate_case: true
+    word: true
+
+  - trigger: "drie"
+    replace: "dire"
+    propagate_case: true
+    word: true
+
+  - trigger: "idre"
+    replace: "dire"
+    propagate_case: true
+    word: true
+
+  - trigger: "diponibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dipsonibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disonibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disopnibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispnibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispnoibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispoibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dispoinbile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponbiile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponbile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponibie"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponibiel"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponible"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponiblie"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponiible"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "disponiile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsiponibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "dsponibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "idsponibile"
+    replace: "disponibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "diet"
+    replace: "dite"
+    propagate_case: true
+    word: true
+
+  - trigger: "dtie"
+    replace: "dite"
+    propagate_case: true
+    word: true
+
+  - trigger: "idte"
+    replace: "dite"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcoumentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "dcumentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "docmentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "docmuentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "docuemntazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "docuentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documenatzione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documenazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentaione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentaizone"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazine"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazinoe"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazioe"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazioen"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazoine"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentazone"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentzaione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documentzione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documetazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documetnazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documnetazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "documntazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "doucmentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "doumentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "odcumentazione"
+    replace: "documentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "dmanda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "dmoanda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "doamnda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "doanda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domada"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domadna"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domana"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domanad"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domnada"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "domnda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "odmanda"
+    replace: "domanda"
+    propagate_case: true
+    word: true
+
+  - trigger: "dmani"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "dmoani"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "doamni"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "doani"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "domai"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "domain"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "domnai"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "domni"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "odmani"
+    replace: "domani"
+    propagate_case: true
+    word: true
+
+  - trigger: "dnna"
+    replace: "donna"
+    propagate_case: true
+    word: true
+
+  - trigger: "dnona"
+    replace: "donna"
+    propagate_case: true
+    word: true
+
+  - trigger: "dona"
+    replace: "donna"
+    propagate_case: true
+    word: true
+
+  - trigger: "donan"
+    replace: "donna"
+    propagate_case: true
+    word: true
+
+  - trigger: "odnna"
+    replace: "donna"
+    propagate_case: true
+    word: true
+
+  - trigger: "doop"
+    replace: "dopo"
+    propagate_case: true
+    word: true
+
+  - trigger: "dpoo"
+    replace: "dopo"
+    propagate_case: true
+    word: true
+
+  - trigger: "odpo"
+    replace: "dopo"
+    propagate_case: true
+    word: true
+
+  - trigger: "domire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "domrire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorimre"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dorire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dormie"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dormier"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dormre"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dormrie"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "drmire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "dromire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "odrmire"
+    replace: "dormire"
+    propagate_case: true
+    word: true
+
+  - trigger: "doev"
+    replace: "dove"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvoe"
+    replace: "dove"
+    propagate_case: true
+    word: true
+
+  - trigger: "odve"
+    replace: "dove"
+    propagate_case: true
+    word: true
+
+  - trigger: "doere"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "doevre"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovee"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "doveer"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovre"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dovree"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvere"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dvoere"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "odvere"
+    replace: "dovere"
+    propagate_case: true
+    word: true
+
+  - trigger: "dnque"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "dnuque"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "dunqe"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "dunqeu"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "dunue"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "dunuqe"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "duqnue"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "duque"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "udnque"
+    replace: "dunque"
+    propagate_case: true
+    word: true
+
+  - trigger: "drante"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "druante"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "duante"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "duarnte"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "durane"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "duranet"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "durate"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "duratne"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "durnate"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "durnte"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "udrante"
+    replace: "durante"
+    propagate_case: true
+    word: true
+
+  - trigger: "ear"
+    replace: "era"
+    propagate_case: true
+    word: true
+
+  - trigger: "rea"
+    replace: "era"
+    propagate_case: true
+    word: true
+
+  - trigger: "eano"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "earno"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "erao"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "eraon"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "ernao"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "erno"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "reano"
+    replace: "erano"
+    propagate_case: true
+    word: true
+
+  - trigger: "earvamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eavamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eraamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eraavmo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravao"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravaom"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravmao"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravmo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ervaamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ervamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "reavamo"
+    replace: "eravamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "earvate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eavate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eraate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eraavte"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravae"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravaet"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravtae"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eravte"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "ervaate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "ervate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "reavate"
+    replace: "eravate"
+    propagate_case: true
+    word: true
+
+  - trigger: "eir"
+    replace: "eri"
+    propagate_case: true
+    word: true
+
+  - trigger: "rei"
+    replace: "eri"
+    propagate_case: true
+    word: true
+
+  - trigger: "eor"
+    replace: "ero"
+    propagate_case: true
+    word: true
+
+  - trigger: "reo"
+    replace: "ero"
+    propagate_case: true
+    word: true
+
+  - trigger: "eempio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "eesmpio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esemio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esemipo"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esempo"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esempoi"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esepio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esepmio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esmepio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esmpio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "seempio"
+    replace: "esempio"
+    propagate_case: true
+    word: true
+
+  - trigger: "eperienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "epserienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "eseprienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "eserienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "espeienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "espeirenza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "espereinza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperenza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperiena"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperienaz"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperieza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperiezna"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperineza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esperinza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "espreienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esprienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "seperienza"
+    replace: "esperienza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esere"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "esesre"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "essee"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "esseer"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "essre"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "essree"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "sesere"
+    replace: "essere"
+    propagate_case: true
+    word: true
+
+  - trigger: "afcciamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faccaimo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faccamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "facciao"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "facciaom"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faccimao"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faccimo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "facicamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcaciamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcciamo"
+    replace: "facciamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "afccio"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "facco"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "faccoi"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "facico"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "facio"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcacio"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "fccio"
+    replace: "faccio"
+    propagate_case: true
+    word: true
+
+  - trigger: "afcile"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "facie"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciel"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "facle"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "faclie"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "faicle"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "faile"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcaile"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcile"
+    replace: "facile"
+    propagate_case: true
+    word: true
+
+  - trigger: "afcilita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciilta"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "facilia"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciliat"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "facilta"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faciltia"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "facliita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faclita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "faiclita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "failita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcailita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "fcilita"
+    replace: "facilita"
+    propagate_case: true
+    word: true
+
+  - trigger: "afi"
+    replace: "fai"
+    propagate_case: true
+    word: true
+
+  - trigger: "fia"
+    replace: "fai"
+    propagate_case: true
+    word: true
+
+  - trigger: "afmiglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "faiglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "faimglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famgilia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famigia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famigila"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famigla"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "famiglai"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "familgia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "familia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "fmaiglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "fmiglia"
+    replace: "famiglia"
+    propagate_case: true
+    word: true
+
+  - trigger: "afnno"
+    replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fano"
+    replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fanon"
+    replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnano"
+    replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnno"
+    replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "afre"
+    replace: "fare"
+    propagate_case: true
+    word: true
+
+  - trigger: "faer"
+    replace: "fare"
+    propagate_case: true
+    word: true
+
+  - trigger: "frae"
+    replace: "fare"
+    propagate_case: true
+    word: true
+
+  - trigger: "afte"
+    replace: "fate"
+    propagate_case: true
+    word: true
+
+  - trigger: "faet"
+    replace: "fate"
+    propagate_case: true
+    word: true
+
+  - trigger: "ftae"
+    replace: "fate"
+    propagate_case: true
+    word: true
+
+  - trigger: "aftto"
+    replace: "fatto"
+    propagate_case: true
+    word: true
+
+  - trigger: "fato"
+    replace: "fatto"
+    propagate_case: true
+    word: true
+
+  - trigger: "fatot"
+    replace: "fatto"
+    propagate_case: true
+    word: true
+
+  - trigger: "ftato"
+    replace: "fatto"
+    propagate_case: true
+    word: true
+
+  - trigger: "ftto"
+    replace: "fatto"
+    propagate_case: true
+    word: true
+
+  - trigger: "fgilia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "fglia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "figia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "figila"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "figla"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "figlai"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "filgia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "filia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifglia"
+    replace: "figlia"
+    propagate_case: true
+    word: true
+
+  - trigger: "fgilio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "fglio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "figilo"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "figio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "figlo"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "figloi"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "filgio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "filio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifglio"
+    replace: "figlio"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiinre"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "fiire"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "finie"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "finier"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "finre"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "finrie"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "fniire"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnire"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifnire"
+    replace: "finire"
+    propagate_case: true
+    word: true
+
+  - trigger: "fore"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "fores"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "fose"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "fosre"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "frose"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "frse"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "ofrse"
+    replace: "forse"
+    propagate_case: true
+    word: true
+
+  - trigger: "far"
+    replace: "fra"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfa"
+    replace: "fra"
+    propagate_case: true
+    word: true
+
+  - trigger: "fartello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fatello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fraetllo"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fratelo"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fratelol"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fratlelo"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fratllo"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "frtaello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "frtello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "rfatello"
+    replace: "fratello"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnuziona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnziona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funiona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funizona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzina"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzinoa"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioa"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioan"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzoina"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuziona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuzniona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "ufnziona"
+    replace: "funziona"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnuzionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnzionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funizonamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzinamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzinoamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioanmento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionaemnto"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionaento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionameno"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionamenot"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionametno"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionameto"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionamneto"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionamnto"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionmaento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionmento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzoinamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzonamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuzionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuznionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "ufnzionamento"
+    replace: "funzionamento"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnuzionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "fnzionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funizonare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzinare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzinoare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioanre"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzioare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionae"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionaer"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionrae"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzionre"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzoinare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "funzonare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuzionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuznionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "ufnzionare"
+    replace: "funzionare"
+    propagate_case: true
+    word: true
+
+  - trigger: "fori"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "fouri"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuoi"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "fuoir"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "furi"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "furoi"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "ufori"
+    replace: "fuori"
+    propagate_case: true
+    word: true
+
+  - trigger: "gicare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "gicoare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioacre"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "giocae"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "giocaer"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "giocrae"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "giocre"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "gocare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "goicare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "igocare"
+    replace: "giocare"
+    propagate_case: true
+    word: true
+
+  - trigger: "giono"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gionro"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioro"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioron"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "girno"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "girono"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "goirno"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gorno"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "igorno"
+    replace: "giorno"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "gioavne"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "giovae"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "giovaen"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "giovnae"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "giovne"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "givane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "givoane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "goivane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "govane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "igovane"
+    replace: "giovane"
+    propagate_case: true
+    word: true
+
+  - trigger: "gil"
+    replace: "gli"
+    propagate_case: true
+    word: true
+
+  - trigger: "lgi"
+    replace: "gli"
+    propagate_case: true
+    word: true
+
+  - trigger: "gande"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "garnde"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "grade"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "gradne"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "grane"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "graned"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "grnade"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "grnde"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgande"
+    replace: "grande"
+    propagate_case: true
+    word: true
+
+  - trigger: "garzie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "gazie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "graie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "graize"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "graze"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "grazei"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "grzaie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "grzie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgazie"
+    replace: "grazie"
+    propagate_case: true
+    word: true
+
+  - trigger: "ahi"
+    replace: "hai"
+    propagate_case: true
+    word: true
+
+  - trigger: "hia"
+    replace: "hai"
+    propagate_case: true
+    word: true
+
+  - trigger: "ahnno"
+    replace: "hanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hano"
+    replace: "hanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hanon"
+    replace: "hanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hnano"
+    replace: "hanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "hnno"
+    replace: "hanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "eiri"
+    replace: "ieri"
+    propagate_case: true
+    word: true
+
+  - trigger: "ieir"
+    replace: "ieri"
+    propagate_case: true
+    word: true
+
+  - trigger: "irei"
+    replace: "ieri"
+    propagate_case: true
+    word: true
+
+  - trigger: "imoprtante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "imortante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "imporante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "imporatnte"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importane"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importanet"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importate"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importatne"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importnate"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "importnte"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "impotante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "impotrante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "improtante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "imprtante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmortante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "iportante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "miportante"
+    replace: "importante"
+    propagate_case: true
+    word: true
+
+  - trigger: "imopssibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "imossibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "imposibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "imposisbile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossbiile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossbile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossibie"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossibiel"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossible"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossiblie"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossiible"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impossiile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impsosibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "impssibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipmossibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipossibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "mipossibile"
+    replace: "impossibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifatti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifnatti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "inaftti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "inatti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "infati"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "infatit"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "inftati"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "inftti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "nifatti"
+    replace: "infatti"
+    propagate_case: true
+    word: true
+
+  - trigger: "ifnormazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "iformazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "infomazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "infomrazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "inforamzione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "inforazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informaione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informaizone"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazine"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazinoe"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazioe"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazioen"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazoine"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informazone"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informzaione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "informzione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "infrmazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "infromazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "inofrmazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "inormazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "niformazione"
+    replace: "informazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "iinziare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iiziare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniiare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniizare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizaire"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziae"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniziaer"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizirae"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inizire"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inziare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inziiare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "niiziare"
+    replace: "iniziare"
+    propagate_case: true
+    word: true
+
+  - trigger: "inlotre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inltre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inolre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inolrte"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inolte"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inolter"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inotlre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inotre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "ioltre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "ionltre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "nioltre"
+    replace: "inoltre"
+    propagate_case: true
+    word: true
+
+  - trigger: "inieme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "iniseme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseime"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "inseme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "insiee"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "insieem"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "insime"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "insimee"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "isieme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "isnieme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "nisieme"
+    replace: "insieme"
+    propagate_case: true
+    word: true
+
+  - trigger: "alrgo"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lago"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lagro"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "laro"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "larog"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lrago"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lrgo"
+    replace: "largo"
+    propagate_case: true
+    word: true
+
+  - trigger: "alsciare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "laciare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lacsiare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lascaire"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lascare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lasciae"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lasciaer"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lascirae"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lascire"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lasiare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lasicare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lsaciare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lsciare"
+    replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - trigger: "alvorare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "laorare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "laovrare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoarre"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorae"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoraer"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorrae"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavorre"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavrare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavroare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvaorare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvorare"
+    replace: "lavorare"
+    propagate_case: true
+    word: true
+
+  - trigger: "alvoro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "laoro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "laovro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoo"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavoor"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lavroo"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvaoro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lvoro"
+    replace: "lavoro"
+    propagate_case: true
+    word: true
+
+  - trigger: "elggere"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "legegre"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "legere"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggee"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggeer"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggre"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "leggree"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "lgegere"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "lggere"
+    replace: "leggere"
+    propagate_case: true
+    word: true
+
+  - trigger: "eli"
+    replace: "lei"
+    propagate_case: true
+    word: true
+
+  - trigger: "lie"
+    replace: "lei"
+    propagate_case: true
+    word: true
+
+  - trigger: "lnotano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lntano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lonano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lonatno"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lontao"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lontaon"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lontnao"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lontno"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lotano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "lotnano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "olntano"
+    replace: "lontano"
+    propagate_case: true
+    word: true
+
+  - trigger: "loor"
+    replace: "loro"
+    propagate_case: true
+    word: true
+
+  - trigger: "lroo"
+    replace: "loro"
+    propagate_case: true
+    word: true
+
+  - trigger: "olro"
+    replace: "loro"
+    propagate_case: true
+    word: true
+
+  - trigger: "liu"
+    replace: "lui"
+    propagate_case: true
+    word: true
+
+  - trigger: "uli"
+    replace: "lui"
+    propagate_case: true
+    word: true
+
+  - trigger: "lngo"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lnugo"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lugno"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lugo"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "luno"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "lunog"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ulngo"
+    replace: "lungo"
+    propagate_case: true
+    word: true
+
+  - trigger: "amdre"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "made"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "mader"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "marde"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "mare"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdare"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdre"
+    replace: "madre"
+    propagate_case: true
+    word: true
+
+  - trigger: "ami"
+    replace: "mai"
+    propagate_case: true
+    word: true
+
+  - trigger: "amle"
+    replace: "male"
+    propagate_case: true
+    word: true
+
+  - trigger: "mael"
+    replace: "male"
+    propagate_case: true
+    word: true
+
+  - trigger: "mlae"
+    replace: "male"
+    propagate_case: true
+    word: true
+
+  - trigger: "amngiare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "magiare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "magniare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangaire"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangiae"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangiaer"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangirae"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mangire"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "maniare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "manigare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnagiare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "mngiare"
+    replace: "mangiare"
+    propagate_case: true
+    word: true
+
+  - trigger: "amno"
+    replace: "mano"
+    propagate_case: true
+    word: true
+
+  - trigger: "maon"
+    replace: "mano"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnao"
+    replace: "mano"
+    propagate_case: true
+    word: true
+
+  - trigger: "emglio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "megilo"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "megio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "meglo"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "megloi"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "melgio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "melio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mgelio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mglio"
+    replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - trigger: "emse"
+    replace: "mese"
+    propagate_case: true
+    word: true
+
+  - trigger: "mees"
+    replace: "mese"
+    propagate_case: true
+    word: true
+
+  - trigger: "msee"
+    replace: "mese"
+    propagate_case: true
+    word: true
+
+  - trigger: "emssaggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mesaggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mesasggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messaggo"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messaggoi"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messagigo"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messagio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messgagio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "messggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "msesaggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mssaggio"
+    replace: "messaggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "emttere"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "metere"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "metetre"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettee"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "metteer"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettre"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "mettree"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "mtetere"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "mttere"
+    replace: "mettere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ima"
+    replace: "mia"
+    propagate_case: true
+    word: true
+
+  - trigger: "ime"
+    replace: "mie"
+    propagate_case: true
+    word: true
+
+  - trigger: "mei"
+    replace: "mie"
+    propagate_case: true
+    word: true
+
+  - trigger: "imei"
+    replace: "miei"
+    propagate_case: true
+    word: true
+
+  - trigger: "meii"
+    replace: "miei"
+    propagate_case: true
+    word: true
+
+  - trigger: "miie"
+    replace: "miei"
+    propagate_case: true
+    word: true
+
+  - trigger: "imglioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mgilioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mglioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migiloramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioamento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioarmento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioraemnto"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioraento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliorameno"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioramenot"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliorametno"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliorameto"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioramneto"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "miglioramnto"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliormaento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliormento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migliroamento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migloiramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "migloramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "milgioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "milioramento"
+    replace: "miglioramento"
+    propagate_case: true
+    word: true
+
+  - trigger: "imnuto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "minto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "mintuo"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "minuo"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "minuot"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "miunto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "miuto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "mniuto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnuto"
+    replace: "minuto"
+    propagate_case: true
+    word: true
+
+  - trigger: "imo"
+    replace: "mio"
+    propagate_case: true
+    word: true
+
+  - trigger: "moi"
+    replace: "mio"
+    propagate_case: true
+    word: true
+
+  - trigger: "mdoo"
+    replace: "modo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mood"
+    replace: "modo"
+    propagate_case: true
+    word: true
+
+  - trigger: "omdo"
+    replace: "modo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mloto"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "mlto"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "molo"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "molot"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "motlo"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "moto"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "omlto"
+    replace: "molto"
+    propagate_case: true
+    word: true
+
+  - trigger: "mmento"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mmoento"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "moemnto"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "moento"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "momeno"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "momenot"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mometno"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mometo"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "momneto"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "momnto"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "ommento"
+    replace: "momento"
+    propagate_case: true
+    word: true
+
+  - trigger: "mndo"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mnodo"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "modno"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "mono"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "monod"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "omndo"
+    replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "encessario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "nceessario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "ncessario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necesario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necesasrio"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessaio"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessairo"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessaro"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessaroi"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessraio"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessrio"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necsesario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "necssario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "neecssario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "neessario"
+    replace: "necessario"
+    propagate_case: true
+    word: true
+
+  - trigger: "encessita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "nceessita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "ncessita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necesista"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necesita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessia"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessiat"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necessta"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necesstia"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necsesita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "necssita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "neecssita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "neessita"
+    replace: "necessita"
+    propagate_case: true
+    word: true
+
+  - trigger: "enssuno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nessno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nessnuo"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nessuo"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nessuon"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nesuno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nesusno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsesuno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nssuno"
+    replace: "nessuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "nio"
+    replace: "noi"
+    propagate_case: true
+    word: true
+
+  - trigger: "oni"
+    replace: "noi"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmoe"
+    replace: "nome"
+    propagate_case: true
+    word: true
+
+  - trigger: "noem"
+    replace: "nome"
+    propagate_case: true
+    word: true
+
+  - trigger: "onme"
+    replace: "nome"
+    propagate_case: true
+    word: true
+
+  - trigger: "nno"
+    replace: "non"
+    propagate_case: true
+    word: true
+
+  - trigger: "onn"
+    replace: "non"
+    propagate_case: true
+    word: true
+
+  - trigger: "nnoostante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nnostante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonosante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonosatnte"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostane"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostanet"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostate"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostatne"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostnate"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonostnte"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonotante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonotsante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonsotante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nonstante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "noonstante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "noostante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "onnostante"
+    replace: "nonostante"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosrta"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosta"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nostar"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "notra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "notsra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsotra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nstra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "onstra"
+    replace: "nostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosrte"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "noste"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "noster"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "notre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "notsre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsotre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "nstre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "onstre"
+    replace: "nostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosrti"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosti"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nostir"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "notri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "notsri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsotri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nstri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "onstri"
+    replace: "nostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosrto"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nosto"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nostor"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "notro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "notsro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nsotro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nstro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "onstro"
+    replace: "nostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmero"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "nmuero"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuemro"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuero"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "numeo"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "numeor"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "numreo"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "numro"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "unmero"
+    replace: "numero"
+    propagate_case: true
+    word: true
+
+  - trigger: "nouva"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nova"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuoa"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuoav"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuva"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuvoa"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "unova"
+    replace: "nuova"
+    propagate_case: true
+    word: true
+
+  - trigger: "nouvo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "novo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuoo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuoov"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuvo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuvoo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "unovo"
+    replace: "nuovo"
+    propagate_case: true
+    word: true
+
+  - trigger: "boiettivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obeittivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obettivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obietitvo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obietivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obiettio"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obiettiov"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obiettvio"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obiettvo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obitetivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "obittivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "oibettivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "oiettivo"
+    replace: "obiettivo"
+    propagate_case: true
+    word: true
+
+  - trigger: "cochio"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "occho"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "occhoi"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "occiho"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "occio"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "ochcio"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "ochio"
+    replace: "occhio"
+    propagate_case: true
+    word: true
+
+  - trigger: "gogi"
+    replace: "oggi"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogi"
+    replace: "oggi"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogig"
+    replace: "oggi"
+    propagate_case: true
+    word: true
+
+  - trigger: "gonuno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ognno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ognnuo"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ognuo"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ognuon"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogunno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oguno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "onguno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "onuno"
+    replace: "ognuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oar"
+    replace: "ora"
+    propagate_case: true
+    word: true
+
+  - trigger: "roa"
+    replace: "ora"
+    propagate_case: true
+    word: true
+
+  - trigger: "oganizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogranizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "oragnizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "oranizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgainzzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgaizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizazre"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzae"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzaer"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzrae"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzre"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzizare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnaizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "roganizzare"
+    replace: "organizzare"
+    propagate_case: true
+    word: true
+
+  - trigger: "oganizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "ogranizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "oragnizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "oranizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgainzzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgaizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizazzione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzaione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzaizone"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazine"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazinoe"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazioe"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazioen"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazoine"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzazone"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzzaione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organizzzione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzizazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "organzzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnaizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "orgnizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "roganizzazione"
+    replace: "organizzazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "apdre"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "pade"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "pader"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "parde"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "pare"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdare"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "pdre"
+    replace: "padre"
+    propagate_case: true
+    word: true
+
+  - trigger: "apese"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "paee"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "paees"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "pase"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "pasee"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "pease"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "pese"
+    replace: "paese"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprlare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "palare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "palrare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "paralre"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "parare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlae"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlaer"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlrae"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "parlre"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pralare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "prlare"
+    replace: "parlare"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprola"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "paola"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "paorla"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "parla"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "parloa"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "paroa"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "paroal"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "praola"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "prola"
+    replace: "parola"
+    propagate_case: true
+    word: true
+
+  - trigger: "aprte"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "paret"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "pate"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "patre"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "prate"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "prte"
+    replace: "parte"
+    propagate_case: true
+    word: true
+
+  - trigger: "epggio"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "peggo"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "peggoi"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "pegigo"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "pegio"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "pgegio"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "pggio"
+    replace: "peggio"
+    propagate_case: true
+    word: true
+
+  - trigger: "epnsare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "penare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "penasre"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pensae"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pensaer"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pensrae"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pensre"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pesare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pesnare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pnesare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pnsare"
+    replace: "pensare"
+    propagate_case: true
+    word: true
+
+  - trigger: "epr"
+    replace: "per"
+    propagate_case: true
+    word: true
+
+  - trigger: "pre"
+    replace: "per"
+    propagate_case: true
+    word: true
+
+  - trigger: "ipccolo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pccolo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pcicolo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "picclo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "piccloo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "piccoo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "piccool"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "picoclo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "picolo"
+    replace: "piccolo"
+    propagate_case: true
+    word: true
+
+  - trigger: "opco"
+    replace: "poco"
+    propagate_case: true
+    word: true
+
+  - trigger: "pcoo"
+    replace: "poco"
+    propagate_case: true
+    word: true
+
+  - trigger: "pooc"
+    replace: "poco"
+    propagate_case: true
+    word: true
+
+  - trigger: "opi"
+    replace: "poi"
+    propagate_case: true
+    word: true
+
+  - trigger: "pio"
+    replace: "poi"
+    propagate_case: true
+    word: true
+
+  - trigger: "oprtare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "porare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "poratre"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "portae"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "portaer"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "portrae"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "portre"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "potare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "potrare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "protare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "prtare"
+    replace: "portare"
+    propagate_case: true
+    word: true
+
+  - trigger: "opssibile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "posibile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "posisbile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possbiile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possbile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possibie"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possibiel"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possible"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possiblie"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possiible"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "possiile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "psosibile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "pssibile"
+    replace: "possibile"
+    propagate_case: true
+    word: true
+
+  - trigger: "optere"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "poere"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "poetre"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "potee"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "poteer"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "potre"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "potree"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptere"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ptoere"
+    replace: "potere"
+    propagate_case: true
+    word: true
+
+  - trigger: "pego"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "pergo"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "preo"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "preog"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "prgeo"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "prgo"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpego"
+    replace: "prego"
+    propagate_case: true
+    word: true
+
+  - trigger: "pendere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "perndere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "predere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prednere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendee"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendeer"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendre"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prendree"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenedre"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prenere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prndere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "prnedere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpendere"
+    replace: "prendere"
+    propagate_case: true
+    word: true
+
+  - trigger: "persentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "pesentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "preentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "preesntazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presenatzione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presenazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentaione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentaizone"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazine"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazinoe"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazioe"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazioen"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazoine"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentazone"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentzaione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presentzione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presetazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presetnazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presnetazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "presntazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "prseentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "prsentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpesentazione"
+    replace: "presentazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "pima"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "pirma"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "pria"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "priam"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "prma"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmia"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpima"
+    replace: "prima"
+    propagate_case: true
+    word: true
+
+  - trigger: "pimo"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pirmo"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prio"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "priom"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmio"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prmo"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpimo"
+    replace: "primo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pobabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "porbabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "prbabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "prboabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "proabbilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "proabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilemnte"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmene"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmenet"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmete"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmetne"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmnete"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabilmnte"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabimente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probabimlente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probablimente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probablmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probaiblmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probailmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probbailmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "probbilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpobabilmente"
+    replace: "probabilmente"
+    propagate_case: true
+    word: true
+
+  - trigger: "poblema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "porblema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "prblema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "prbolema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "probelma"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "probema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "problea"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "probleam"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "problma"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "problmea"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "prolbema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "prolema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoblema"
+    replace: "problema"
+    propagate_case: true
+    word: true
+
+  - trigger: "poblemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "porblemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "prblemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "prbolemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "probelmi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "probemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "problei"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "probleim"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "problmei"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "problmi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "prolbemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "prolemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoblemi"
+    replace: "problemi"
+    propagate_case: true
+    word: true
+
+  - trigger: "pocesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "porcesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prcesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "prcoesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proceso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "procesos"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "procseso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "procsso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proecsso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "proesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpocesso"
+    replace: "processo"
+    propagate_case: true
+    word: true
+
+  - trigger: "pogetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "porgetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "prgetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "prgoetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "proegtto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "proetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "progeto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "progetot"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "progteto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "progtto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpogetto"
+    replace: "progetto"
+    propagate_case: true
+    word: true
+
+  - trigger: "poprio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "porprio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "propio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "propiro"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "propro"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "proproi"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "prorio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "prorpio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "prporio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "prprio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpoprio"
+    replace: "proprio"
+    propagate_case: true
+    word: true
+
+  - trigger: "porvare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "povare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "proare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "proavre"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "provae"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "provaer"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "provrae"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "provre"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "prvare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "prvoare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "rpovare"
+    replace: "provare"
+    propagate_case: true
+    word: true
+
+  - trigger: "pnto"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "pnuto"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "puno"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "punot"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "putno"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "puto"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "upnto"
+    replace: "punto"
+    propagate_case: true
+    word: true
+
+  - trigger: "qau"
+    replace: "qua"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqa"
+    replace: "qua"
+    propagate_case: true
+    word: true
+
+  - trigger: "qalcosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qaulcosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quaclosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quacosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcoa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcoas"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcsa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcsoa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualocsa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulacosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulcosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqalcosa"
+    replace: "qualcosa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qalcuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qaulcuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "quacluno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "quacuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcnuo"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcuo"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualcuon"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualucno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qualuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulacuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulcuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqalcuno"
+    replace: "qualcuno"
+    propagate_case: true
+    word: true
+
+  - trigger: "qale"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "qaule"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "quae"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "quael"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulae"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "qule"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqale"
+    replace: "quale"
+    propagate_case: true
+    word: true
+
+  - trigger: "qando"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "qaundo"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "quadno"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "quado"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "quano"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "quanod"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "qunado"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "qundo"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqando"
+    replace: "quando"
+    propagate_case: true
+    word: true
+
+  - trigger: "qanto"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "qaunto"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "quanot"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "quatno"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "quato"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "qunato"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "qunto"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqanto"
+    replace: "quanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "qasi"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qausi"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quai"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quais"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusai"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusi"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqasi"
+    replace: "quasi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qella"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeulla"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "quela"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "quelal"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulela"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulla"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqella"
+    replace: "quella"
+    propagate_case: true
+    word: true
+
+  - trigger: "qelle"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeulle"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "quele"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "quelel"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulele"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulle"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqelle"
+    replace: "quelle"
+    propagate_case: true
+    word: true
+
+  - trigger: "qelli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeulli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "queli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "quelil"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "quleli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqelli"
+    replace: "quelli"
+    propagate_case: true
+    word: true
+
+  - trigger: "qello"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeullo"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "quelo"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "quelol"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "qulelo"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "qullo"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqello"
+    replace: "quello"
+    propagate_case: true
+    word: true
+
+  - trigger: "qesta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeusta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quesa"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quesat"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "queta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quetsa"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "quseta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqesta"
+    replace: "questa"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeste"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeuste"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "quese"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "queset"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "quete"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "quetse"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusete"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "quste"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqeste"
+    replace: "queste"
+    propagate_case: true
+    word: true
+
+  - trigger: "qesti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeusti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quesi"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quesit"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "queti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quetsi"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quseti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqesti"
+    replace: "questi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qesto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "qeusto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "queso"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "quesot"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "queto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "quetso"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "quseto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "qusto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqesto"
+    replace: "questo"
+    propagate_case: true
+    word: true
+
+  - trigger: "qiu"
+    replace: "qui"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqi"
+    replace: "qui"
+    propagate_case: true
+    word: true
+
+  - trigger: "qindi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qiundi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quidi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quidni"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quini"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "quinid"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qundi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "qunidi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "uqindi"
+    replace: "quindi"
+    propagate_case: true
+    word: true
+
+  - trigger: "argazzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "raagzzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "raazzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ragazo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ragazoz"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ragzazo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ragzzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgaazzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rgazzo"
+    replace: "ragazzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "erstare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "resare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "resatre"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "restae"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "restaer"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "restrae"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "restre"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "retare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "retsare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsetare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "rstare"
+    replace: "restare"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsposta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "riposta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "ripsosta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "risopsta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "risosta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "risposa"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "risposat"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispota"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispotsa"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispsota"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rispsta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiposta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsposta"
+    replace: "risposta"
+    propagate_case: true
+    word: true
+
+  - trigger: "irsultato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risltato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "rislutato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risulato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risulatto"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risultao"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risultaot"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risulttao"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risultto"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risutato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "risutlato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "riultato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "riusltato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsiultato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "rsultato"
+    replace: "risultato"
+    propagate_case: true
+    word: true
+
+  - trigger: "aspere"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "saepre"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "saere"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapee"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapeer"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapre"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "sapree"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "spaere"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "spere"
+    replace: "sapere"
+    propagate_case: true
+    word: true
+
+  - trigger: "csrivere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scirvere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scivere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrievre"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivee"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scriveer"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivre"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrivree"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrvere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "scrviere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "srcivere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "srivere"
+    replace: "scrivere"
+    propagate_case: true
+    word: true
+
+  - trigger: "csuola"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "scola"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "scoula"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "scula"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "sculoa"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "scuoa"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "scuoal"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "sucola"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "suola"
+    replace: "scuola"
+    propagate_case: true
+    word: true
+
+  - trigger: "csusa"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "scsa"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "scsua"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "scua"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "scuas"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "sucsa"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "susa"
+    replace: "scusa"
+    propagate_case: true
+    word: true
+
+  - trigger: "esbbene"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sbbene"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sbebene"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebbee"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebbeen"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebbne"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebbnee"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebebne"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "sebene"
+    replace: "sebbene"
+    propagate_case: true
+    word: true
+
+  - trigger: "esconda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "sceonda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "sconda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "secnda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "secnoda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "secoda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "secodna"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "secona"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "seconad"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "seocnda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "seonda"
+    replace: "seconda"
+    propagate_case: true
+    word: true
+
+  - trigger: "escondo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sceondo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "scondo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "secndo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "secnodo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "secodno"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "secodo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "secono"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "seconod"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "seocndo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "seondo"
+    replace: "secondo"
+    propagate_case: true
+    word: true
+
+  - trigger: "esi"
+    replace: "sei"
+    propagate_case: true
+    word: true
+
+  - trigger: "sie"
+    replace: "sei"
+    propagate_case: true
+    word: true
+
+  - trigger: "esmpre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "sempe"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "semper"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "semre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "semrpe"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "sepmre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "sepre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "smepre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "smpre"
+    replace: "sempre"
+    propagate_case: true
+    word: true
+
+  - trigger: "esntire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "senire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "senitre"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentie"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentier"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentre"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "sentrie"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "setire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "setnire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "snetire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "sntire"
+    replace: "sentire"
+    propagate_case: true
+    word: true
+
+  - trigger: "esnza"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "sena"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "senaz"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "seza"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "sezna"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "sneza"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "snza"
+    replace: "senza"
+    propagate_case: true
+    word: true
+
+  - trigger: "esrvizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "serivzio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "serizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "serviio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "serviizo"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "servizo"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "servizoi"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "servziio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "servzio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "sevizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "sevrizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "srevizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "srvizio"
+    replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - trigger: "esttimana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "setimana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "setitmana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settiamna"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settiana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settimaa"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settimaan"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settimna"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settimnaa"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settmana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "settmiana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "stetimana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "sttimana"
+    replace: "settimana"
+    propagate_case: true
+    word: true
+
+  - trigger: "isamo"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "saimo"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "samo"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "siao"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "siaom"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "simao"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "simo"
+    replace: "siamo"
+    propagate_case: true
+    word: true
+
+  - trigger: "iscuramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sciuramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "scuramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicruamente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuamente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuarmente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuraemnte"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuraente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuramene"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuramenet"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuramete"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicurametne"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuramnete"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuramnte"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicurmaente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicurmente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "siucramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "siuramente"
+    replace: "sicuramente"
+    propagate_case: true
+    word: true
+
+  - trigger: "iscuro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "sciuro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "scuro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicruo"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuo"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "sicuor"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "siucro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "siuro"
+    replace: "sicuro"
+    propagate_case: true
+    word: true
+
+  - trigger: "isete"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "seite"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "sete"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "siee"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "sieet"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "site"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "sitee"
+    replace: "siete"
+    propagate_case: true
+    word: true
+
+  - trigger: "isstema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sisema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sisetma"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sistea"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sisteam"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sistma"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sistmea"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sitema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sitsema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "ssitema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "sstema"
+    replace: "sistema"
+    propagate_case: true
+    word: true
+
+  - trigger: "istuazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "sitauzione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "sitazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situaione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situaizone"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazine"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazinoe"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazioe"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazioen"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazoine"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situazone"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situzaione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "situzione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "siuazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "siutazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "stiuazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "stuazione"
+    replace: "situazione"
+    propagate_case: true
+    word: true
+
+  - trigger: "osluzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "slouzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "sluzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluizone"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzine"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzinoe"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzioe"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzioen"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzoine"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzone"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "solzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "solzuione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "soulzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "souzione"
+    replace: "soluzione"
+    propagate_case: true
+    word: true
+
+  - trigger: "osluzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "slouzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "sluzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluizoni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzini"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzinoi"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzioi"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzioin"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzoini"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soluzoni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "solzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "solzuioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "soulzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "souzioni"
+    replace: "soluzioni"
+    propagate_case: true
+    word: true
+
+  - trigger: "osno"
+    replace: "sono"
+    propagate_case: true
+    word: true
+
+  - trigger: "snoo"
+    replace: "sono"
+    propagate_case: true
+    word: true
+
+  - trigger: "soon"
+    replace: "sono"
+    propagate_case: true
+    word: true
+
+  - trigger: "ospra"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "sopa"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "sopar"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "sora"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "sorpa"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "spora"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "spra"
+    replace: "sopra"
+    propagate_case: true
+    word: true
+
+  - trigger: "osrella"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "soella"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "soerlla"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "sorela"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "sorelal"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "sorlela"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "sorlla"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "srella"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "sroella"
+    replace: "sorella"
+    propagate_case: true
+    word: true
+
+  - trigger: "ostto"
+    replace: "sotto"
+    propagate_case: true
+    word: true
+
+  - trigger: "soto"
+    replace: "sotto"
+    propagate_case: true
+    word: true
+
+  - trigger: "sotot"
+    replace: "sotto"
+    propagate_case: true
+    word: true
+
+  - trigger: "stoto"
+    replace: "sotto"
+    propagate_case: true
+    word: true
+
+  - trigger: "stto"
+    replace: "sotto"
+    propagate_case: true
+    word: true
+
+  - trigger: "sare"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "satre"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "stae"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "staer"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "strae"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "stre"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsare"
+    replace: "stare"
+    propagate_case: true
+    word: true
+
+  - trigger: "soria"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "sotria"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "stoia"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "stoira"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "stora"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "storai"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "stria"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "stroia"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsoria"
+    replace: "storia"
+    propagate_case: true
+    word: true
+
+  - trigger: "sretto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "srtetto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "stertto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "stetto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "streto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "stretot"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "strteto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "strtto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsretto"
+    replace: "stretto"
+    propagate_case: true
+    word: true
+
+  - trigger: "sau"
+    replace: "sua"
+    propagate_case: true
+    word: true
+
+  - trigger: "usa"
+    replace: "sua"
+    propagate_case: true
+    word: true
+
+  - trigger: "sbito"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "sbuito"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "subio"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "subiot"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "subtio"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "subto"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "suibto"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "suito"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "usbito"
+    replace: "subito"
+    propagate_case: true
+    word: true
+
+  - trigger: "seu"
+    replace: "sue"
+    propagate_case: true
+    word: true
+
+  - trigger: "use"
+    replace: "sue"
+    propagate_case: true
+    word: true
+
+  - trigger: "sou"
+    replace: "suo"
+    propagate_case: true
+    word: true
+
+  - trigger: "uso"
+    replace: "suo"
+    propagate_case: true
+    word: true
+
+  - trigger: "soui"
+    replace: "suoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "suio"
+    replace: "suoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "usoi"
+    replace: "suoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "siluppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sivluppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svilppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svilpupo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svilupo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svilupop"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sviulppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "sviuppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svliuppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "svluppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsiluppo"
+    replace: "sviluppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "atnto"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tano"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tanot"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tatno"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tato"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tnato"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tnto"
+    replace: "tanto"
+    propagate_case: true
+    word: true
+
+  - trigger: "etmpo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "temo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "temop"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tepmo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tepo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tmepo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tmpo"
+    replace: "tempo"
+    propagate_case: true
+    word: true
+
+  - trigger: "etnere"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "teenre"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "teere"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "tenee"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "teneer"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "tenre"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "tenree"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "tneere"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "tnere"
+    replace: "tenere"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrza"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "tera"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "teraz"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "teza"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "tezra"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "treza"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "trza"
+    replace: "terza"
+    propagate_case: true
+    word: true
+
+  - trigger: "etrzo"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tero"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "teroz"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tezo"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tezro"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trezo"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trzo"
+    replace: "terzo"
+    propagate_case: true
+    word: true
+
+  - trigger: "etsta"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "tesa"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "tesat"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "teta"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "tetsa"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "tseta"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "tsta"
+    replace: "testa"
+    propagate_case: true
+    word: true
+
+  - trigger: "itpo"
+    replace: "tipo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tiop"
+    replace: "tipo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tpio"
+    replace: "tipo"
+    propagate_case: true
+    word: true
+
+  - trigger: "otrnare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tonrare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "toranre"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "torare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornae"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornaer"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornrae"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tornre"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trnare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tronare"
+    replace: "tornare"
+    propagate_case: true
+    word: true
+
+  - trigger: "rta"
+    replace: "tra"
+    propagate_case: true
+    word: true
+
+  - trigger: "tar"
+    replace: "tra"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtoppo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "toppo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "torppo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tropo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "tropop"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trpopo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "trppo"
+    replace: "troppo"
+    propagate_case: true
+    word: true
+
+  - trigger: "rtovare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "torvare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tovare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "troare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "troavre"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovae"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovaer"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovrae"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trovre"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trvare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "trvoare"
+    replace: "trovare"
+    propagate_case: true
+    word: true
+
+  - trigger: "tau"
+    replace: "tua"
+    propagate_case: true
+    word: true
+
+  - trigger: "uta"
+    replace: "tua"
+    propagate_case: true
+    word: true
+
+  - trigger: "teu"
+    replace: "tue"
+    propagate_case: true
+    word: true
+
+  - trigger: "ute"
+    replace: "tue"
+    propagate_case: true
+    word: true
+
+  - trigger: "tou"
+    replace: "tuo"
+    propagate_case: true
+    word: true
+
+  - trigger: "uto"
+    replace: "tuo"
+    propagate_case: true
+    word: true
+
+  - trigger: "toui"
+    replace: "tuoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuio"
+    replace: "tuoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "utoi"
+    replace: "tuoi"
+    propagate_case: true
+    word: true
+
+  - trigger: "tttavia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "ttutavia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tutatvia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tutavia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttaia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttaiva"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttava"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttavai"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttvaia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuttvia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "utttavia"
+    replace: "tuttavia"
+    propagate_case: true
+    word: true
+
+  - trigger: "ttto"
+    replace: "tutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "ttuto"
+    replace: "tutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tuto"
+    replace: "tutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "tutot"
+    replace: "tutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "uttto"
+    replace: "tutto"
+    propagate_case: true
+    word: true
+
+  - trigger: "lutima"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ulima"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ulitma"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultia"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultiam"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultma"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultmia"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "utima"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "utlima"
+    replace: "ultima"
+    propagate_case: true
+    word: true
+
+  - trigger: "lutimo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ulimo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ulitmo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultio"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultiom"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultmio"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "ultmo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "utimo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "utlimo"
+    replace: "ultimo"
+    propagate_case: true
+    word: true
+
+  - trigger: "nua"
+    replace: "una"
+    propagate_case: true
+    word: true
+
+  - trigger: "uan"
+    replace: "una"
+    propagate_case: true
+    word: true
+
+  - trigger: "nuo"
+    replace: "uno"
+    propagate_case: true
+    word: true
+
+  - trigger: "uon"
+    replace: "uno"
+    propagate_case: true
+    word: true
+
+  - trigger: "oumo"
+    replace: "uomo"
+    propagate_case: true
+    word: true
+
+  - trigger: "umoo"
+    replace: "uomo"
+    propagate_case: true
+    word: true
+
+  - trigger: "uoom"
+    replace: "uomo"
+    propagate_case: true
+    word: true
+
+  - trigger: "suare"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "uare"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "uasre"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "usae"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "usaer"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "usrae"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "usre"
+    replace: "usare"
+    propagate_case: true
+    word: true
+
+  - trigger: "avdo"
+    replace: "vado"
+    propagate_case: true
+    word: true
+
+  - trigger: "vaod"
+    replace: "vado"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdao"
+    replace: "vado"
+    propagate_case: true
+    word: true
+
+  - trigger: "avi"
+    replace: "vai"
+    propagate_case: true
+    word: true
+
+  - trigger: "via"
+    replace: "vai"
+    propagate_case: true
+    word: true
+
+  - trigger: "avnno"
+    replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vano"
+    replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vanon"
+    replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vnano"
+    replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "vnno"
+    replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - trigger: "evcchia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vcchia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vcechia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "veccha"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecchai"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "veccia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecciha"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vechcia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "vechia"
+    replace: "vecchia"
+    propagate_case: true
+    word: true
+
+  - trigger: "evcchio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vcchio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vcechio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "veccho"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecchoi"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vecciho"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "veccio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vechcio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "vechio"
+    replace: "vecchio"
+    propagate_case: true
+    word: true
+
+  - trigger: "evdere"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdeere"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vdere"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedee"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedeer"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedre"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vedree"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "veedre"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "veere"
+    replace: "vedere"
+    propagate_case: true
+    word: true
+
+  - trigger: "evloce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "velce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "velcoe"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloe"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloec"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "veoce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "veolce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "vleoce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "vloce"
+    replace: "veloce"
+    propagate_case: true
+    word: true
+
+  - trigger: "evlocemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velcemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velcoemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloceemnte"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloceente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemene"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemenet"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemete"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemetne"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemnete"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocemnte"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocmeente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "velocmente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloecmente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veloemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veocemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "veolcemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "vleocemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "vlocemente"
+    replace: "velocemente"
+    propagate_case: true
+    word: true
+
+  - trigger: "evnire"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "veinre"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "veire"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "venie"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "venier"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "venre"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "venrie"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "vneire"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "vnire"
+    replace: "venire"
+    propagate_case: true
+    word: true
+
+  - trigger: "evrso"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "vero"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "veros"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "veso"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "vesro"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "vreso"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "vrso"
+    replace: "verso"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivcino"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vciino"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vcino"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vicio"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vicion"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vicnio"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "vicno"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "viicno"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "viino"
+    replace: "vicino"
+    propagate_case: true
+    word: true
+
+  - trigger: "ivta"
+    replace: "vita"
+    propagate_case: true
+    word: true
+
+  - trigger: "viat"
+    replace: "vita"
+    propagate_case: true
+    word: true
+
+  - trigger: "vtia"
+    replace: "vita"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovi"
+    replace: "voi"
+    propagate_case: true
+    word: true
+
+  - trigger: "vio"
+    replace: "voi"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovlere"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vlere"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "vloere"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "voelre"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "voere"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "volee"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "voleer"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "volre"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "volree"
+    replace: "volere"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovstra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosrta"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosta"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vostar"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "votra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "votsra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsotra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "vstra"
+    replace: "vostra"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovstre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosrte"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "voste"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "voster"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "votre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "votsre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsotre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "vstre"
+    replace: "vostre"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovstri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosrti"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosti"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vostir"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "votri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "votsri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsotri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "vstri"
+    replace: "vostri"
+    propagate_case: true
+    word: true
+
+  - trigger: "ovstro"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosro"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosrto"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vosto"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vostor"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "votro"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "votsro"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vsotro"
+    replace: "vostro"
+    propagate_case: true
+    word: true
+
+  - trigger: "vstro"
+    replace: "vostro"
+    propagate_case: true
+    word: true

--- a/packages/refuos-italiano/0.1.0/package.yml
+++ b/packages/refuos-italiano/0.1.0/package.yml
@@ -32,6 +32,13 @@ matches:
     word: true
 
   - triggers:
+    - "acor"
+    - "arco"
+    replace: "acro"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "adeso"
     - "adesos"
     - "adseso"
@@ -70,6 +77,12 @@ matches:
     word: true
 
   - triggers:
+    - "aih"
+    replace: "ahi"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "aitare"
     - "aituare"
     - "aiuare"
@@ -102,8 +115,13 @@ matches:
   - triggers:
     - "alot"
     - "atlo"
-    - "lato"
     replace: "alto"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "aim"
+    replace: "ami"
     propagate_case: true
     word: true
 
@@ -120,9 +138,16 @@ matches:
     word: true
 
   - triggers:
+    - "acne"
+    - "anec"
+    - "nace"
+    replace: "ance"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "ache"
     - "acnhe"
-    - "ance"
     - "anceh"
     - "anhce"
     - "anhe"
@@ -189,10 +214,15 @@ matches:
     word: true
 
   - triggers:
-    - "ano"
     - "anon"
-    - "nano"
     replace: "anno"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "aon"
+    - "nao"
+    replace: "ano"
     propagate_case: true
     word: true
 
@@ -350,6 +380,12 @@ matches:
     word: true
 
   - triggers:
+    - "aiv"
+    replace: "avi"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "abmbino"
     - "babino"
     - "babmino"
@@ -366,8 +402,15 @@ matches:
     word: true
 
   - triggers:
+    - "absa"
+    - "baas"
+    - "bsaa"
+    replace: "basa"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "abssa"
-    - "basa"
     - "basas"
     - "bsasa"
     - "bssa"
@@ -376,7 +419,14 @@ matches:
     word: true
 
   - triggers:
-    - "bela"
+    - "beal"
+    - "blea"
+    - "ebla"
+    replace: "bela"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "belal"
     - "blela"
     - "blla"
@@ -422,9 +472,48 @@ matches:
     word: true
 
   - triggers:
+    - "bnoa"
+    - "boan"
+    - "obna"
+    replace: "bona"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "bnoo"
+    - "boon"
+    - "obno"
+    replace: "bono"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "brta"
+    - "brtua"
+    - "brua"
+    - "bruat"
+    - "burta"
+    - "buta"
+    - "rbuta"
+    replace: "bruta"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "brto"
+    - "brtuo"
+    - "bruo"
+    - "bruot"
+    - "burto"
+    - "buto"
+    - "rbuto"
+    replace: "bruto"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "brtta"
     - "brtuta"
-    - "bruta"
     - "brutat"
     - "burtta"
     - "butta"
@@ -436,7 +525,6 @@ matches:
   - triggers:
     - "brtto"
     - "brtuto"
-    - "bruto"
     - "brutot"
     - "burtto"
     - "butto"
@@ -446,7 +534,6 @@ matches:
     word: true
 
   - triggers:
-    - "bona"
     - "bouna"
     - "buna"
     - "bunoa"
@@ -500,7 +587,6 @@ matches:
     word: true
 
   - triggers:
-    - "bono"
     - "bouno"
     - "buno"
     - "bunoo"
@@ -508,6 +594,13 @@ matches:
     - "buoon"
     - "ubono"
     replace: "buono"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "acio"
+    - "caoi"
+    replace: "caio"
     propagate_case: true
     word: true
 
@@ -576,7 +669,6 @@ matches:
     word: true
 
   - triggers:
-    - "acro"
     - "caor"
     - "crao"
     replace: "caro"
@@ -700,7 +792,6 @@ matches:
     word: true
 
   - triggers:
-    - "caio"
     - "cioa"
     - "icao"
     replace: "ciao"
@@ -895,9 +986,16 @@ matches:
     word: true
 
   - triggers:
+    - "coor"
+    - "croo"
+    - "ocro"
+    replace: "coro"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "copo"
     - "copro"
-    - "coro"
     - "corop"
     - "cropo"
     - "crpo"
@@ -1181,9 +1279,16 @@ matches:
     word: true
 
   - triggers:
+    - "dnoa"
+    - "doan"
+    - "odna"
+    replace: "dona"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "dnna"
     - "dnona"
-    - "dona"
     - "donan"
     - "odnna"
     replace: "donna"
@@ -1468,11 +1573,18 @@ matches:
 
   - triggers:
     - "afnno"
-    - "fano"
     - "fanon"
     - "fnano"
     - "fnno"
     replace: "fanno"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "afno"
+    - "faon"
+    - "fnao"
+    replace: "fano"
     propagate_case: true
     word: true
 
@@ -1485,6 +1597,22 @@ matches:
     word: true
 
   - triggers:
+    - "afri"
+    - "fair"
+    - "frai"
+    replace: "fari"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "afro"
+    - "faor"
+    - "frao"
+    replace: "faro"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "afte"
     - "faet"
     - "ftae"
@@ -1493,8 +1621,15 @@ matches:
     word: true
 
   - triggers:
+    - "afto"
+    - "faot"
+    - "ftao"
+    replace: "fato"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "aftto"
-    - "fato"
     - "fatot"
     - "ftato"
     - "ftto"
@@ -1545,7 +1680,22 @@ matches:
     word: true
 
   - triggers:
-    - "fore"
+    - "foer"
+    - "froe"
+    - "ofre"
+    replace: "fore"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "foir"
+    - "froi"
+    - "ofri"
+    replace: "fori"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "fores"
     - "fose"
     - "fosre"
@@ -1648,7 +1798,6 @@ matches:
     word: true
 
   - triggers:
-    - "fori"
     - "fouri"
     - "fuoi"
     - "fuoir"
@@ -1741,7 +1890,6 @@ matches:
     word: true
 
   - triggers:
-    - "ahi"
     - "hia"
     replace: "hai"
     propagate_case: true
@@ -1900,8 +2048,15 @@ matches:
     word: true
 
   - triggers:
+    - "algo"
+    - "laog"
+    - "lgao"
+    replace: "lago"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "alrgo"
-    - "lago"
     - "lagro"
     - "laro"
     - "larog"
@@ -1926,6 +2081,13 @@ matches:
     - "lsaciare"
     - "lsciare"
     replace: "lasciare"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "laot"
+    - "ltao"
+    replace: "lato"
     propagate_case: true
     word: true
 
@@ -2030,16 +2192,9 @@ matches:
     - "made"
     - "mader"
     - "marde"
-    - "mare"
     - "mdare"
     - "mdre"
     replace: "madre"
-    propagate_case: true
-    word: true
-
-  - triggers:
-    - "ami"
-    replace: "mai"
     propagate_case: true
     word: true
 
@@ -2078,6 +2233,14 @@ matches:
     word: true
 
   - triggers:
+    - "amre"
+    - "maer"
+    - "mrae"
+    replace: "mare"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "emglio"
     - "megilo"
     - "megio"
@@ -2088,6 +2251,14 @@ matches:
     - "mgelio"
     - "mglio"
     replace: "meglio"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "emre"
+    - "meer"
+    - "mree"
+    replace: "mere"
     propagate_case: true
     word: true
 
@@ -2213,7 +2384,6 @@ matches:
     - "molo"
     - "molot"
     - "motlo"
-    - "moto"
     - "omlto"
     replace: "molto"
     propagate_case: true
@@ -2239,10 +2409,32 @@ matches:
     - "mndo"
     - "mnodo"
     - "modno"
-    - "mono"
     - "monod"
     - "omndo"
     replace: "mondo"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "mnoo"
+    - "moon"
+    - "omno"
+    replace: "mono"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "moot"
+    - "mtoo"
+    - "omto"
+    replace: "moto"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "naon"
+    - "nnao"
+    replace: "nano"
     propagate_case: true
     word: true
 
@@ -2550,7 +2742,6 @@ matches:
     - "pade"
     - "pader"
     - "parde"
-    - "pare"
     - "pdare"
     - "pdre"
     replace: "padre"
@@ -2566,6 +2757,14 @@ matches:
     - "pease"
     - "pese"
     replace: "paese"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "apre"
+    - "paer"
+    - "prae"
+    replace: "pare"
     propagate_case: true
     word: true
 
@@ -2646,6 +2845,14 @@ matches:
     word: true
 
   - triggers:
+    - "epro"
+    - "peor"
+    - "preo"
+    replace: "pero"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "ipccolo"
     - "pccolo"
     - "pcicolo"
@@ -2660,6 +2867,12 @@ matches:
     word: true
 
   - triggers:
+    - "ipo"
+    replace: "pio"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "opco"
     - "pcoo"
     - "pooc"
@@ -2669,7 +2882,6 @@ matches:
 
   - triggers:
     - "opi"
-    - "pio"
     replace: "poi"
     propagate_case: true
     word: true
@@ -2725,7 +2937,6 @@ matches:
   - triggers:
     - "pego"
     - "pergo"
-    - "preo"
     - "preog"
     - "prgeo"
     - "prgo"
@@ -3246,6 +3457,14 @@ matches:
     word: true
 
   - triggers:
+    - "asra"
+    - "saar"
+    - "sraa"
+    replace: "sara"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "csrivere"
     - "scirvere"
     - "scivere"
@@ -3357,6 +3576,14 @@ matches:
     word: true
 
   - triggers:
+    - "esna"
+    - "sean"
+    - "snea"
+    replace: "sena"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "esntire"
     - "senire"
     - "senitre"
@@ -3374,7 +3601,6 @@ matches:
 
   - triggers:
     - "esnza"
-    - "sena"
     - "senaz"
     - "seza"
     - "sezna"
@@ -3399,6 +3625,14 @@ matches:
     - "srevizio"
     - "srvizio"
     replace: "servizio"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "este"
+    - "seet"
+    - "stee"
+    replace: "sete"
     propagate_case: true
     word: true
 
@@ -3473,10 +3707,8 @@ matches:
   - triggers:
     - "isete"
     - "seite"
-    - "sete"
     - "siee"
     - "sieet"
-    - "site"
     - "sitee"
     replace: "siete"
     propagate_case: true
@@ -3704,6 +3936,14 @@ matches:
     word: true
 
   - triggers:
+    - "atle"
+    - "tael"
+    - "tlae"
+    replace: "tale"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "atnto"
     - "tano"
     - "tanot"
@@ -3716,8 +3956,15 @@ matches:
     word: true
 
   - triggers:
+    - "etmo"
+    - "teom"
+    - "tmeo"
+    replace: "temo"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "etmpo"
-    - "temo"
     - "temop"
     - "tepmo"
     - "tepo"
@@ -3766,8 +4013,15 @@ matches:
     word: true
 
   - triggers:
+    - "etsa"
+    - "teas"
+    - "tsea"
+    replace: "tesa"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "etsta"
-    - "tesa"
     - "tesat"
     - "teta"
     - "tetsa"
@@ -3809,10 +4063,21 @@ matches:
     word: true
 
   - triggers:
+    - "rtopo"
+    - "topo"
+    - "torpo"
+    - "troo"
+    - "troop"
+    - "trpo"
+    - "trpoo"
+    replace: "tropo"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "rtoppo"
     - "toppo"
     - "torppo"
-    - "tropo"
     - "tropop"
     - "trpopo"
     - "trppo"
@@ -3866,6 +4131,14 @@ matches:
     word: true
 
   - triggers:
+    - "ttuo"
+    - "tuot"
+    - "utto"
+    replace: "tuto"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "tttavia"
     - "ttutavia"
     - "tutatvia"
@@ -3884,7 +4157,6 @@ matches:
   - triggers:
     - "ttto"
     - "ttuto"
-    - "tuto"
     - "tutot"
     - "uttto"
     replace: "tutto"
@@ -3962,19 +4234,19 @@ matches:
     word: true
 
   - triggers:
-    - "avi"
-    - "via"
-    replace: "vai"
-    propagate_case: true
-    word: true
-
-  - triggers:
     - "avnno"
-    - "vano"
     - "vanon"
     - "vnano"
     - "vnno"
     replace: "vanno"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "avno"
+    - "vaon"
+    - "vnao"
+    replace: "vano"
     propagate_case: true
     word: true
 
@@ -4073,14 +4345,27 @@ matches:
     word: true
 
   - triggers:
+    - "evro"
+    - "veor"
+    - "vreo"
+    replace: "vero"
+    propagate_case: true
+    word: true
+
+  - triggers:
     - "evrso"
-    - "vero"
     - "veros"
     - "veso"
     - "vesro"
     - "vreso"
     - "vrso"
     replace: "verso"
+    propagate_case: true
+    word: true
+
+  - triggers:
+    - "iva"
+    replace: "via"
     propagate_case: true
     word: true
 

--- a/packages/refuos-italiano/0.1.0/package.yml
+++ b/packages/refuos-italiano/0.1.0/package.yml
@@ -5,13217 +5,4180 @@
 
 matches:
 
-  - trigger: "abbaimo"
+  - triggers:
+    - "abbaimo"
+    - "abbamo"
+    - "abbiao"
+    - "abbiaom"
+    - "abbimao"
+    - "abbimo"
+    - "abiamo"
+    - "abibamo"
+    - "babiamo"
     replace: "abbiamo"
     propagate_case: true
     word: true
 
-  - trigger: "abbamo"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abbiao"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abbiaom"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abbimao"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abbimo"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abiamo"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "abibamo"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "babiamo"
-    replace: "abbiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "acqa"
+  - triggers:
+    - "acqa"
+    - "acqau"
+    - "acua"
+    - "acuqa"
+    - "aqcua"
+    - "aqua"
+    - "caqua"
     replace: "acqua"
     propagate_case: true
     word: true
 
-  - trigger: "acqau"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "acua"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "acuqa"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "aqcua"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "aqua"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "caqua"
-    replace: "acqua"
-    propagate_case: true
-    word: true
-
-  - trigger: "adeso"
+  - triggers:
+    - "adeso"
+    - "adesos"
+    - "adseso"
+    - "adsso"
+    - "aedsso"
+    - "aesso"
+    - "daesso"
     replace: "adesso"
     propagate_case: true
     word: true
 
-  - trigger: "adesos"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "adseso"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "adsso"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "aedsso"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "aesso"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "daesso"
-    replace: "adesso"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggionamento"
+  - triggers:
+    - "aggionamento"
+    - "aggionramento"
+    - "aggioramento"
+    - "aggioranmento"
+    - "aggiornaemnto"
+    - "aggiornaento"
+    - "aggiornameno"
+    - "aggiornamenot"
+    - "aggiornametno"
+    - "aggiornameto"
+    - "aggiornamneto"
+    - "aggiornamnto"
+    - "aggiornmaento"
+    - "aggiornmento"
+    - "aggirnamento"
+    - "aggironamento"
+    - "aggoirnamento"
+    - "aggornamento"
+    - "agigornamento"
+    - "agiornamento"
+    - "gagiornamento"
     replace: "aggiornamento"
     propagate_case: true
     word: true
 
-  - trigger: "aggionramento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioramento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggioranmento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornaemnto"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornaento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornameno"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornamenot"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornametno"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornameto"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornamneto"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornamnto"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornmaento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggiornmento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggirnamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggironamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggoirnamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aggornamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "agigornamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "agiornamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "gagiornamento"
-    replace: "aggiornamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "aitare"
+  - triggers:
+    - "aitare"
+    - "aituare"
+    - "aiuare"
+    - "aiuatre"
+    - "aiutae"
+    - "aiutaer"
+    - "aiutrae"
+    - "aiutre"
+    - "auitare"
+    - "autare"
+    - "iautare"
     replace: "aiutare"
     propagate_case: true
     word: true
 
-  - trigger: "aituare"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuare"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiuatre"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutae"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutaer"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutrae"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aiutre"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "auitare"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "autare"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "iautare"
-    replace: "aiutare"
-    propagate_case: true
-    word: true
-
-  - trigger: "alemno"
+  - triggers:
+    - "alemno"
+    - "aleno"
+    - "almeo"
+    - "almeon"
+    - "almneo"
+    - "almno"
+    - "ameno"
+    - "amleno"
+    - "lameno"
     replace: "almeno"
     propagate_case: true
     word: true
 
-  - trigger: "aleno"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "almeo"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "almeon"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "almneo"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "almno"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ameno"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "amleno"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "lameno"
-    replace: "almeno"
-    propagate_case: true
-    word: true
-
-  - trigger: "alot"
+  - triggers:
+    - "alot"
+    - "atlo"
+    - "lato"
     replace: "alto"
     propagate_case: true
     word: true
 
-  - trigger: "atlo"
-    replace: "alto"
-    propagate_case: true
-    word: true
-
-  - trigger: "lato"
-    replace: "alto"
-    propagate_case: true
-    word: true
-
-  - trigger: "aico"
+  - triggers:
+    - "aico"
+    - "aimco"
+    - "amcio"
+    - "amco"
+    - "amio"
+    - "amioc"
+    - "maico"
     replace: "amico"
     propagate_case: true
     word: true
 
-  - trigger: "aimco"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "amcio"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "amco"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "amio"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "amioc"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "maico"
-    replace: "amico"
-    propagate_case: true
-    word: true
-
-  - trigger: "ache"
+  - triggers:
+    - "ache"
+    - "acnhe"
+    - "ance"
+    - "anceh"
+    - "anhce"
+    - "anhe"
+    - "nache"
     replace: "anche"
     propagate_case: true
     word: true
 
-  - trigger: "acnhe"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "ance"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "anceh"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "anhce"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "anhe"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "nache"
-    replace: "anche"
-    propagate_case: true
-    word: true
-
-  - trigger: "acnora"
+  - triggers:
+    - "acnora"
+    - "acora"
+    - "ancoa"
+    - "ancoar"
+    - "ancra"
+    - "ancroa"
+    - "anocra"
+    - "anora"
+    - "nacora"
     replace: "ancora"
     propagate_case: true
     word: true
 
-  - trigger: "acora"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancoa"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancoar"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancra"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "ancroa"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "anocra"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "anora"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "nacora"
-    replace: "ancora"
-    propagate_case: true
-    word: true
-
-  - trigger: "adare"
+  - triggers:
+    - "adare"
+    - "adnare"
+    - "anadre"
+    - "anare"
+    - "andae"
+    - "andaer"
+    - "andrae"
+    - "andre"
+    - "nadare"
     replace: "andare"
     propagate_case: true
     word: true
 
-  - trigger: "adnare"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "anadre"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "anare"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "andae"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "andaer"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "andrae"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "andre"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadare"
-    replace: "andare"
-    propagate_case: true
-    word: true
-
-  - trigger: "adate"
+  - triggers:
+    - "adate"
+    - "adnate"
+    - "anadte"
+    - "anate"
+    - "andaet"
+    - "andtae"
+    - "andte"
+    - "nadate"
     replace: "andate"
     propagate_case: true
     word: true
 
-  - trigger: "adnate"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "anadte"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "anate"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "andaet"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "andtae"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "andte"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadate"
-    replace: "andate"
-    propagate_case: true
-    word: true
-
-  - trigger: "adiamo"
+  - triggers:
+    - "adiamo"
+    - "adniamo"
+    - "andaimo"
+    - "andamo"
+    - "andiao"
+    - "andiaom"
+    - "andimao"
+    - "andimo"
+    - "aniamo"
+    - "anidamo"
+    - "nadiamo"
     replace: "andiamo"
     propagate_case: true
     word: true
 
-  - trigger: "adniamo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andaimo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andamo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andiao"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andiaom"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andimao"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "andimo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "aniamo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "anidamo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nadiamo"
-    replace: "andiamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ano"
+  - triggers:
+    - "ano"
+    - "anon"
+    - "nano"
     replace: "anno"
     propagate_case: true
     word: true
 
-  - trigger: "anon"
-    replace: "anno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nano"
-    replace: "anno"
-    propagate_case: true
-    word: true
-
-  - trigger: "apena"
+  - triggers:
+    - "apena"
+    - "apepna"
+    - "appea"
+    - "appean"
+    - "appna"
+    - "appnea"
+    - "papena"
     replace: "appena"
     propagate_case: true
     word: true
 
-  - trigger: "apepna"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "appea"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "appean"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "appna"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "appnea"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "papena"
-    replace: "appena"
-    propagate_case: true
-    word: true
-
-  - trigger: "appntamento"
+  - triggers:
+    - "appntamento"
+    - "appnutamento"
+    - "appunamento"
+    - "appunatmento"
+    - "appuntaemnto"
+    - "appuntaento"
+    - "appuntameno"
+    - "appuntamenot"
+    - "appuntametno"
+    - "appuntameto"
+    - "appuntamneto"
+    - "appuntamnto"
+    - "appuntmaento"
+    - "appuntmento"
+    - "apputamento"
+    - "apputnamento"
+    - "apuntamento"
+    - "apupntamento"
+    - "papuntamento"
     replace: "appuntamento"
     propagate_case: true
     word: true
 
-  - trigger: "appnutamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appunamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appunatmento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntaemnto"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntaento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntameno"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntamenot"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntametno"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntameto"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntamneto"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntamnto"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntmaento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "appuntmento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "apputamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "apputnamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "apuntamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "apupntamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "papuntamento"
-    replace: "appuntamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "apire"
+  - triggers:
+    - "apire"
+    - "apirre"
+    - "aprie"
+    - "aprier"
+    - "aprre"
+    - "aprrie"
+    - "arire"
+    - "arpire"
+    - "parire"
     replace: "aprire"
     propagate_case: true
     word: true
 
-  - trigger: "apirre"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprie"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprier"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprre"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprrie"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "arire"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "arpire"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "parire"
-    replace: "aprire"
-    propagate_case: true
-    word: true
-
-  - trigger: "arirvederci"
+  - triggers:
+    - "arirvederci"
+    - "arivederci"
+    - "arriederci"
+    - "arrievderci"
+    - "arrivdeerci"
+    - "arrivderci"
+    - "arrivedeci"
+    - "arrivedecri"
+    - "arrivederi"
+    - "arrivederic"
+    - "arrivedrci"
+    - "arrivedreci"
+    - "arriveedrci"
+    - "arriveerci"
+    - "arrvederci"
+    - "arrviederci"
+    - "rarivederci"
     replace: "arrivederci"
     propagate_case: true
     word: true
 
-  - trigger: "arivederci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriederci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrievderci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivdeerci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivderci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivedeci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivedecri"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivederi"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivederic"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivedrci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrivedreci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveedrci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arriveerci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrvederci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "arrviederci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "rarivederci"
-    replace: "arrivederci"
-    propagate_case: true
-    word: true
-
-  - trigger: "apettare"
+  - triggers:
+    - "apettare"
+    - "apsettare"
+    - "asepttare"
+    - "asettare"
+    - "aspetare"
+    - "aspetatre"
+    - "aspettae"
+    - "aspettaer"
+    - "aspettrae"
+    - "aspettre"
+    - "asptetare"
+    - "aspttare"
+    - "sapettare"
     replace: "aspettare"
     propagate_case: true
     word: true
 
-  - trigger: "apsettare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "asepttare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "asettare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspetatre"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettae"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettaer"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettrae"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspettre"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "asptetare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspttare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapettare"
-    replace: "aspettare"
-    propagate_case: true
-    word: true
-
-  - trigger: "atenzione"
+  - triggers:
+    - "atenzione"
+    - "atetnzione"
+    - "attenione"
+    - "attenizone"
+    - "attenzine"
+    - "attenzinoe"
+    - "attenzioe"
+    - "attenzioen"
+    - "attenzoine"
+    - "attenzone"
+    - "attezione"
+    - "atteznione"
+    - "attnezione"
+    - "attnzione"
+    - "tatenzione"
     replace: "attenzione"
     propagate_case: true
     word: true
 
-  - trigger: "atetnzione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenizone"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzine"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzinoe"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzioe"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzioen"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzoine"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attenzone"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attezione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "atteznione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attnezione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "attnzione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "tatenzione"
-    replace: "attenzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "atraverso"
+  - triggers:
+    - "atraverso"
+    - "atrtaverso"
+    - "attarverso"
+    - "attaverso"
+    - "attraerso"
+    - "attraevrso"
+    - "attravero"
+    - "attraveros"
+    - "attraveso"
+    - "attravesro"
+    - "attravreso"
+    - "attravrso"
+    - "attrvaerso"
+    - "attrverso"
+    - "tatraverso"
     replace: "attraverso"
     propagate_case: true
     word: true
 
-  - trigger: "atrtaverso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attarverso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attaverso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attraerso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attraevrso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attravero"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attraveros"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attraveso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attravesro"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attravreso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attravrso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attrvaerso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "attrverso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "tatraverso"
-    replace: "attraverso"
-    propagate_case: true
-    word: true
-
-  - trigger: "aere"
+  - triggers:
+    - "aere"
+    - "aevre"
+    - "avee"
+    - "aveer"
+    - "avre"
+    - "avree"
+    - "vaere"
     replace: "avere"
     propagate_case: true
     word: true
 
-  - trigger: "aevre"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "avee"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "aveer"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "avre"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "avree"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vaere"
-    replace: "avere"
-    propagate_case: true
-    word: true
-
-  - trigger: "aete"
+  - triggers:
+    - "aete"
+    - "aevte"
+    - "aveet"
+    - "avte"
+    - "avtee"
+    - "vaete"
     replace: "avete"
     propagate_case: true
     word: true
 
-  - trigger: "aevte"
-    replace: "avete"
-    propagate_case: true
-    word: true
-
-  - trigger: "aveet"
-    replace: "avete"
-    propagate_case: true
-    word: true
-
-  - trigger: "avte"
-    replace: "avete"
-    propagate_case: true
-    word: true
-
-  - trigger: "avtee"
-    replace: "avete"
-    propagate_case: true
-    word: true
-
-  - trigger: "vaete"
-    replace: "avete"
-    propagate_case: true
-    word: true
-
-  - trigger: "abmbino"
+  - triggers:
+    - "abmbino"
+    - "babino"
+    - "babmino"
+    - "bambio"
+    - "bambion"
+    - "bambnio"
+    - "bambno"
+    - "bamibno"
+    - "bamino"
+    - "bmabino"
+    - "bmbino"
     replace: "bambino"
     propagate_case: true
     word: true
 
-  - trigger: "babino"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "babmino"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bambio"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bambion"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bambnio"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bambno"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bamibno"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bamino"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bmabino"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "bmbino"
-    replace: "bambino"
-    propagate_case: true
-    word: true
-
-  - trigger: "abssa"
+  - triggers:
+    - "abssa"
+    - "basa"
+    - "basas"
+    - "bsasa"
+    - "bssa"
     replace: "bassa"
     propagate_case: true
     word: true
 
-  - trigger: "basa"
-    replace: "bassa"
-    propagate_case: true
-    word: true
-
-  - trigger: "basas"
-    replace: "bassa"
-    propagate_case: true
-    word: true
-
-  - trigger: "bsasa"
-    replace: "bassa"
-    propagate_case: true
-    word: true
-
-  - trigger: "bssa"
-    replace: "bassa"
-    propagate_case: true
-    word: true
-
-  - trigger: "bela"
+  - triggers:
+    - "bela"
+    - "belal"
+    - "blela"
+    - "blla"
+    - "eblla"
     replace: "bella"
     propagate_case: true
     word: true
 
-  - trigger: "belal"
-    replace: "bella"
-    propagate_case: true
-    word: true
-
-  - trigger: "blela"
-    replace: "bella"
-    propagate_case: true
-    word: true
-
-  - trigger: "blla"
-    replace: "bella"
-    propagate_case: true
-    word: true
-
-  - trigger: "eblla"
-    replace: "bella"
-    propagate_case: true
-    word: true
-
-  - trigger: "belo"
+  - triggers:
+    - "belo"
+    - "belol"
+    - "blelo"
+    - "bllo"
+    - "ebllo"
     replace: "bello"
     propagate_case: true
     word: true
 
-  - trigger: "belol"
-    replace: "bello"
-    propagate_case: true
-    word: true
-
-  - trigger: "blelo"
-    replace: "bello"
-    propagate_case: true
-    word: true
-
-  - trigger: "bllo"
-    replace: "bello"
-    propagate_case: true
-    word: true
-
-  - trigger: "ebllo"
-    replace: "bello"
-    propagate_case: true
-    word: true
-
-  - trigger: "been"
+  - triggers:
+    - "been"
+    - "bnee"
+    - "ebne"
     replace: "bene"
     propagate_case: true
     word: true
 
-  - trigger: "bnee"
-    replace: "bene"
-    propagate_case: true
-    word: true
-
-  - trigger: "ebne"
-    replace: "bene"
-    propagate_case: true
-    word: true
-
-  - trigger: "beer"
+  - triggers:
+    - "beer"
+    - "bree"
+    - "ebre"
     replace: "bere"
     propagate_case: true
     word: true
 
-  - trigger: "bree"
-    replace: "bere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ebre"
-    replace: "bere"
-    propagate_case: true
-    word: true
-
-  - trigger: "bcca"
+  - triggers:
+    - "bcca"
+    - "bcoca"
+    - "boca"
+    - "bocac"
+    - "obcca"
     replace: "bocca"
     propagate_case: true
     word: true
 
-  - trigger: "bcoca"
-    replace: "bocca"
-    propagate_case: true
-    word: true
-
-  - trigger: "boca"
-    replace: "bocca"
-    propagate_case: true
-    word: true
-
-  - trigger: "bocac"
-    replace: "bocca"
-    propagate_case: true
-    word: true
-
-  - trigger: "obcca"
-    replace: "bocca"
-    propagate_case: true
-    word: true
-
-  - trigger: "brtta"
+  - triggers:
+    - "brtta"
+    - "brtuta"
+    - "bruta"
+    - "brutat"
+    - "burtta"
+    - "butta"
+    - "rbutta"
     replace: "brutta"
     propagate_case: true
     word: true
 
-  - trigger: "brtuta"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "bruta"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "brutat"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "burtta"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "butta"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbutta"
-    replace: "brutta"
-    propagate_case: true
-    word: true
-
-  - trigger: "brtto"
+  - triggers:
+    - "brtto"
+    - "brtuto"
+    - "bruto"
+    - "brutot"
+    - "burtto"
+    - "butto"
+    - "rbutto"
     replace: "brutto"
     propagate_case: true
     word: true
 
-  - trigger: "brtuto"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "bruto"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "brutot"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "burtto"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "butto"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "rbutto"
-    replace: "brutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "bona"
+  - triggers:
+    - "bona"
+    - "bouna"
+    - "buna"
+    - "bunoa"
+    - "buoa"
+    - "buoan"
+    - "ubona"
     replace: "buona"
     propagate_case: true
     word: true
 
-  - trigger: "bouna"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "buna"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "bunoa"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoa"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoan"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubona"
-    replace: "buona"
-    propagate_case: true
-    word: true
-
-  - trigger: "bonasera"
+  - triggers:
+    - "bonasera"
+    - "bounasera"
+    - "bunasera"
+    - "bunoasera"
+    - "buoansera"
+    - "buoasera"
+    - "buonaera"
+    - "buonaesra"
+    - "buonasea"
+    - "buonasear"
+    - "buonasra"
+    - "buonasrea"
+    - "buonsaera"
+    - "buonsera"
+    - "ubonasera"
     replace: "buonasera"
     propagate_case: true
     word: true
 
-  - trigger: "bounasera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "bunasera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "bunoasera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoansera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoasera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonaera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonaesra"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonasea"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonasear"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonasra"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonasrea"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonsaera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonsera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubonasera"
-    replace: "buonasera"
-    propagate_case: true
-    word: true
-
-  - trigger: "bongiorno"
+  - triggers:
+    - "bongiorno"
+    - "boungiorno"
+    - "bungiorno"
+    - "bunogiorno"
+    - "buogiorno"
+    - "buogniorno"
+    - "buongiono"
+    - "buongionro"
+    - "buongioro"
+    - "buongioron"
+    - "buongirno"
+    - "buongirono"
+    - "buongoirno"
+    - "buongorno"
+    - "buonigorno"
+    - "buoniorno"
+    - "ubongiorno"
     replace: "buongiorno"
     propagate_case: true
     word: true
 
-  - trigger: "boungiorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "bungiorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "bunogiorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buogiorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buogniorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongiono"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongionro"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongioro"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongioron"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongirno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongirono"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongoirno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buongorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buonigorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoniorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubongiorno"
-    replace: "buongiorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "bono"
+  - triggers:
+    - "bono"
+    - "bouno"
+    - "buno"
+    - "bunoo"
+    - "buoo"
+    - "buoon"
+    - "ubono"
     replace: "buono"
     propagate_case: true
     word: true
 
-  - trigger: "bouno"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "buno"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "bunoo"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoo"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "buoon"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "ubono"
-    replace: "buono"
-    propagate_case: true
-    word: true
-
-  - trigger: "acmbiamento"
+  - triggers:
+    - "acmbiamento"
+    - "cabiamento"
+    - "cabmiamento"
+    - "cambaimento"
+    - "cambamento"
+    - "cambiaemnto"
+    - "cambiaento"
+    - "cambiameno"
+    - "cambiamenot"
+    - "cambiametno"
+    - "cambiameto"
+    - "cambiamneto"
+    - "cambiamnto"
+    - "cambimaento"
+    - "cambimento"
+    - "camiamento"
+    - "camibamento"
+    - "cmabiamento"
+    - "cmbiamento"
     replace: "cambiamento"
     propagate_case: true
     word: true
 
-  - trigger: "cabiamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cabmiamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambaimento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiaemnto"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiaento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiameno"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiamenot"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiametno"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiameto"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiamneto"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiamnto"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambimaento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambimento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "camiamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "camibamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmabiamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmbiamento"
-    replace: "cambiamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "acmbiare"
+  - triggers:
+    - "acmbiare"
+    - "cabiare"
+    - "cabmiare"
+    - "cambaire"
+    - "cambare"
+    - "cambiae"
+    - "cambiaer"
+    - "cambirae"
+    - "cambire"
+    - "camiare"
+    - "camibare"
+    - "cmabiare"
+    - "cmbiare"
     replace: "cambiare"
     propagate_case: true
     word: true
 
-  - trigger: "cabiare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cabmiare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambaire"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiae"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambiaer"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambirae"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cambire"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "camiare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "camibare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmabiare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmbiare"
-    replace: "cambiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "acpire"
+  - triggers:
+    - "acpire"
+    - "caipre"
+    - "caire"
+    - "capie"
+    - "capier"
+    - "capre"
+    - "caprie"
+    - "cpaire"
+    - "cpire"
     replace: "capire"
     propagate_case: true
     word: true
 
-  - trigger: "caipre"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "caire"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "capie"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "capier"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "capre"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "caprie"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpaire"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "cpire"
-    replace: "capire"
-    propagate_case: true
-    word: true
-
-  - trigger: "acra"
+  - triggers:
+    - "acra"
+    - "caar"
+    - "craa"
     replace: "cara"
     propagate_case: true
     word: true
 
-  - trigger: "caar"
-    replace: "cara"
-    propagate_case: true
-    word: true
-
-  - trigger: "craa"
-    replace: "cara"
-    propagate_case: true
-    word: true
-
-  - trigger: "acro"
+  - triggers:
+    - "acro"
+    - "caor"
+    - "crao"
     replace: "caro"
     propagate_case: true
     word: true
 
-  - trigger: "caor"
-    replace: "caro"
-    propagate_case: true
-    word: true
-
-  - trigger: "crao"
-    replace: "caro"
-    propagate_case: true
-    word: true
-
-  - trigger: "acsa"
+  - triggers:
+    - "acsa"
+    - "caas"
+    - "csaa"
     replace: "casa"
     propagate_case: true
     word: true
 
-  - trigger: "caas"
-    replace: "casa"
-    propagate_case: true
-    word: true
-
-  - trigger: "csaa"
-    replace: "casa"
-    propagate_case: true
-    word: true
-
-  - trigger: "acso"
+  - triggers:
+    - "acso"
+    - "caos"
+    - "csao"
     replace: "caso"
     propagate_case: true
     word: true
 
-  - trigger: "caos"
-    replace: "caso"
-    propagate_case: true
-    word: true
-
-  - trigger: "csao"
-    replace: "caso"
-    propagate_case: true
-    word: true
-
-  - trigger: "acttiva"
+  - triggers:
+    - "acttiva"
+    - "catitva"
+    - "cativa"
+    - "cattia"
+    - "cattiav"
+    - "cattva"
+    - "cattvia"
+    - "ctativa"
+    - "cttiva"
     replace: "cattiva"
     propagate_case: true
     word: true
 
-  - trigger: "catitva"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cativa"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattia"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattiav"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattva"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattvia"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "ctativa"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "cttiva"
-    replace: "cattiva"
-    propagate_case: true
-    word: true
-
-  - trigger: "acttivo"
+  - triggers:
+    - "acttivo"
+    - "catitvo"
+    - "cativo"
+    - "cattio"
+    - "cattiov"
+    - "cattvio"
+    - "cattvo"
+    - "ctativo"
+    - "cttivo"
     replace: "cattivo"
     propagate_case: true
     word: true
 
-  - trigger: "catitvo"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cativo"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattio"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattiov"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattvio"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cattvo"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ctativo"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cttivo"
-    replace: "cattivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceramente"
+  - triggers:
+    - "ceramente"
+    - "ceratmente"
+    - "certaemnte"
+    - "certaente"
+    - "certamene"
+    - "certamenet"
+    - "certamete"
+    - "certametne"
+    - "certamnete"
+    - "certamnte"
+    - "certmaente"
+    - "certmente"
+    - "cetamente"
+    - "cetramente"
+    - "cretamente"
+    - "crtamente"
+    - "ecrtamente"
     replace: "certamente"
     propagate_case: true
     word: true
 
-  - trigger: "ceratmente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certaemnte"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certaente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certamene"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certamenet"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certamete"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certametne"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certamnete"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certamnte"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certmaente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "certmente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "cetamente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "cetramente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "cretamente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "crtamente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "ecrtamente"
-    replace: "certamente"
-    propagate_case: true
-    word: true
-
-  - trigger: "ceh"
+  - triggers:
+    - "ceh"
+    - "hce"
     replace: "che"
     propagate_case: true
     word: true
 
-  - trigger: "hce"
-    replace: "che"
-    propagate_case: true
-    word: true
-
-  - trigger: "cih"
+  - triggers:
+    - "cih"
+    - "hci"
     replace: "chi"
     propagate_case: true
     word: true
 
-  - trigger: "hci"
-    replace: "chi"
-    propagate_case: true
-    word: true
-
-  - trigger: "chaimare"
+  - triggers:
+    - "chaimare"
+    - "chamare"
+    - "chiaamre"
+    - "chiaare"
+    - "chiamae"
+    - "chiamaer"
+    - "chiamrae"
+    - "chiamre"
+    - "chimaare"
+    - "chimare"
+    - "ciamare"
+    - "cihamare"
+    - "hciamare"
     replace: "chiamare"
     propagate_case: true
     word: true
 
-  - trigger: "chamare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaamre"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiaare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamae"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamaer"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamrae"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiamre"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimaare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chimare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciamare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihamare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciamare"
-    replace: "chiamare"
-    propagate_case: true
-    word: true
-
-  - trigger: "chidere"
+  - triggers:
+    - "chidere"
+    - "chiduere"
+    - "chiudee"
+    - "chiudeer"
+    - "chiudre"
+    - "chiudree"
+    - "chiuedre"
+    - "chiuere"
+    - "chudere"
+    - "chuidere"
+    - "cihudere"
+    - "ciudere"
+    - "hciudere"
     replace: "chiudere"
     propagate_case: true
     word: true
 
-  - trigger: "chiduere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiudee"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiudeer"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiudre"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiudree"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiuedre"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chiuere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chudere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "chuidere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "cihudere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciudere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "hciudere"
-    replace: "chiudere"
-    propagate_case: true
-    word: true
-
-  - trigger: "caio"
+  - triggers:
+    - "caio"
+    - "cioa"
+    - "icao"
     replace: "ciao"
     propagate_case: true
     word: true
 
-  - trigger: "cioa"
-    replace: "ciao"
-    propagate_case: true
-    word: true
-
-  - trigger: "icao"
-    replace: "ciao"
-    propagate_case: true
-    word: true
-
-  - trigger: "caiscuno"
+  - triggers:
+    - "caiscuno"
+    - "cascuno"
+    - "ciacsuno"
+    - "ciacuno"
+    - "ciascno"
+    - "ciascnuo"
+    - "ciascuo"
+    - "ciascuon"
+    - "ciasucno"
+    - "ciasuno"
+    - "cisacuno"
+    - "ciscuno"
+    - "icascuno"
     replace: "ciascuno"
     propagate_case: true
     word: true
 
-  - trigger: "cascuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciacsuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciacuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciascno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciascnuo"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciascuo"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciascuon"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciasucno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciasuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cisacuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ciscuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "icascuno"
-    replace: "ciascuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "cllaborare"
+  - triggers:
+    - "cllaborare"
+    - "clolaborare"
+    - "colaborare"
+    - "colalborare"
+    - "collaboare"
+    - "collaboarre"
+    - "collaborae"
+    - "collaboraer"
+    - "collaborrae"
+    - "collaborre"
+    - "collabrare"
+    - "collabroare"
+    - "collaobrare"
+    - "collaorare"
+    - "collbaorare"
+    - "collborare"
+    - "ocllaborare"
     replace: "collaborare"
     propagate_case: true
     word: true
 
-  - trigger: "clolaborare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "colaborare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "colalborare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboarre"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborae"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboraer"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborrae"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborre"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collabrare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collabroare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaobrare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaorare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collbaorare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "collborare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocllaborare"
-    replace: "collaborare"
-    propagate_case: true
-    word: true
-
-  - trigger: "cllaborazione"
+  - triggers:
+    - "cllaborazione"
+    - "clolaborazione"
+    - "colaborazione"
+    - "colalborazione"
+    - "collaboarzione"
+    - "collaboazione"
+    - "collaboraione"
+    - "collaboraizone"
+    - "collaborazine"
+    - "collaborazinoe"
+    - "collaborazioe"
+    - "collaborazioen"
+    - "collaborazoine"
+    - "collaborazone"
+    - "collaborzaione"
+    - "collaborzione"
+    - "collabrazione"
+    - "collabroazione"
+    - "collaobrazione"
+    - "collaorazione"
+    - "collbaorazione"
+    - "collborazione"
+    - "ocllaborazione"
     replace: "collaborazione"
     propagate_case: true
     word: true
 
-  - trigger: "clolaborazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "colaborazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "colalborazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboarzione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboraione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaboraizone"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazine"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazinoe"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazioe"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazioen"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazoine"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborazone"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborzaione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaborzione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collabrazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collabroazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaobrazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collaorazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collbaorazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "collborazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocllaborazione"
-    replace: "collaborazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmoe"
+  - triggers:
+    - "cmoe"
+    - "coem"
+    - "ocme"
     replace: "come"
     propagate_case: true
     word: true
 
-  - trigger: "coem"
-    replace: "come"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocme"
-    replace: "come"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmounicazione"
+  - triggers:
+    - "cmounicazione"
+    - "cmunicazione"
+    - "comnicazione"
+    - "comnuicazione"
+    - "comuicazione"
+    - "comuincazione"
+    - "comuncazione"
+    - "comunciazione"
+    - "comuniaczione"
+    - "comuniazione"
+    - "comunicaione"
+    - "comunicaizone"
+    - "comunicazine"
+    - "comunicazinoe"
+    - "comunicazioe"
+    - "comunicazioen"
+    - "comunicazoine"
+    - "comunicazone"
+    - "comuniczaione"
+    - "comuniczione"
+    - "coumnicazione"
+    - "counicazione"
+    - "ocmunicazione"
     replace: "comunicazione"
     propagate_case: true
     word: true
 
-  - trigger: "cmunicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnuicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuincazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuncazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunciazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniaczione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicaione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicaizone"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazine"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazinoe"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazioe"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazioen"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazoine"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunicazone"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniczaione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuniczione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "coumnicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "counicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmunicazione"
-    replace: "comunicazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "cmounque"
+  - triggers:
+    - "cmounque"
+    - "cmunque"
+    - "comnque"
+    - "comnuque"
+    - "comunqe"
+    - "comunqeu"
+    - "comunue"
+    - "comunuqe"
+    - "comuqnue"
+    - "comuque"
+    - "coumnque"
+    - "counque"
+    - "ocmunque"
     replace: "comunque"
     propagate_case: true
     word: true
 
-  - trigger: "cmunque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comnuque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunqe"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunqeu"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunue"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comunuqe"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuqnue"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "comuque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "coumnque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "counque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocmunque"
-    replace: "comunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "cno"
+  - triggers:
+    - "cno"
+    - "ocn"
     replace: "con"
     propagate_case: true
     word: true
 
-  - trigger: "ocn"
-    replace: "con"
-    propagate_case: true
-    word: true
-
-  - trigger: "cndizione"
+  - triggers:
+    - "cndizione"
+    - "cnodizione"
+    - "codizione"
+    - "codnizione"
+    - "condiione"
+    - "condiizone"
+    - "condizine"
+    - "condizinoe"
+    - "condizioe"
+    - "condizioen"
+    - "condizoine"
+    - "condizone"
+    - "condziione"
+    - "condzione"
+    - "conidzione"
+    - "conizione"
+    - "ocndizione"
     replace: "condizione"
     propagate_case: true
     word: true
 
-  - trigger: "cnodizione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "codizione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "codnizione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condiizone"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizine"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizinoe"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizioe"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizioen"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizoine"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condizone"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condziione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "condzione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "conidzione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "conizione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocndizione"
-    replace: "condizione"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnooscenza"
+  - triggers:
+    - "cnooscenza"
+    - "cnoscenza"
+    - "conocenza"
+    - "conocsenza"
+    - "conoscena"
+    - "conoscenaz"
+    - "conosceza"
+    - "conoscezna"
+    - "conoscneza"
+    - "conoscnza"
+    - "conosecnza"
+    - "conosenza"
+    - "conscenza"
+    - "consocenza"
+    - "coonscenza"
+    - "cooscenza"
+    - "ocnoscenza"
     replace: "conoscenza"
     propagate_case: true
     word: true
 
-  - trigger: "cnoscenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conocenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conocsenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conoscena"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conoscenaz"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conosceza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conoscezna"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conoscneza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conoscnza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conosecnza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conosenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "conscenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "consocenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "coonscenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "cooscenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocnoscenza"
-    replace: "conoscenza"
-    propagate_case: true
-    word: true
-
-  - trigger: "cnotro"
+  - triggers:
+    - "cnotro"
+    - "cntro"
+    - "conro"
+    - "conrto"
+    - "conto"
+    - "contor"
+    - "cotnro"
+    - "cotro"
+    - "ocntro"
     replace: "contro"
     propagate_case: true
     word: true
 
-  - trigger: "cntro"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "conro"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "conrto"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "conto"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "contor"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotnro"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "cotro"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocntro"
-    replace: "contro"
-    propagate_case: true
-    word: true
-
-  - trigger: "copo"
+  - triggers:
+    - "copo"
+    - "copro"
+    - "coro"
+    - "corop"
+    - "cropo"
+    - "crpo"
+    - "ocrpo"
     replace: "corpo"
     propagate_case: true
     word: true
 
-  - trigger: "copro"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "coro"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corop"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cropo"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "crpo"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocrpo"
-    replace: "corpo"
-    propagate_case: true
-    word: true
-
-  - trigger: "corot"
+  - triggers:
+    - "corot"
+    - "coto"
+    - "croto"
+    - "crto"
+    - "ocrto"
     replace: "corto"
     propagate_case: true
     word: true
 
-  - trigger: "coto"
-    replace: "corto"
-    propagate_case: true
-    word: true
-
-  - trigger: "croto"
-    replace: "corto"
-    propagate_case: true
-    word: true
-
-  - trigger: "crto"
-    replace: "corto"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocrto"
-    replace: "corto"
-    propagate_case: true
-    word: true
-
-  - trigger: "coas"
+  - triggers:
+    - "coas"
+    - "csoa"
+    - "ocsa"
     replace: "cosa"
     propagate_case: true
     word: true
 
-  - trigger: "csoa"
-    replace: "cosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "ocsa"
-    replace: "cosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "cedere"
+  - triggers:
+    - "cedere"
+    - "cerdere"
+    - "crdeere"
+    - "crdere"
+    - "credee"
+    - "credeer"
+    - "credre"
+    - "credree"
+    - "creedre"
+    - "creere"
+    - "rcedere"
     replace: "credere"
     propagate_case: true
     word: true
 
-  - trigger: "cerdere"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "crdeere"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "crdere"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "credee"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "credeer"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "credre"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "credree"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "creedre"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "creere"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "rcedere"
-    replace: "credere"
-    propagate_case: true
-    word: true
-
-  - trigger: "core"
+  - triggers:
+    - "core"
+    - "coure"
+    - "cuoe"
+    - "cuoer"
+    - "cure"
+    - "curoe"
+    - "ucore"
     replace: "cuore"
     propagate_case: true
     word: true
 
-  - trigger: "coure"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "cuoe"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "cuoer"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "cure"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "curoe"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "ucore"
-    replace: "cuore"
-    propagate_case: true
-    word: true
-
-  - trigger: "adre"
+  - triggers:
+    - "adre"
+    - "daer"
+    - "drae"
     replace: "dare"
     propagate_case: true
     word: true
 
-  - trigger: "daer"
-    replace: "dare"
-    propagate_case: true
-    word: true
-
-  - trigger: "drae"
-    replace: "dare"
-    propagate_case: true
-    word: true
-
-  - trigger: "advvero"
+  - triggers:
+    - "advvero"
+    - "davero"
+    - "davevro"
+    - "davveo"
+    - "davveor"
+    - "davvreo"
+    - "davvro"
+    - "dvavero"
+    - "dvvero"
     replace: "davvero"
     propagate_case: true
     word: true
 
-  - trigger: "davero"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "davevro"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "davveo"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "davveor"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "davvreo"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "davvro"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvavero"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvvero"
-    replace: "davvero"
-    propagate_case: true
-    word: true
-
-  - trigger: "dceisione"
+  - triggers:
+    - "dceisione"
+    - "dcisione"
+    - "deciione"
+    - "deciisone"
+    - "decisine"
+    - "decisinoe"
+    - "decisioe"
+    - "decisioen"
+    - "decisoine"
+    - "decisone"
+    - "decsiione"
+    - "decsione"
+    - "deicsione"
+    - "deisione"
+    - "edcisione"
     replace: "decisione"
     propagate_case: true
     word: true
 
-  - trigger: "dcisione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "deciione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "deciisone"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisine"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisinoe"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisioe"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisioen"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisoine"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decisone"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decsiione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "decsione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "deicsione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "deisione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "edcisione"
-    replace: "decisione"
-    propagate_case: true
-    word: true
-
-  - trigger: "denro"
+  - triggers:
+    - "denro"
+    - "denrto"
+    - "dento"
+    - "dentor"
+    - "detnro"
+    - "detro"
+    - "dnetro"
+    - "dntro"
+    - "edntro"
     replace: "dentro"
     propagate_case: true
     word: true
 
-  - trigger: "denrto"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "dento"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "dentor"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "detnro"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "detro"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "dnetro"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "dntro"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "edntro"
-    replace: "dentro"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcie"
+  - triggers:
+    - "dcie"
+    - "diec"
+    - "idce"
     replace: "dice"
     propagate_case: true
     word: true
 
-  - trigger: "diec"
-    replace: "dice"
-    propagate_case: true
-    word: true
-
-  - trigger: "idce"
-    replace: "dice"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcii"
+  - triggers:
+    - "dcii"
+    - "diic"
+    - "idci"
     replace: "dici"
     propagate_case: true
     word: true
 
-  - trigger: "diic"
-    replace: "dici"
-    propagate_case: true
-    word: true
-
-  - trigger: "idci"
-    replace: "dici"
-    propagate_case: true
-    word: true
-
-  - trigger: "dciamo"
+  - triggers:
+    - "dciamo"
+    - "dciiamo"
+    - "dicaimo"
+    - "dicamo"
+    - "diciao"
+    - "diciaom"
+    - "dicimao"
+    - "dicimo"
+    - "diiamo"
+    - "diicamo"
+    - "idciamo"
     replace: "diciamo"
     propagate_case: true
     word: true
 
-  - trigger: "dciiamo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicaimo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicamo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "diciao"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "diciaom"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicimao"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicimo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "diiamo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "diicamo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "idciamo"
-    replace: "diciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcio"
+  - triggers:
+    - "dcio"
+    - "dioc"
+    - "idco"
     replace: "dico"
     propagate_case: true
     word: true
 
-  - trigger: "dioc"
-    replace: "dico"
-    propagate_case: true
-    word: true
-
-  - trigger: "idco"
-    replace: "dico"
-    propagate_case: true
-    word: true
-
-  - trigger: "dciono"
+  - triggers:
+    - "dciono"
+    - "dcono"
+    - "dicno"
+    - "dicnoo"
+    - "dicoo"
+    - "dicoon"
+    - "diocno"
+    - "diono"
+    - "idcono"
     replace: "dicono"
     propagate_case: true
     word: true
 
-  - trigger: "dcono"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicno"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicnoo"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicoo"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "dicoon"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "diocno"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "diono"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "idcono"
-    replace: "dicono"
-    propagate_case: true
-    word: true
-
-  - trigger: "dfficile"
+  - triggers:
+    - "dfficile"
+    - "dfificile"
+    - "diffciile"
+    - "diffcile"
+    - "difficie"
+    - "difficiel"
+    - "difficle"
+    - "difficlie"
+    - "diffiicle"
+    - "diffiile"
+    - "dificile"
+    - "dififcile"
+    - "idfficile"
     replace: "difficile"
     propagate_case: true
     word: true
 
-  - trigger: "dfificile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "diffciile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "diffcile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "difficie"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "difficiel"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "difficle"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "difficlie"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "diffiicle"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "diffiile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dificile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dififcile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "idfficile"
-    replace: "difficile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dier"
+  - triggers:
+    - "dier"
+    - "drie"
+    - "idre"
     replace: "dire"
     propagate_case: true
     word: true
 
-  - trigger: "drie"
-    replace: "dire"
-    propagate_case: true
-    word: true
-
-  - trigger: "idre"
-    replace: "dire"
-    propagate_case: true
-    word: true
-
-  - trigger: "diponibile"
+  - triggers:
+    - "diponibile"
+    - "dipsonibile"
+    - "disonibile"
+    - "disopnibile"
+    - "dispnibile"
+    - "dispnoibile"
+    - "dispoibile"
+    - "dispoinbile"
+    - "disponbiile"
+    - "disponbile"
+    - "disponibie"
+    - "disponibiel"
+    - "disponible"
+    - "disponiblie"
+    - "disponiible"
+    - "disponiile"
+    - "dsiponibile"
+    - "dsponibile"
+    - "idsponibile"
     replace: "disponibile"
     propagate_case: true
     word: true
 
-  - trigger: "dipsonibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disonibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disopnibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispnibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispnoibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispoibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dispoinbile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponbiile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponbile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponibie"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponibiel"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponible"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponiblie"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponiible"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "disponiile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsiponibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "dsponibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "idsponibile"
-    replace: "disponibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "diet"
+  - triggers:
+    - "diet"
+    - "dtie"
+    - "idte"
     replace: "dite"
     propagate_case: true
     word: true
 
-  - trigger: "dtie"
-    replace: "dite"
-    propagate_case: true
-    word: true
-
-  - trigger: "idte"
-    replace: "dite"
-    propagate_case: true
-    word: true
-
-  - trigger: "dcoumentazione"
+  - triggers:
+    - "dcoumentazione"
+    - "dcumentazione"
+    - "docmentazione"
+    - "docmuentazione"
+    - "docuemntazione"
+    - "docuentazione"
+    - "documenatzione"
+    - "documenazione"
+    - "documentaione"
+    - "documentaizone"
+    - "documentazine"
+    - "documentazinoe"
+    - "documentazioe"
+    - "documentazioen"
+    - "documentazoine"
+    - "documentazone"
+    - "documentzaione"
+    - "documentzione"
+    - "documetazione"
+    - "documetnazione"
+    - "documnetazione"
+    - "documntazione"
+    - "doucmentazione"
+    - "doumentazione"
+    - "odcumentazione"
     replace: "documentazione"
     propagate_case: true
     word: true
 
-  - trigger: "dcumentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "docmentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "docmuentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "docuemntazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "docuentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documenatzione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documenazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentaione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentaizone"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazine"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazinoe"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazioe"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazioen"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazoine"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentazone"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentzaione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documentzione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documetazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documetnazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documnetazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "documntazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "doucmentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "doumentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "odcumentazione"
-    replace: "documentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "dmanda"
+  - triggers:
+    - "dmanda"
+    - "dmoanda"
+    - "doamnda"
+    - "doanda"
+    - "domada"
+    - "domadna"
+    - "domana"
+    - "domanad"
+    - "domnada"
+    - "domnda"
+    - "odmanda"
     replace: "domanda"
     propagate_case: true
     word: true
 
-  - trigger: "dmoanda"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "doamnda"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "doanda"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domada"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domadna"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domana"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domanad"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domnada"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "domnda"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "odmanda"
-    replace: "domanda"
-    propagate_case: true
-    word: true
-
-  - trigger: "dmani"
+  - triggers:
+    - "dmani"
+    - "dmoani"
+    - "doamni"
+    - "doani"
+    - "domai"
+    - "domain"
+    - "domnai"
+    - "domni"
+    - "odmani"
     replace: "domani"
     propagate_case: true
     word: true
 
-  - trigger: "dmoani"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "doamni"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "doani"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "domai"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "domain"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "domnai"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "domni"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "odmani"
-    replace: "domani"
-    propagate_case: true
-    word: true
-
-  - trigger: "dnna"
+  - triggers:
+    - "dnna"
+    - "dnona"
+    - "dona"
+    - "donan"
+    - "odnna"
     replace: "donna"
     propagate_case: true
     word: true
 
-  - trigger: "dnona"
-    replace: "donna"
-    propagate_case: true
-    word: true
-
-  - trigger: "dona"
-    replace: "donna"
-    propagate_case: true
-    word: true
-
-  - trigger: "donan"
-    replace: "donna"
-    propagate_case: true
-    word: true
-
-  - trigger: "odnna"
-    replace: "donna"
-    propagate_case: true
-    word: true
-
-  - trigger: "doop"
+  - triggers:
+    - "doop"
+    - "dpoo"
+    - "odpo"
     replace: "dopo"
     propagate_case: true
     word: true
 
-  - trigger: "dpoo"
-    replace: "dopo"
-    propagate_case: true
-    word: true
-
-  - trigger: "odpo"
-    replace: "dopo"
-    propagate_case: true
-    word: true
-
-  - trigger: "domire"
+  - triggers:
+    - "domire"
+    - "domrire"
+    - "dorimre"
+    - "dorire"
+    - "dormie"
+    - "dormier"
+    - "dormre"
+    - "dormrie"
+    - "drmire"
+    - "dromire"
+    - "odrmire"
     replace: "dormire"
     propagate_case: true
     word: true
 
-  - trigger: "domrire"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dorimre"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dorire"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dormie"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dormier"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dormre"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dormrie"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "drmire"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "dromire"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "odrmire"
-    replace: "dormire"
-    propagate_case: true
-    word: true
-
-  - trigger: "doev"
+  - triggers:
+    - "doev"
+    - "dvoe"
+    - "odve"
     replace: "dove"
     propagate_case: true
     word: true
 
-  - trigger: "dvoe"
-    replace: "dove"
-    propagate_case: true
-    word: true
-
-  - trigger: "odve"
-    replace: "dove"
-    propagate_case: true
-    word: true
-
-  - trigger: "doere"
+  - triggers:
+    - "doere"
+    - "doevre"
+    - "dovee"
+    - "doveer"
+    - "dovre"
+    - "dovree"
+    - "dvere"
+    - "dvoere"
+    - "odvere"
     replace: "dovere"
     propagate_case: true
     word: true
 
-  - trigger: "doevre"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovee"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "doveer"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovre"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dovree"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvere"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dvoere"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "odvere"
-    replace: "dovere"
-    propagate_case: true
-    word: true
-
-  - trigger: "dnque"
+  - triggers:
+    - "dnque"
+    - "dnuque"
+    - "dunqe"
+    - "dunqeu"
+    - "dunue"
+    - "dunuqe"
+    - "duqnue"
+    - "duque"
+    - "udnque"
     replace: "dunque"
     propagate_case: true
     word: true
 
-  - trigger: "dnuque"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "dunqe"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "dunqeu"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "dunue"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "dunuqe"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "duqnue"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "duque"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "udnque"
-    replace: "dunque"
-    propagate_case: true
-    word: true
-
-  - trigger: "drante"
+  - triggers:
+    - "drante"
+    - "druante"
+    - "duante"
+    - "duarnte"
+    - "durane"
+    - "duranet"
+    - "durate"
+    - "duratne"
+    - "durnate"
+    - "durnte"
+    - "udrante"
     replace: "durante"
     propagate_case: true
     word: true
 
-  - trigger: "druante"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "duante"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "duarnte"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "durane"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "duranet"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "durate"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "duratne"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "durnate"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "durnte"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "udrante"
-    replace: "durante"
-    propagate_case: true
-    word: true
-
-  - trigger: "ear"
+  - triggers:
+    - "ear"
+    - "rea"
     replace: "era"
     propagate_case: true
     word: true
 
-  - trigger: "rea"
-    replace: "era"
-    propagate_case: true
-    word: true
-
-  - trigger: "eano"
+  - triggers:
+    - "eano"
+    - "earno"
+    - "erao"
+    - "eraon"
+    - "ernao"
+    - "erno"
+    - "reano"
     replace: "erano"
     propagate_case: true
     word: true
 
-  - trigger: "earno"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "erao"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "eraon"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "ernao"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "erno"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "reano"
-    replace: "erano"
-    propagate_case: true
-    word: true
-
-  - trigger: "earvamo"
+  - triggers:
+    - "earvamo"
+    - "eavamo"
+    - "eraamo"
+    - "eraavmo"
+    - "eravao"
+    - "eravaom"
+    - "eravmao"
+    - "eravmo"
+    - "ervaamo"
+    - "ervamo"
+    - "reavamo"
     replace: "eravamo"
     propagate_case: true
     word: true
 
-  - trigger: "eavamo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eraamo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eraavmo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravao"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravaom"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravmao"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravmo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ervaamo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ervamo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "reavamo"
-    replace: "eravamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "earvate"
+  - triggers:
+    - "earvate"
+    - "eavate"
+    - "eraate"
+    - "eraavte"
+    - "eravae"
+    - "eravaet"
+    - "eravtae"
+    - "eravte"
+    - "ervaate"
+    - "ervate"
+    - "reavate"
     replace: "eravate"
     propagate_case: true
     word: true
 
-  - trigger: "eavate"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eraate"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eraavte"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravae"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravaet"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravtae"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eravte"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "ervaate"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "ervate"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "reavate"
-    replace: "eravate"
-    propagate_case: true
-    word: true
-
-  - trigger: "eir"
+  - triggers:
+    - "eir"
+    - "rei"
     replace: "eri"
     propagate_case: true
     word: true
 
-  - trigger: "rei"
-    replace: "eri"
-    propagate_case: true
-    word: true
-
-  - trigger: "eor"
+  - triggers:
+    - "eor"
+    - "reo"
     replace: "ero"
     propagate_case: true
     word: true
 
-  - trigger: "reo"
-    replace: "ero"
-    propagate_case: true
-    word: true
-
-  - trigger: "eempio"
+  - triggers:
+    - "eempio"
+    - "eesmpio"
+    - "esemio"
+    - "esemipo"
+    - "esempo"
+    - "esempoi"
+    - "esepio"
+    - "esepmio"
+    - "esmepio"
+    - "esmpio"
+    - "seempio"
     replace: "esempio"
     propagate_case: true
     word: true
 
-  - trigger: "eesmpio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esemio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esemipo"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esempo"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esempoi"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esepio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esepmio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esmepio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esmpio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "seempio"
-    replace: "esempio"
-    propagate_case: true
-    word: true
-
-  - trigger: "eperienza"
+  - triggers:
+    - "eperienza"
+    - "epserienza"
+    - "eseprienza"
+    - "eserienza"
+    - "espeienza"
+    - "espeirenza"
+    - "espereinza"
+    - "esperenza"
+    - "esperiena"
+    - "esperienaz"
+    - "esperieza"
+    - "esperiezna"
+    - "esperineza"
+    - "esperinza"
+    - "espreienza"
+    - "esprienza"
+    - "seperienza"
     replace: "esperienza"
     propagate_case: true
     word: true
 
-  - trigger: "epserienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "eseprienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "eserienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "espeienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "espeirenza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "espereinza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperenza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperiena"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperienaz"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperieza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperiezna"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperineza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esperinza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "espreienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esprienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "seperienza"
-    replace: "esperienza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esere"
+  - triggers:
+    - "esere"
+    - "esesre"
+    - "essee"
+    - "esseer"
+    - "essre"
+    - "essree"
+    - "sesere"
     replace: "essere"
     propagate_case: true
     word: true
 
-  - trigger: "esesre"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "essee"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "esseer"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "essre"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "essree"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "sesere"
-    replace: "essere"
-    propagate_case: true
-    word: true
-
-  - trigger: "afcciamo"
+  - triggers:
+    - "afcciamo"
+    - "faccaimo"
+    - "faccamo"
+    - "facciao"
+    - "facciaom"
+    - "faccimao"
+    - "faccimo"
+    - "faciamo"
+    - "facicamo"
+    - "fcaciamo"
+    - "fcciamo"
     replace: "facciamo"
     propagate_case: true
     word: true
 
-  - trigger: "faccaimo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "faccamo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "facciao"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "facciaom"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "faccimao"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "faccimo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "faciamo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "facicamo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcaciamo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcciamo"
-    replace: "facciamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "afccio"
+  - triggers:
+    - "afccio"
+    - "facco"
+    - "faccoi"
+    - "facico"
+    - "facio"
+    - "fcacio"
+    - "fccio"
     replace: "faccio"
     propagate_case: true
     word: true
 
-  - trigger: "facco"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "faccoi"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "facico"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "facio"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcacio"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "fccio"
-    replace: "faccio"
-    propagate_case: true
-    word: true
-
-  - trigger: "afcile"
+  - triggers:
+    - "afcile"
+    - "facie"
+    - "faciel"
+    - "facle"
+    - "faclie"
+    - "faicle"
+    - "faile"
+    - "fcaile"
+    - "fcile"
     replace: "facile"
     propagate_case: true
     word: true
 
-  - trigger: "facie"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "faciel"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "facle"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "faclie"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "faicle"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "faile"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcaile"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcile"
-    replace: "facile"
-    propagate_case: true
-    word: true
-
-  - trigger: "afcilita"
+  - triggers:
+    - "afcilita"
+    - "faciilta"
+    - "faciita"
+    - "facilia"
+    - "faciliat"
+    - "facilta"
+    - "faciltia"
+    - "facliita"
+    - "faclita"
+    - "faiclita"
+    - "failita"
+    - "fcailita"
+    - "fcilita"
     replace: "facilita"
     propagate_case: true
     word: true
 
-  - trigger: "faciilta"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "faciita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "facilia"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "faciliat"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "facilta"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "faciltia"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "facliita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "faclita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "faiclita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "failita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcailita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "fcilita"
-    replace: "facilita"
-    propagate_case: true
-    word: true
-
-  - trigger: "afi"
+  - triggers:
+    - "afi"
+    - "fia"
     replace: "fai"
     propagate_case: true
     word: true
 
-  - trigger: "fia"
-    replace: "fai"
-    propagate_case: true
-    word: true
-
-  - trigger: "afmiglia"
+  - triggers:
+    - "afmiglia"
+    - "faiglia"
+    - "faimglia"
+    - "famgilia"
+    - "famglia"
+    - "famigia"
+    - "famigila"
+    - "famigla"
+    - "famiglai"
+    - "familgia"
+    - "familia"
+    - "fmaiglia"
+    - "fmiglia"
     replace: "famiglia"
     propagate_case: true
     word: true
 
-  - trigger: "faiglia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "faimglia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famgilia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famglia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famigia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famigila"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famigla"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "famiglai"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "familgia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "familia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "fmaiglia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "fmiglia"
-    replace: "famiglia"
-    propagate_case: true
-    word: true
-
-  - trigger: "afnno"
+  - triggers:
+    - "afnno"
+    - "fano"
+    - "fanon"
+    - "fnano"
+    - "fnno"
     replace: "fanno"
     propagate_case: true
     word: true
 
-  - trigger: "fano"
-    replace: "fanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fanon"
-    replace: "fanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnano"
-    replace: "fanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnno"
-    replace: "fanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "afre"
+  - triggers:
+    - "afre"
+    - "faer"
+    - "frae"
     replace: "fare"
     propagate_case: true
     word: true
 
-  - trigger: "faer"
-    replace: "fare"
-    propagate_case: true
-    word: true
-
-  - trigger: "frae"
-    replace: "fare"
-    propagate_case: true
-    word: true
-
-  - trigger: "afte"
+  - triggers:
+    - "afte"
+    - "faet"
+    - "ftae"
     replace: "fate"
     propagate_case: true
     word: true
 
-  - trigger: "faet"
-    replace: "fate"
-    propagate_case: true
-    word: true
-
-  - trigger: "ftae"
-    replace: "fate"
-    propagate_case: true
-    word: true
-
-  - trigger: "aftto"
+  - triggers:
+    - "aftto"
+    - "fato"
+    - "fatot"
+    - "ftato"
+    - "ftto"
     replace: "fatto"
     propagate_case: true
     word: true
 
-  - trigger: "fato"
-    replace: "fatto"
-    propagate_case: true
-    word: true
-
-  - trigger: "fatot"
-    replace: "fatto"
-    propagate_case: true
-    word: true
-
-  - trigger: "ftato"
-    replace: "fatto"
-    propagate_case: true
-    word: true
-
-  - trigger: "ftto"
-    replace: "fatto"
-    propagate_case: true
-    word: true
-
-  - trigger: "fgilia"
+  - triggers:
+    - "fgilia"
+    - "fglia"
+    - "figia"
+    - "figila"
+    - "figla"
+    - "figlai"
+    - "filgia"
+    - "filia"
+    - "ifglia"
     replace: "figlia"
     propagate_case: true
     word: true
 
-  - trigger: "fglia"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "figia"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "figila"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "figla"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "figlai"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "filgia"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "filia"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifglia"
-    replace: "figlia"
-    propagate_case: true
-    word: true
-
-  - trigger: "fgilio"
+  - triggers:
+    - "fgilio"
+    - "fglio"
+    - "figilo"
+    - "figio"
+    - "figlo"
+    - "figloi"
+    - "filgio"
+    - "filio"
+    - "ifglio"
     replace: "figlio"
     propagate_case: true
     word: true
 
-  - trigger: "fglio"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "figilo"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "figio"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "figlo"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "figloi"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "filgio"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "filio"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifglio"
-    replace: "figlio"
-    propagate_case: true
-    word: true
-
-  - trigger: "fiinre"
+  - triggers:
+    - "fiinre"
+    - "fiire"
+    - "finie"
+    - "finier"
+    - "finre"
+    - "finrie"
+    - "fniire"
+    - "fnire"
+    - "ifnire"
     replace: "finire"
     propagate_case: true
     word: true
 
-  - trigger: "fiire"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "finie"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "finier"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "finre"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "finrie"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "fniire"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnire"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifnire"
-    replace: "finire"
-    propagate_case: true
-    word: true
-
-  - trigger: "fore"
+  - triggers:
+    - "fore"
+    - "fores"
+    - "fose"
+    - "fosre"
+    - "frose"
+    - "frse"
+    - "ofrse"
     replace: "forse"
     propagate_case: true
     word: true
 
-  - trigger: "fores"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "fose"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "fosre"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "frose"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "frse"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "ofrse"
-    replace: "forse"
-    propagate_case: true
-    word: true
-
-  - trigger: "far"
+  - triggers:
+    - "far"
+    - "rfa"
     replace: "fra"
     propagate_case: true
     word: true
 
-  - trigger: "rfa"
-    replace: "fra"
-    propagate_case: true
-    word: true
-
-  - trigger: "fartello"
+  - triggers:
+    - "fartello"
+    - "fatello"
+    - "fraello"
+    - "fraetllo"
+    - "fratelo"
+    - "fratelol"
+    - "fratlelo"
+    - "fratllo"
+    - "frtaello"
+    - "frtello"
+    - "rfatello"
     replace: "fratello"
     propagate_case: true
     word: true
 
-  - trigger: "fatello"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraello"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fraetllo"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fratelo"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fratelol"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fratlelo"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fratllo"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "frtaello"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "frtello"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "rfatello"
-    replace: "fratello"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnuziona"
+  - triggers:
+    - "fnuziona"
+    - "fnziona"
+    - "funiona"
+    - "funizona"
+    - "funzina"
+    - "funzinoa"
+    - "funzioa"
+    - "funzioan"
+    - "funzoina"
+    - "funzona"
+    - "fuziona"
+    - "fuzniona"
+    - "ufnziona"
     replace: "funziona"
     propagate_case: true
     word: true
 
-  - trigger: "fnziona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funiona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funizona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzina"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzinoa"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioa"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioan"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzoina"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuziona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuzniona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "ufnziona"
-    replace: "funziona"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnuzionamento"
+  - triggers:
+    - "fnuzionamento"
+    - "fnzionamento"
+    - "funionamento"
+    - "funizonamento"
+    - "funzinamento"
+    - "funzinoamento"
+    - "funzioamento"
+    - "funzioanmento"
+    - "funzionaemnto"
+    - "funzionaento"
+    - "funzionameno"
+    - "funzionamenot"
+    - "funzionametno"
+    - "funzionameto"
+    - "funzionamneto"
+    - "funzionamnto"
+    - "funzionmaento"
+    - "funzionmento"
+    - "funzoinamento"
+    - "funzonamento"
+    - "fuzionamento"
+    - "fuznionamento"
+    - "ufnzionamento"
     replace: "funzionamento"
     propagate_case: true
     word: true
 
-  - trigger: "fnzionamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funionamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funizonamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzinamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzinoamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioanmento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionaemnto"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionaento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionameno"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionamenot"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionametno"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionameto"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionamneto"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionamnto"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionmaento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionmento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzoinamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzonamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuzionamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuznionamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "ufnzionamento"
-    replace: "funzionamento"
-    propagate_case: true
-    word: true
-
-  - trigger: "fnuzionare"
+  - triggers:
+    - "fnuzionare"
+    - "fnzionare"
+    - "funionare"
+    - "funizonare"
+    - "funzinare"
+    - "funzinoare"
+    - "funzioanre"
+    - "funzioare"
+    - "funzionae"
+    - "funzionaer"
+    - "funzionrae"
+    - "funzionre"
+    - "funzoinare"
+    - "funzonare"
+    - "fuzionare"
+    - "fuznionare"
+    - "ufnzionare"
     replace: "funzionare"
     propagate_case: true
     word: true
 
-  - trigger: "fnzionare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funionare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funizonare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzinare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzinoare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioanre"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzioare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionae"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionaer"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionrae"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzionre"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzoinare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "funzonare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuzionare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuznionare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "ufnzionare"
-    replace: "funzionare"
-    propagate_case: true
-    word: true
-
-  - trigger: "fori"
+  - triggers:
+    - "fori"
+    - "fouri"
+    - "fuoi"
+    - "fuoir"
+    - "furi"
+    - "furoi"
+    - "ufori"
     replace: "fuori"
     propagate_case: true
     word: true
 
-  - trigger: "fouri"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuoi"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "fuoir"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "furi"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "furoi"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "ufori"
-    replace: "fuori"
-    propagate_case: true
-    word: true
-
-  - trigger: "gicare"
+  - triggers:
+    - "gicare"
+    - "gicoare"
+    - "gioacre"
+    - "gioare"
+    - "giocae"
+    - "giocaer"
+    - "giocrae"
+    - "giocre"
+    - "gocare"
+    - "goicare"
+    - "igocare"
     replace: "giocare"
     propagate_case: true
     word: true
 
-  - trigger: "gicoare"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "gioacre"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "gioare"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "giocae"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "giocaer"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "giocrae"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "giocre"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "gocare"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "goicare"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "igocare"
-    replace: "giocare"
-    propagate_case: true
-    word: true
-
-  - trigger: "giono"
+  - triggers:
+    - "giono"
+    - "gionro"
+    - "gioro"
+    - "gioron"
+    - "girno"
+    - "girono"
+    - "goirno"
+    - "gorno"
+    - "igorno"
     replace: "giorno"
     propagate_case: true
     word: true
 
-  - trigger: "gionro"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gioro"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gioron"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "girno"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "girono"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "goirno"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gorno"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "igorno"
-    replace: "giorno"
-    propagate_case: true
-    word: true
-
-  - trigger: "gioane"
+  - triggers:
+    - "gioane"
+    - "gioavne"
+    - "giovae"
+    - "giovaen"
+    - "giovnae"
+    - "giovne"
+    - "givane"
+    - "givoane"
+    - "goivane"
+    - "govane"
+    - "igovane"
     replace: "giovane"
     propagate_case: true
     word: true
 
-  - trigger: "gioavne"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "giovae"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "giovaen"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "giovnae"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "giovne"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "givane"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "givoane"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "goivane"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "govane"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "igovane"
-    replace: "giovane"
-    propagate_case: true
-    word: true
-
-  - trigger: "gil"
+  - triggers:
+    - "gil"
+    - "lgi"
     replace: "gli"
     propagate_case: true
     word: true
 
-  - trigger: "lgi"
-    replace: "gli"
-    propagate_case: true
-    word: true
-
-  - trigger: "gande"
+  - triggers:
+    - "gande"
+    - "garnde"
+    - "grade"
+    - "gradne"
+    - "grane"
+    - "graned"
+    - "grnade"
+    - "grnde"
+    - "rgande"
     replace: "grande"
     propagate_case: true
     word: true
 
-  - trigger: "garnde"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "grade"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "gradne"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "grane"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "graned"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "grnade"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "grnde"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgande"
-    replace: "grande"
-    propagate_case: true
-    word: true
-
-  - trigger: "garzie"
+  - triggers:
+    - "garzie"
+    - "gazie"
+    - "graie"
+    - "graize"
+    - "graze"
+    - "grazei"
+    - "grzaie"
+    - "grzie"
+    - "rgazie"
     replace: "grazie"
     propagate_case: true
     word: true
 
-  - trigger: "gazie"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "graie"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "graize"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "graze"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "grazei"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "grzaie"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "grzie"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgazie"
-    replace: "grazie"
-    propagate_case: true
-    word: true
-
-  - trigger: "ahi"
+  - triggers:
+    - "ahi"
+    - "hia"
     replace: "hai"
     propagate_case: true
     word: true
 
-  - trigger: "hia"
-    replace: "hai"
-    propagate_case: true
-    word: true
-
-  - trigger: "ahnno"
+  - triggers:
+    - "ahnno"
+    - "hano"
+    - "hanon"
+    - "hnano"
+    - "hnno"
     replace: "hanno"
     propagate_case: true
     word: true
 
-  - trigger: "hano"
-    replace: "hanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "hanon"
-    replace: "hanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "hnano"
-    replace: "hanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "hnno"
-    replace: "hanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "eiri"
+  - triggers:
+    - "eiri"
+    - "ieir"
+    - "irei"
     replace: "ieri"
     propagate_case: true
     word: true
 
-  - trigger: "ieir"
-    replace: "ieri"
-    propagate_case: true
-    word: true
-
-  - trigger: "irei"
-    replace: "ieri"
-    propagate_case: true
-    word: true
-
-  - trigger: "imoprtante"
+  - triggers:
+    - "imoprtante"
+    - "imortante"
+    - "imporante"
+    - "imporatnte"
+    - "importane"
+    - "importanet"
+    - "importate"
+    - "importatne"
+    - "importnate"
+    - "importnte"
+    - "impotante"
+    - "impotrante"
+    - "improtante"
+    - "imprtante"
+    - "ipmortante"
+    - "iportante"
+    - "miportante"
     replace: "importante"
     propagate_case: true
     word: true
 
-  - trigger: "imortante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "imporante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "imporatnte"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importane"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importanet"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importate"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importatne"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importnate"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "importnte"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "impotante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "impotrante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "improtante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "imprtante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmortante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "iportante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "miportante"
-    replace: "importante"
-    propagate_case: true
-    word: true
-
-  - trigger: "imopssibile"
+  - triggers:
+    - "imopssibile"
+    - "imossibile"
+    - "imposibile"
+    - "imposisbile"
+    - "impossbiile"
+    - "impossbile"
+    - "impossibie"
+    - "impossibiel"
+    - "impossible"
+    - "impossiblie"
+    - "impossiible"
+    - "impossiile"
+    - "impsosibile"
+    - "impssibile"
+    - "ipmossibile"
+    - "ipossibile"
+    - "mipossibile"
     replace: "impossibile"
     propagate_case: true
     word: true
 
-  - trigger: "imossibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "imposibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "imposisbile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossbiile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossbile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossibie"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossibiel"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossible"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossiblie"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossiible"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impossiile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impsosibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "impssibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipmossibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipossibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "mipossibile"
-    replace: "impossibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifatti"
+  - triggers:
+    - "ifatti"
+    - "ifnatti"
+    - "inaftti"
+    - "inatti"
+    - "infati"
+    - "infatit"
+    - "inftati"
+    - "inftti"
+    - "nifatti"
     replace: "infatti"
     propagate_case: true
     word: true
 
-  - trigger: "ifnatti"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "inaftti"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "inatti"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "infati"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "infatit"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "inftati"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "inftti"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "nifatti"
-    replace: "infatti"
-    propagate_case: true
-    word: true
-
-  - trigger: "ifnormazione"
+  - triggers:
+    - "ifnormazione"
+    - "iformazione"
+    - "infomazione"
+    - "infomrazione"
+    - "inforamzione"
+    - "inforazione"
+    - "informaione"
+    - "informaizone"
+    - "informazine"
+    - "informazinoe"
+    - "informazioe"
+    - "informazioen"
+    - "informazoine"
+    - "informazone"
+    - "informzaione"
+    - "informzione"
+    - "infrmazione"
+    - "infromazione"
+    - "inofrmazione"
+    - "inormazione"
+    - "niformazione"
     replace: "informazione"
     propagate_case: true
     word: true
 
-  - trigger: "iformazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "infomazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "infomrazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "inforamzione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "inforazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informaione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informaizone"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazine"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazinoe"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazioe"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazioen"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazoine"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informazone"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informzaione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "informzione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "infrmazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "infromazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "inofrmazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "inormazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "niformazione"
-    replace: "informazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "iinziare"
+  - triggers:
+    - "iinziare"
+    - "iiziare"
+    - "iniiare"
+    - "iniizare"
+    - "inizaire"
+    - "inizare"
+    - "iniziae"
+    - "iniziaer"
+    - "inizirae"
+    - "inizire"
+    - "inziare"
+    - "inziiare"
+    - "niiziare"
     replace: "iniziare"
     propagate_case: true
     word: true
 
-  - trigger: "iiziare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniiare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniizare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizaire"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziae"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "iniziaer"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizirae"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inizire"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inziare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inziiare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "niiziare"
-    replace: "iniziare"
-    propagate_case: true
-    word: true
-
-  - trigger: "inlotre"
+  - triggers:
+    - "inlotre"
+    - "inltre"
+    - "inolre"
+    - "inolrte"
+    - "inolte"
+    - "inolter"
+    - "inotlre"
+    - "inotre"
+    - "ioltre"
+    - "ionltre"
+    - "nioltre"
     replace: "inoltre"
     propagate_case: true
     word: true
 
-  - trigger: "inltre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inolre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inolrte"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inolte"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inolter"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inotlre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inotre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "ioltre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "ionltre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "nioltre"
-    replace: "inoltre"
-    propagate_case: true
-    word: true
-
-  - trigger: "inieme"
+  - triggers:
+    - "inieme"
+    - "iniseme"
+    - "inseime"
+    - "inseme"
+    - "insiee"
+    - "insieem"
+    - "insime"
+    - "insimee"
+    - "isieme"
+    - "isnieme"
+    - "nisieme"
     replace: "insieme"
     propagate_case: true
     word: true
 
-  - trigger: "iniseme"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseime"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "inseme"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "insiee"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "insieem"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "insime"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "insimee"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "isieme"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "isnieme"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "nisieme"
-    replace: "insieme"
-    propagate_case: true
-    word: true
-
-  - trigger: "alrgo"
+  - triggers:
+    - "alrgo"
+    - "lago"
+    - "lagro"
+    - "laro"
+    - "larog"
+    - "lrago"
+    - "lrgo"
     replace: "largo"
     propagate_case: true
     word: true
 
-  - trigger: "lago"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lagro"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "laro"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "larog"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lrago"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lrgo"
-    replace: "largo"
-    propagate_case: true
-    word: true
-
-  - trigger: "alsciare"
+  - triggers:
+    - "alsciare"
+    - "laciare"
+    - "lacsiare"
+    - "lascaire"
+    - "lascare"
+    - "lasciae"
+    - "lasciaer"
+    - "lascirae"
+    - "lascire"
+    - "lasiare"
+    - "lasicare"
+    - "lsaciare"
+    - "lsciare"
     replace: "lasciare"
     propagate_case: true
     word: true
 
-  - trigger: "laciare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lacsiare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lascaire"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lascare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lasciae"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lasciaer"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lascirae"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lascire"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lasiare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lasicare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lsaciare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lsciare"
-    replace: "lasciare"
-    propagate_case: true
-    word: true
-
-  - trigger: "alvorare"
+  - triggers:
+    - "alvorare"
+    - "laorare"
+    - "laovrare"
+    - "lavoare"
+    - "lavoarre"
+    - "lavorae"
+    - "lavoraer"
+    - "lavorrae"
+    - "lavorre"
+    - "lavrare"
+    - "lavroare"
+    - "lvaorare"
+    - "lvorare"
     replace: "lavorare"
     propagate_case: true
     word: true
 
-  - trigger: "laorare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "laovrare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoarre"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorae"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoraer"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorrae"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavorre"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavrare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavroare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvaorare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvorare"
-    replace: "lavorare"
-    propagate_case: true
-    word: true
-
-  - trigger: "alvoro"
+  - triggers:
+    - "alvoro"
+    - "laoro"
+    - "laovro"
+    - "lavoo"
+    - "lavoor"
+    - "lavro"
+    - "lavroo"
+    - "lvaoro"
+    - "lvoro"
     replace: "lavoro"
     propagate_case: true
     word: true
 
-  - trigger: "laoro"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "laovro"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoo"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavoor"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavro"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lavroo"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvaoro"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "lvoro"
-    replace: "lavoro"
-    propagate_case: true
-    word: true
-
-  - trigger: "elggere"
+  - triggers:
+    - "elggere"
+    - "legegre"
+    - "legere"
+    - "leggee"
+    - "leggeer"
+    - "leggre"
+    - "leggree"
+    - "lgegere"
+    - "lggere"
     replace: "leggere"
     propagate_case: true
     word: true
 
-  - trigger: "legegre"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "legere"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggee"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggeer"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggre"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "leggree"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "lgegere"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "lggere"
-    replace: "leggere"
-    propagate_case: true
-    word: true
-
-  - trigger: "eli"
+  - triggers:
+    - "eli"
+    - "lie"
     replace: "lei"
     propagate_case: true
     word: true
 
-  - trigger: "lie"
-    replace: "lei"
-    propagate_case: true
-    word: true
-
-  - trigger: "lnotano"
+  - triggers:
+    - "lnotano"
+    - "lntano"
+    - "lonano"
+    - "lonatno"
+    - "lontao"
+    - "lontaon"
+    - "lontnao"
+    - "lontno"
+    - "lotano"
+    - "lotnano"
+    - "olntano"
     replace: "lontano"
     propagate_case: true
     word: true
 
-  - trigger: "lntano"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lonano"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lonatno"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lontao"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lontaon"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lontnao"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lontno"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lotano"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "lotnano"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "olntano"
-    replace: "lontano"
-    propagate_case: true
-    word: true
-
-  - trigger: "loor"
+  - triggers:
+    - "loor"
+    - "lroo"
+    - "olro"
     replace: "loro"
     propagate_case: true
     word: true
 
-  - trigger: "lroo"
-    replace: "loro"
-    propagate_case: true
-    word: true
-
-  - trigger: "olro"
-    replace: "loro"
-    propagate_case: true
-    word: true
-
-  - trigger: "liu"
+  - triggers:
+    - "liu"
+    - "uli"
     replace: "lui"
     propagate_case: true
     word: true
 
-  - trigger: "uli"
-    replace: "lui"
-    propagate_case: true
-    word: true
-
-  - trigger: "lngo"
+  - triggers:
+    - "lngo"
+    - "lnugo"
+    - "lugno"
+    - "lugo"
+    - "luno"
+    - "lunog"
+    - "ulngo"
     replace: "lungo"
     propagate_case: true
     word: true
 
-  - trigger: "lnugo"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lugno"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lugo"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "luno"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "lunog"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ulngo"
-    replace: "lungo"
-    propagate_case: true
-    word: true
-
-  - trigger: "amdre"
+  - triggers:
+    - "amdre"
+    - "made"
+    - "mader"
+    - "marde"
+    - "mare"
+    - "mdare"
+    - "mdre"
     replace: "madre"
     propagate_case: true
     word: true
 
-  - trigger: "made"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "mader"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "marde"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "mare"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "mdare"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "mdre"
-    replace: "madre"
-    propagate_case: true
-    word: true
-
-  - trigger: "ami"
+  - triggers:
+    - "ami"
     replace: "mai"
     propagate_case: true
     word: true
 
-  - trigger: "amle"
+  - triggers:
+    - "amle"
+    - "mael"
+    - "mlae"
     replace: "male"
     propagate_case: true
     word: true
 
-  - trigger: "mael"
-    replace: "male"
-    propagate_case: true
-    word: true
-
-  - trigger: "mlae"
-    replace: "male"
-    propagate_case: true
-    word: true
-
-  - trigger: "amngiare"
+  - triggers:
+    - "amngiare"
+    - "magiare"
+    - "magniare"
+    - "mangaire"
+    - "mangare"
+    - "mangiae"
+    - "mangiaer"
+    - "mangirae"
+    - "mangire"
+    - "maniare"
+    - "manigare"
+    - "mnagiare"
+    - "mngiare"
     replace: "mangiare"
     propagate_case: true
     word: true
 
-  - trigger: "magiare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "magniare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangaire"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangiae"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangiaer"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangirae"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mangire"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "maniare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "manigare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnagiare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "mngiare"
-    replace: "mangiare"
-    propagate_case: true
-    word: true
-
-  - trigger: "amno"
+  - triggers:
+    - "amno"
+    - "maon"
+    - "mnao"
     replace: "mano"
     propagate_case: true
     word: true
 
-  - trigger: "maon"
-    replace: "mano"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnao"
-    replace: "mano"
-    propagate_case: true
-    word: true
-
-  - trigger: "emglio"
+  - triggers:
+    - "emglio"
+    - "megilo"
+    - "megio"
+    - "meglo"
+    - "megloi"
+    - "melgio"
+    - "melio"
+    - "mgelio"
+    - "mglio"
     replace: "meglio"
     propagate_case: true
     word: true
 
-  - trigger: "megilo"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "megio"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "meglo"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "megloi"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "melgio"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "melio"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "mgelio"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "mglio"
-    replace: "meglio"
-    propagate_case: true
-    word: true
-
-  - trigger: "emse"
+  - triggers:
+    - "emse"
+    - "mees"
+    - "msee"
     replace: "mese"
     propagate_case: true
     word: true
 
-  - trigger: "mees"
-    replace: "mese"
-    propagate_case: true
-    word: true
-
-  - trigger: "msee"
-    replace: "mese"
-    propagate_case: true
-    word: true
-
-  - trigger: "emssaggio"
+  - triggers:
+    - "emssaggio"
+    - "mesaggio"
+    - "mesasggio"
+    - "messaggo"
+    - "messaggoi"
+    - "messagigo"
+    - "messagio"
+    - "messgagio"
+    - "messggio"
+    - "msesaggio"
+    - "mssaggio"
     replace: "messaggio"
     propagate_case: true
     word: true
 
-  - trigger: "mesaggio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "mesasggio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messaggo"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messaggoi"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messagigo"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messagio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messgagio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "messggio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "msesaggio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "mssaggio"
-    replace: "messaggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "emttere"
+  - triggers:
+    - "emttere"
+    - "metere"
+    - "metetre"
+    - "mettee"
+    - "metteer"
+    - "mettre"
+    - "mettree"
+    - "mtetere"
+    - "mttere"
     replace: "mettere"
     propagate_case: true
     word: true
 
-  - trigger: "metere"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "metetre"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettee"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "metteer"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettre"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "mettree"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "mtetere"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "mttere"
-    replace: "mettere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ima"
+  - triggers:
+    - "ima"
     replace: "mia"
     propagate_case: true
     word: true
 
-  - trigger: "ime"
+  - triggers:
+    - "ime"
+    - "mei"
     replace: "mie"
     propagate_case: true
     word: true
 
-  - trigger: "mei"
-    replace: "mie"
-    propagate_case: true
-    word: true
-
-  - trigger: "imei"
+  - triggers:
+    - "imei"
+    - "meii"
+    - "miie"
     replace: "miei"
     propagate_case: true
     word: true
 
-  - trigger: "meii"
-    replace: "miei"
-    propagate_case: true
-    word: true
-
-  - trigger: "miie"
-    replace: "miei"
-    propagate_case: true
-    word: true
-
-  - trigger: "imglioramento"
+  - triggers:
+    - "imglioramento"
+    - "mgilioramento"
+    - "mglioramento"
+    - "migiloramento"
+    - "migioramento"
+    - "miglioamento"
+    - "miglioarmento"
+    - "miglioraemnto"
+    - "miglioraento"
+    - "migliorameno"
+    - "miglioramenot"
+    - "migliorametno"
+    - "migliorameto"
+    - "miglioramneto"
+    - "miglioramnto"
+    - "migliormaento"
+    - "migliormento"
+    - "migliramento"
+    - "migliroamento"
+    - "migloiramento"
+    - "migloramento"
+    - "milgioramento"
+    - "milioramento"
     replace: "miglioramento"
     propagate_case: true
     word: true
 
-  - trigger: "mgilioramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "mglioramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migiloramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migioramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioamento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioarmento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioraemnto"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioraento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliorameno"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioramenot"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliorametno"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliorameto"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioramneto"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "miglioramnto"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliormaento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliormento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migliroamento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migloiramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "migloramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "milgioramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "milioramento"
-    replace: "miglioramento"
-    propagate_case: true
-    word: true
-
-  - trigger: "imnuto"
+  - triggers:
+    - "imnuto"
+    - "minto"
+    - "mintuo"
+    - "minuo"
+    - "minuot"
+    - "miunto"
+    - "miuto"
+    - "mniuto"
+    - "mnuto"
     replace: "minuto"
     propagate_case: true
     word: true
 
-  - trigger: "minto"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "mintuo"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "minuo"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "minuot"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "miunto"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "miuto"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "mniuto"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "mnuto"
-    replace: "minuto"
-    propagate_case: true
-    word: true
-
-  - trigger: "imo"
+  - triggers:
+    - "imo"
+    - "moi"
     replace: "mio"
     propagate_case: true
     word: true
 
-  - trigger: "moi"
-    replace: "mio"
-    propagate_case: true
-    word: true
-
-  - trigger: "mdoo"
+  - triggers:
+    - "mdoo"
+    - "mood"
+    - "omdo"
     replace: "modo"
     propagate_case: true
     word: true
 
-  - trigger: "mood"
-    replace: "modo"
-    propagate_case: true
-    word: true
-
-  - trigger: "omdo"
-    replace: "modo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mloto"
+  - triggers:
+    - "mloto"
+    - "mlto"
+    - "molo"
+    - "molot"
+    - "motlo"
+    - "moto"
+    - "omlto"
     replace: "molto"
     propagate_case: true
     word: true
 
-  - trigger: "mlto"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "molo"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "molot"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "motlo"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "moto"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "omlto"
-    replace: "molto"
-    propagate_case: true
-    word: true
-
-  - trigger: "mmento"
+  - triggers:
+    - "mmento"
+    - "mmoento"
+    - "moemnto"
+    - "moento"
+    - "momeno"
+    - "momenot"
+    - "mometno"
+    - "mometo"
+    - "momneto"
+    - "momnto"
+    - "ommento"
     replace: "momento"
     propagate_case: true
     word: true
 
-  - trigger: "mmoento"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "moemnto"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "moento"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "momeno"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "momenot"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "mometno"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "mometo"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "momneto"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "momnto"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "ommento"
-    replace: "momento"
-    propagate_case: true
-    word: true
-
-  - trigger: "mndo"
+  - triggers:
+    - "mndo"
+    - "mnodo"
+    - "modno"
+    - "mono"
+    - "monod"
+    - "omndo"
     replace: "mondo"
     propagate_case: true
     word: true
 
-  - trigger: "mnodo"
-    replace: "mondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "modno"
-    replace: "mondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "mono"
-    replace: "mondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "monod"
-    replace: "mondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "omndo"
-    replace: "mondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "encessario"
+  - triggers:
+    - "encessario"
+    - "nceessario"
+    - "ncessario"
+    - "necesario"
+    - "necesasrio"
+    - "necessaio"
+    - "necessairo"
+    - "necessaro"
+    - "necessaroi"
+    - "necessraio"
+    - "necessrio"
+    - "necsesario"
+    - "necssario"
+    - "neecssario"
+    - "neessario"
     replace: "necessario"
     propagate_case: true
     word: true
 
-  - trigger: "nceessario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "ncessario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necesario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necesasrio"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessaio"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessairo"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessaro"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessaroi"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessraio"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessrio"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necsesario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "necssario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "neecssario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "neessario"
-    replace: "necessario"
-    propagate_case: true
-    word: true
-
-  - trigger: "encessita"
+  - triggers:
+    - "encessita"
+    - "nceessita"
+    - "ncessita"
+    - "necesista"
+    - "necesita"
+    - "necessia"
+    - "necessiat"
+    - "necessta"
+    - "necesstia"
+    - "necsesita"
+    - "necssita"
+    - "neecssita"
+    - "neessita"
     replace: "necessita"
     propagate_case: true
     word: true
 
-  - trigger: "nceessita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "ncessita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necesista"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necesita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessia"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessiat"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necessta"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necesstia"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necsesita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "necssita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "neecssita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "neessita"
-    replace: "necessita"
-    propagate_case: true
-    word: true
-
-  - trigger: "enssuno"
+  - triggers:
+    - "enssuno"
+    - "nessno"
+    - "nessnuo"
+    - "nessuo"
+    - "nessuon"
+    - "nesuno"
+    - "nesusno"
+    - "nsesuno"
+    - "nssuno"
     replace: "nessuno"
     propagate_case: true
     word: true
 
-  - trigger: "nessno"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nessnuo"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nessuo"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nessuon"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nesuno"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nesusno"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsesuno"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nssuno"
-    replace: "nessuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "nio"
+  - triggers:
+    - "nio"
+    - "oni"
     replace: "noi"
     propagate_case: true
     word: true
 
-  - trigger: "oni"
-    replace: "noi"
-    propagate_case: true
-    word: true
-
-  - trigger: "nmoe"
+  - triggers:
+    - "nmoe"
+    - "noem"
+    - "onme"
     replace: "nome"
     propagate_case: true
     word: true
 
-  - trigger: "noem"
-    replace: "nome"
-    propagate_case: true
-    word: true
-
-  - trigger: "onme"
-    replace: "nome"
-    propagate_case: true
-    word: true
-
-  - trigger: "nno"
+  - triggers:
+    - "nno"
+    - "onn"
     replace: "non"
     propagate_case: true
     word: true
 
-  - trigger: "onn"
-    replace: "non"
-    propagate_case: true
-    word: true
-
-  - trigger: "nnoostante"
+  - triggers:
+    - "nnoostante"
+    - "nnostante"
+    - "nonosante"
+    - "nonosatnte"
+    - "nonostane"
+    - "nonostanet"
+    - "nonostate"
+    - "nonostatne"
+    - "nonostnate"
+    - "nonostnte"
+    - "nonotante"
+    - "nonotsante"
+    - "nonsotante"
+    - "nonstante"
+    - "noonstante"
+    - "noostante"
+    - "onnostante"
     replace: "nonostante"
     propagate_case: true
     word: true
 
-  - trigger: "nnostante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonosante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonosatnte"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostane"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostanet"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostate"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostatne"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostnate"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonostnte"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonotante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonotsante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonsotante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nonstante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "noonstante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "noostante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "onnostante"
-    replace: "nonostante"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosra"
+  - triggers:
+    - "nosra"
+    - "nosrta"
+    - "nosta"
+    - "nostar"
+    - "notra"
+    - "notsra"
+    - "nsotra"
+    - "nstra"
+    - "onstra"
     replace: "nostra"
     propagate_case: true
     word: true
 
-  - trigger: "nosrta"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosta"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "nostar"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "notra"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "notsra"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsotra"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "nstra"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "onstra"
-    replace: "nostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosre"
+  - triggers:
+    - "nosre"
+    - "nosrte"
+    - "noste"
+    - "noster"
+    - "notre"
+    - "notsre"
+    - "nsotre"
+    - "nstre"
+    - "onstre"
     replace: "nostre"
     propagate_case: true
     word: true
 
-  - trigger: "nosrte"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "noste"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "noster"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "notre"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "notsre"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsotre"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "nstre"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "onstre"
-    replace: "nostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosri"
+  - triggers:
+    - "nosri"
+    - "nosrti"
+    - "nosti"
+    - "nostir"
+    - "notri"
+    - "notsri"
+    - "nsotri"
+    - "nstri"
+    - "onstri"
     replace: "nostri"
     propagate_case: true
     word: true
 
-  - trigger: "nosrti"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosti"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "nostir"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "notri"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "notsri"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsotri"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "nstri"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "onstri"
-    replace: "nostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosro"
+  - triggers:
+    - "nosro"
+    - "nosrto"
+    - "nosto"
+    - "nostor"
+    - "notro"
+    - "notsro"
+    - "nsotro"
+    - "nstro"
+    - "onstro"
     replace: "nostro"
     propagate_case: true
     word: true
 
-  - trigger: "nosrto"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "nosto"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "nostor"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "notro"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "notsro"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "nsotro"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "nstro"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "onstro"
-    replace: "nostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "nmero"
+  - triggers:
+    - "nmero"
+    - "nmuero"
+    - "nuemro"
+    - "nuero"
+    - "numeo"
+    - "numeor"
+    - "numreo"
+    - "numro"
+    - "unmero"
     replace: "numero"
     propagate_case: true
     word: true
 
-  - trigger: "nmuero"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuemro"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuero"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "numeo"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "numeor"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "numreo"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "numro"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "unmero"
-    replace: "numero"
-    propagate_case: true
-    word: true
-
-  - trigger: "nouva"
+  - triggers:
+    - "nouva"
+    - "nova"
+    - "nuoa"
+    - "nuoav"
+    - "nuva"
+    - "nuvoa"
+    - "unova"
     replace: "nuova"
     propagate_case: true
     word: true
 
-  - trigger: "nova"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuoa"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuoav"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuva"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuvoa"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "unova"
-    replace: "nuova"
-    propagate_case: true
-    word: true
-
-  - trigger: "nouvo"
+  - triggers:
+    - "nouvo"
+    - "novo"
+    - "nuoo"
+    - "nuoov"
+    - "nuvo"
+    - "nuvoo"
+    - "unovo"
     replace: "nuovo"
     propagate_case: true
     word: true
 
-  - trigger: "novo"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuoo"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuoov"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuvo"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuvoo"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "unovo"
-    replace: "nuovo"
-    propagate_case: true
-    word: true
-
-  - trigger: "boiettivo"
+  - triggers:
+    - "boiettivo"
+    - "obeittivo"
+    - "obettivo"
+    - "obietitvo"
+    - "obietivo"
+    - "obiettio"
+    - "obiettiov"
+    - "obiettvio"
+    - "obiettvo"
+    - "obitetivo"
+    - "obittivo"
+    - "oibettivo"
+    - "oiettivo"
     replace: "obiettivo"
     propagate_case: true
     word: true
 
-  - trigger: "obeittivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obettivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obietitvo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obietivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obiettio"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obiettiov"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obiettvio"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obiettvo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obitetivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "obittivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "oibettivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "oiettivo"
-    replace: "obiettivo"
-    propagate_case: true
-    word: true
-
-  - trigger: "cochio"
+  - triggers:
+    - "cochio"
+    - "occho"
+    - "occhoi"
+    - "occiho"
+    - "occio"
+    - "ochcio"
+    - "ochio"
     replace: "occhio"
     propagate_case: true
     word: true
 
-  - trigger: "occho"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "occhoi"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "occiho"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "occio"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "ochcio"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "ochio"
-    replace: "occhio"
-    propagate_case: true
-    word: true
-
-  - trigger: "gogi"
+  - triggers:
+    - "gogi"
+    - "ogi"
+    - "ogig"
     replace: "oggi"
     propagate_case: true
     word: true
 
-  - trigger: "ogi"
-    replace: "oggi"
-    propagate_case: true
-    word: true
-
-  - trigger: "ogig"
-    replace: "oggi"
-    propagate_case: true
-    word: true
-
-  - trigger: "gonuno"
+  - triggers:
+    - "gonuno"
+    - "ognno"
+    - "ognnuo"
+    - "ognuo"
+    - "ognuon"
+    - "ogunno"
+    - "oguno"
+    - "onguno"
+    - "onuno"
     replace: "ognuno"
     propagate_case: true
     word: true
 
-  - trigger: "ognno"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ognnuo"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ognuo"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ognuon"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "ogunno"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oguno"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "onguno"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "onuno"
-    replace: "ognuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oar"
+  - triggers:
+    - "oar"
+    - "roa"
     replace: "ora"
     propagate_case: true
     word: true
 
-  - trigger: "roa"
-    replace: "ora"
-    propagate_case: true
-    word: true
-
-  - trigger: "oganizzare"
+  - triggers:
+    - "oganizzare"
+    - "ogranizzare"
+    - "oragnizzare"
+    - "oranizzare"
+    - "orgainzzare"
+    - "orgaizzare"
+    - "organizare"
+    - "organizazre"
+    - "organizzae"
+    - "organizzaer"
+    - "organizzrae"
+    - "organizzre"
+    - "organzizare"
+    - "organzzare"
+    - "orgnaizzare"
+    - "orgnizzare"
+    - "roganizzare"
     replace: "organizzare"
     propagate_case: true
     word: true
 
-  - trigger: "ogranizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "oragnizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "oranizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgainzzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgaizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizazre"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzae"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzaer"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzrae"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzre"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzizare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnaizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "roganizzare"
-    replace: "organizzare"
-    propagate_case: true
-    word: true
-
-  - trigger: "oganizzazione"
+  - triggers:
+    - "oganizzazione"
+    - "ogranizzazione"
+    - "oragnizzazione"
+    - "oranizzazione"
+    - "orgainzzazione"
+    - "orgaizzazione"
+    - "organizazione"
+    - "organizazzione"
+    - "organizzaione"
+    - "organizzaizone"
+    - "organizzazine"
+    - "organizzazinoe"
+    - "organizzazioe"
+    - "organizzazioen"
+    - "organizzazoine"
+    - "organizzazone"
+    - "organizzzaione"
+    - "organizzzione"
+    - "organzizazione"
+    - "organzzazione"
+    - "orgnaizzazione"
+    - "orgnizzazione"
+    - "roganizzazione"
     replace: "organizzazione"
     propagate_case: true
     word: true
 
-  - trigger: "ogranizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "oragnizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "oranizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgainzzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgaizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizazzione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzaione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzaizone"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazine"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazinoe"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazioe"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazioen"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazoine"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzazone"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzzaione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organizzzione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzizazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "organzzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnaizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "orgnizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "roganizzazione"
-    replace: "organizzazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "apdre"
+  - triggers:
+    - "apdre"
+    - "pade"
+    - "pader"
+    - "parde"
+    - "pare"
+    - "pdare"
+    - "pdre"
     replace: "padre"
     propagate_case: true
     word: true
 
-  - trigger: "pade"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "pader"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "parde"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "pare"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "pdare"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "pdre"
-    replace: "padre"
-    propagate_case: true
-    word: true
-
-  - trigger: "apese"
+  - triggers:
+    - "apese"
+    - "paee"
+    - "paees"
+    - "pase"
+    - "pasee"
+    - "pease"
+    - "pese"
     replace: "paese"
     propagate_case: true
     word: true
 
-  - trigger: "paee"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "paees"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "pase"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "pasee"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "pease"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "pese"
-    replace: "paese"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprlare"
+  - triggers:
+    - "aprlare"
+    - "palare"
+    - "palrare"
+    - "paralre"
+    - "parare"
+    - "parlae"
+    - "parlaer"
+    - "parlrae"
+    - "parlre"
+    - "pralare"
+    - "prlare"
     replace: "parlare"
     propagate_case: true
     word: true
 
-  - trigger: "palare"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "palrare"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "paralre"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "parare"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlae"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlaer"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlrae"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "parlre"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pralare"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "prlare"
-    replace: "parlare"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprola"
+  - triggers:
+    - "aprola"
+    - "paola"
+    - "paorla"
+    - "parla"
+    - "parloa"
+    - "paroa"
+    - "paroal"
+    - "praola"
+    - "prola"
     replace: "parola"
     propagate_case: true
     word: true
 
-  - trigger: "paola"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "paorla"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "parla"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "parloa"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "paroa"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "paroal"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "praola"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "prola"
-    replace: "parola"
-    propagate_case: true
-    word: true
-
-  - trigger: "aprte"
+  - triggers:
+    - "aprte"
+    - "paret"
+    - "pate"
+    - "patre"
+    - "prate"
+    - "prte"
     replace: "parte"
     propagate_case: true
     word: true
 
-  - trigger: "paret"
-    replace: "parte"
-    propagate_case: true
-    word: true
-
-  - trigger: "pate"
-    replace: "parte"
-    propagate_case: true
-    word: true
-
-  - trigger: "patre"
-    replace: "parte"
-    propagate_case: true
-    word: true
-
-  - trigger: "prate"
-    replace: "parte"
-    propagate_case: true
-    word: true
-
-  - trigger: "prte"
-    replace: "parte"
-    propagate_case: true
-    word: true
-
-  - trigger: "epggio"
+  - triggers:
+    - "epggio"
+    - "peggo"
+    - "peggoi"
+    - "pegigo"
+    - "pegio"
+    - "pgegio"
+    - "pggio"
     replace: "peggio"
     propagate_case: true
     word: true
 
-  - trigger: "peggo"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "peggoi"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "pegigo"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "pegio"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "pgegio"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "pggio"
-    replace: "peggio"
-    propagate_case: true
-    word: true
-
-  - trigger: "epnsare"
+  - triggers:
+    - "epnsare"
+    - "penare"
+    - "penasre"
+    - "pensae"
+    - "pensaer"
+    - "pensrae"
+    - "pensre"
+    - "pesare"
+    - "pesnare"
+    - "pnesare"
+    - "pnsare"
     replace: "pensare"
     propagate_case: true
     word: true
 
-  - trigger: "penare"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "penasre"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pensae"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pensaer"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pensrae"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pensre"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pesare"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pesnare"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pnesare"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pnsare"
-    replace: "pensare"
-    propagate_case: true
-    word: true
-
-  - trigger: "epr"
+  - triggers:
+    - "epr"
+    - "pre"
     replace: "per"
     propagate_case: true
     word: true
 
-  - trigger: "pre"
-    replace: "per"
-    propagate_case: true
-    word: true
-
-  - trigger: "ipccolo"
+  - triggers:
+    - "ipccolo"
+    - "pccolo"
+    - "pcicolo"
+    - "picclo"
+    - "piccloo"
+    - "piccoo"
+    - "piccool"
+    - "picoclo"
+    - "picolo"
     replace: "piccolo"
     propagate_case: true
     word: true
 
-  - trigger: "pccolo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pcicolo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "picclo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "piccloo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "piccoo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "piccool"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "picoclo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "picolo"
-    replace: "piccolo"
-    propagate_case: true
-    word: true
-
-  - trigger: "opco"
+  - triggers:
+    - "opco"
+    - "pcoo"
+    - "pooc"
     replace: "poco"
     propagate_case: true
     word: true
 
-  - trigger: "pcoo"
-    replace: "poco"
-    propagate_case: true
-    word: true
-
-  - trigger: "pooc"
-    replace: "poco"
-    propagate_case: true
-    word: true
-
-  - trigger: "opi"
+  - triggers:
+    - "opi"
+    - "pio"
     replace: "poi"
     propagate_case: true
     word: true
 
-  - trigger: "pio"
-    replace: "poi"
-    propagate_case: true
-    word: true
-
-  - trigger: "oprtare"
+  - triggers:
+    - "oprtare"
+    - "porare"
+    - "poratre"
+    - "portae"
+    - "portaer"
+    - "portrae"
+    - "portre"
+    - "potare"
+    - "potrare"
+    - "protare"
+    - "prtare"
     replace: "portare"
     propagate_case: true
     word: true
 
-  - trigger: "porare"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "poratre"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "portae"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "portaer"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "portrae"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "portre"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "potare"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "potrare"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "protare"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "prtare"
-    replace: "portare"
-    propagate_case: true
-    word: true
-
-  - trigger: "opssibile"
+  - triggers:
+    - "opssibile"
+    - "posibile"
+    - "posisbile"
+    - "possbiile"
+    - "possbile"
+    - "possibie"
+    - "possibiel"
+    - "possible"
+    - "possiblie"
+    - "possiible"
+    - "possiile"
+    - "psosibile"
+    - "pssibile"
     replace: "possibile"
     propagate_case: true
     word: true
 
-  - trigger: "posibile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "posisbile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possbiile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possbile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possibie"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possibiel"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possible"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possiblie"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possiible"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "possiile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "psosibile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "pssibile"
-    replace: "possibile"
-    propagate_case: true
-    word: true
-
-  - trigger: "optere"
+  - triggers:
+    - "optere"
+    - "poere"
+    - "poetre"
+    - "potee"
+    - "poteer"
+    - "potre"
+    - "potree"
+    - "ptere"
+    - "ptoere"
     replace: "potere"
     propagate_case: true
     word: true
 
-  - trigger: "poere"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "poetre"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "potee"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "poteer"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "potre"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "potree"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptere"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ptoere"
-    replace: "potere"
-    propagate_case: true
-    word: true
-
-  - trigger: "pego"
+  - triggers:
+    - "pego"
+    - "pergo"
+    - "preo"
+    - "preog"
+    - "prgeo"
+    - "prgo"
+    - "rpego"
     replace: "prego"
     propagate_case: true
     word: true
 
-  - trigger: "pergo"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "preo"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "preog"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "prgeo"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "prgo"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpego"
-    replace: "prego"
-    propagate_case: true
-    word: true
-
-  - trigger: "pendere"
+  - triggers:
+    - "pendere"
+    - "perndere"
+    - "predere"
+    - "prednere"
+    - "prendee"
+    - "prendeer"
+    - "prendre"
+    - "prendree"
+    - "prenedre"
+    - "prenere"
+    - "prndere"
+    - "prnedere"
+    - "rpendere"
     replace: "prendere"
     propagate_case: true
     word: true
 
-  - trigger: "perndere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "predere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prednere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendee"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendeer"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendre"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prendree"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenedre"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prenere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prndere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "prnedere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpendere"
-    replace: "prendere"
-    propagate_case: true
-    word: true
-
-  - trigger: "persentazione"
+  - triggers:
+    - "persentazione"
+    - "pesentazione"
+    - "preentazione"
+    - "preesntazione"
+    - "presenatzione"
+    - "presenazione"
+    - "presentaione"
+    - "presentaizone"
+    - "presentazine"
+    - "presentazinoe"
+    - "presentazioe"
+    - "presentazioen"
+    - "presentazoine"
+    - "presentazone"
+    - "presentzaione"
+    - "presentzione"
+    - "presetazione"
+    - "presetnazione"
+    - "presnetazione"
+    - "presntazione"
+    - "prseentazione"
+    - "prsentazione"
+    - "rpesentazione"
     replace: "presentazione"
     propagate_case: true
     word: true
 
-  - trigger: "pesentazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "preentazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "preesntazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presenatzione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presenazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentaione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentaizone"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazine"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazinoe"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazioe"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazioen"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazoine"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentazone"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentzaione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presentzione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presetazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presetnazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presnetazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "presntazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "prseentazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "prsentazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpesentazione"
-    replace: "presentazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "pima"
+  - triggers:
+    - "pima"
+    - "pirma"
+    - "pria"
+    - "priam"
+    - "prma"
+    - "prmia"
+    - "rpima"
     replace: "prima"
     propagate_case: true
     word: true
 
-  - trigger: "pirma"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "pria"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "priam"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "prma"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmia"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpima"
-    replace: "prima"
-    propagate_case: true
-    word: true
-
-  - trigger: "pimo"
+  - triggers:
+    - "pimo"
+    - "pirmo"
+    - "prio"
+    - "priom"
+    - "prmio"
+    - "prmo"
+    - "rpimo"
     replace: "primo"
     propagate_case: true
     word: true
 
-  - trigger: "pirmo"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prio"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "priom"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmio"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prmo"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpimo"
-    replace: "primo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pobabilmente"
+  - triggers:
+    - "pobabilmente"
+    - "porbabilmente"
+    - "prbabilmente"
+    - "prboabilmente"
+    - "proabbilmente"
+    - "proabilmente"
+    - "probabilemnte"
+    - "probabilente"
+    - "probabilmene"
+    - "probabilmenet"
+    - "probabilmete"
+    - "probabilmetne"
+    - "probabilmnete"
+    - "probabilmnte"
+    - "probabimente"
+    - "probabimlente"
+    - "probablimente"
+    - "probablmente"
+    - "probaiblmente"
+    - "probailmente"
+    - "probbailmente"
+    - "probbilmente"
+    - "rpobabilmente"
     replace: "probabilmente"
     propagate_case: true
     word: true
 
-  - trigger: "porbabilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "prbabilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "prboabilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "proabbilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "proabilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilemnte"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmene"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmenet"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmete"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmetne"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmnete"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabilmnte"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabimente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probabimlente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probablimente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probablmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probaiblmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probailmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probbailmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "probbilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpobabilmente"
-    replace: "probabilmente"
-    propagate_case: true
-    word: true
-
-  - trigger: "poblema"
+  - triggers:
+    - "poblema"
+    - "porblema"
+    - "prblema"
+    - "prbolema"
+    - "probelma"
+    - "probema"
+    - "problea"
+    - "probleam"
+    - "problma"
+    - "problmea"
+    - "prolbema"
+    - "prolema"
+    - "rpoblema"
     replace: "problema"
     propagate_case: true
     word: true
 
-  - trigger: "porblema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "prblema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "prbolema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "probelma"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "probema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "problea"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "probleam"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "problma"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "problmea"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "prolbema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "prolema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoblema"
-    replace: "problema"
-    propagate_case: true
-    word: true
-
-  - trigger: "poblemi"
+  - triggers:
+    - "poblemi"
+    - "porblemi"
+    - "prblemi"
+    - "prbolemi"
+    - "probelmi"
+    - "probemi"
+    - "problei"
+    - "probleim"
+    - "problmei"
+    - "problmi"
+    - "prolbemi"
+    - "prolemi"
+    - "rpoblemi"
     replace: "problemi"
     propagate_case: true
     word: true
 
-  - trigger: "porblemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "prblemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "prbolemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "probelmi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "probemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "problei"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "probleim"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "problmei"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "problmi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "prolbemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "prolemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoblemi"
-    replace: "problemi"
-    propagate_case: true
-    word: true
-
-  - trigger: "pocesso"
+  - triggers:
+    - "pocesso"
+    - "porcesso"
+    - "prcesso"
+    - "prcoesso"
+    - "proceso"
+    - "procesos"
+    - "procseso"
+    - "procsso"
+    - "proecsso"
+    - "proesso"
+    - "rpocesso"
     replace: "processo"
     propagate_case: true
     word: true
 
-  - trigger: "porcesso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prcesso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "prcoesso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proceso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "procesos"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "procseso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "procsso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proecsso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "proesso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpocesso"
-    replace: "processo"
-    propagate_case: true
-    word: true
-
-  - trigger: "pogetto"
+  - triggers:
+    - "pogetto"
+    - "porgetto"
+    - "prgetto"
+    - "prgoetto"
+    - "proegtto"
+    - "proetto"
+    - "progeto"
+    - "progetot"
+    - "progteto"
+    - "progtto"
+    - "rpogetto"
     replace: "progetto"
     propagate_case: true
     word: true
 
-  - trigger: "porgetto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "prgetto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "prgoetto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "proegtto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "proetto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "progeto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "progetot"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "progteto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "progtto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpogetto"
-    replace: "progetto"
-    propagate_case: true
-    word: true
-
-  - trigger: "poprio"
+  - triggers:
+    - "poprio"
+    - "porprio"
+    - "propio"
+    - "propiro"
+    - "propro"
+    - "proproi"
+    - "prorio"
+    - "prorpio"
+    - "prporio"
+    - "prprio"
+    - "rpoprio"
     replace: "proprio"
     propagate_case: true
     word: true
 
-  - trigger: "porprio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "propio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "propiro"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "propro"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "proproi"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "prorio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "prorpio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "prporio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "prprio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpoprio"
-    replace: "proprio"
-    propagate_case: true
-    word: true
-
-  - trigger: "porvare"
+  - triggers:
+    - "porvare"
+    - "povare"
+    - "proare"
+    - "proavre"
+    - "provae"
+    - "provaer"
+    - "provrae"
+    - "provre"
+    - "prvare"
+    - "prvoare"
+    - "rpovare"
     replace: "provare"
     propagate_case: true
     word: true
 
-  - trigger: "povare"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "proare"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "proavre"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "provae"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "provaer"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "provrae"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "provre"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "prvare"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "prvoare"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "rpovare"
-    replace: "provare"
-    propagate_case: true
-    word: true
-
-  - trigger: "pnto"
+  - triggers:
+    - "pnto"
+    - "pnuto"
+    - "puno"
+    - "punot"
+    - "putno"
+    - "puto"
+    - "upnto"
     replace: "punto"
     propagate_case: true
     word: true
 
-  - trigger: "pnuto"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "puno"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "punot"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "putno"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "puto"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "upnto"
-    replace: "punto"
-    propagate_case: true
-    word: true
-
-  - trigger: "qau"
+  - triggers:
+    - "qau"
+    - "uqa"
     replace: "qua"
     propagate_case: true
     word: true
 
-  - trigger: "uqa"
-    replace: "qua"
-    propagate_case: true
-    word: true
-
-  - trigger: "qalcosa"
+  - triggers:
+    - "qalcosa"
+    - "qaulcosa"
+    - "quaclosa"
+    - "quacosa"
+    - "qualcoa"
+    - "qualcoas"
+    - "qualcsa"
+    - "qualcsoa"
+    - "qualocsa"
+    - "qualosa"
+    - "qulacosa"
+    - "qulcosa"
+    - "uqalcosa"
     replace: "qualcosa"
     propagate_case: true
     word: true
 
-  - trigger: "qaulcosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quaclosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quacosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcoa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcoas"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcsa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcsoa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualocsa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulacosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulcosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqalcosa"
-    replace: "qualcosa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qalcuno"
+  - triggers:
+    - "qalcuno"
+    - "qaulcuno"
+    - "quacluno"
+    - "quacuno"
+    - "qualcno"
+    - "qualcnuo"
+    - "qualcuo"
+    - "qualcuon"
+    - "qualucno"
+    - "qualuno"
+    - "qulacuno"
+    - "qulcuno"
+    - "uqalcuno"
     replace: "qualcuno"
     propagate_case: true
     word: true
 
-  - trigger: "qaulcuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "quacluno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "quacuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcnuo"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcuo"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualcuon"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualucno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qualuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulacuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulcuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqalcuno"
-    replace: "qualcuno"
-    propagate_case: true
-    word: true
-
-  - trigger: "qale"
+  - triggers:
+    - "qale"
+    - "qaule"
+    - "quae"
+    - "quael"
+    - "qulae"
+    - "qule"
+    - "uqale"
     replace: "quale"
     propagate_case: true
     word: true
 
-  - trigger: "qaule"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "quae"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "quael"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulae"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "qule"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqale"
-    replace: "quale"
-    propagate_case: true
-    word: true
-
-  - trigger: "qando"
+  - triggers:
+    - "qando"
+    - "qaundo"
+    - "quadno"
+    - "quado"
+    - "quano"
+    - "quanod"
+    - "qunado"
+    - "qundo"
+    - "uqando"
     replace: "quando"
     propagate_case: true
     word: true
 
-  - trigger: "qaundo"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "quadno"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "quado"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "quano"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "quanod"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "qunado"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "qundo"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqando"
-    replace: "quando"
-    propagate_case: true
-    word: true
-
-  - trigger: "qanto"
+  - triggers:
+    - "qanto"
+    - "qaunto"
+    - "quanot"
+    - "quatno"
+    - "quato"
+    - "qunato"
+    - "qunto"
+    - "uqanto"
     replace: "quanto"
     propagate_case: true
     word: true
 
-  - trigger: "qaunto"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "quanot"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "quatno"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "quato"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "qunato"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "qunto"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqanto"
-    replace: "quanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "qasi"
+  - triggers:
+    - "qasi"
+    - "qausi"
+    - "quai"
+    - "quais"
+    - "qusai"
+    - "qusi"
+    - "uqasi"
     replace: "quasi"
     propagate_case: true
     word: true
 
-  - trigger: "qausi"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quai"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quais"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusai"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusi"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqasi"
-    replace: "quasi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qella"
+  - triggers:
+    - "qella"
+    - "qeulla"
+    - "quela"
+    - "quelal"
+    - "qulela"
+    - "qulla"
+    - "uqella"
     replace: "quella"
     propagate_case: true
     word: true
 
-  - trigger: "qeulla"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "quela"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "quelal"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulela"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulla"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqella"
-    replace: "quella"
-    propagate_case: true
-    word: true
-
-  - trigger: "qelle"
+  - triggers:
+    - "qelle"
+    - "qeulle"
+    - "quele"
+    - "quelel"
+    - "qulele"
+    - "qulle"
+    - "uqelle"
     replace: "quelle"
     propagate_case: true
     word: true
 
-  - trigger: "qeulle"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "quele"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "quelel"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulele"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulle"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqelle"
-    replace: "quelle"
-    propagate_case: true
-    word: true
-
-  - trigger: "qelli"
+  - triggers:
+    - "qelli"
+    - "qeulli"
+    - "queli"
+    - "quelil"
+    - "quleli"
+    - "qulli"
+    - "uqelli"
     replace: "quelli"
     propagate_case: true
     word: true
 
-  - trigger: "qeulli"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "queli"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "quelil"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "quleli"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulli"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqelli"
-    replace: "quelli"
-    propagate_case: true
-    word: true
-
-  - trigger: "qello"
+  - triggers:
+    - "qello"
+    - "qeullo"
+    - "quelo"
+    - "quelol"
+    - "qulelo"
+    - "qullo"
+    - "uqello"
     replace: "quello"
     propagate_case: true
     word: true
 
-  - trigger: "qeullo"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "quelo"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "quelol"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "qulelo"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "qullo"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqello"
-    replace: "quello"
-    propagate_case: true
-    word: true
-
-  - trigger: "qesta"
+  - triggers:
+    - "qesta"
+    - "qeusta"
+    - "quesa"
+    - "quesat"
+    - "queta"
+    - "quetsa"
+    - "quseta"
+    - "qusta"
+    - "uqesta"
     replace: "questa"
     propagate_case: true
     word: true
 
-  - trigger: "qeusta"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quesa"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quesat"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "queta"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quetsa"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "quseta"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusta"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqesta"
-    replace: "questa"
-    propagate_case: true
-    word: true
-
-  - trigger: "qeste"
+  - triggers:
+    - "qeste"
+    - "qeuste"
+    - "quese"
+    - "queset"
+    - "quete"
+    - "quetse"
+    - "qusete"
+    - "quste"
+    - "uqeste"
     replace: "queste"
     propagate_case: true
     word: true
 
-  - trigger: "qeuste"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "quese"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "queset"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "quete"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "quetse"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusete"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "quste"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqeste"
-    replace: "queste"
-    propagate_case: true
-    word: true
-
-  - trigger: "qesti"
+  - triggers:
+    - "qesti"
+    - "qeusti"
+    - "quesi"
+    - "quesit"
+    - "queti"
+    - "quetsi"
+    - "quseti"
+    - "qusti"
+    - "uqesti"
     replace: "questi"
     propagate_case: true
     word: true
 
-  - trigger: "qeusti"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quesi"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quesit"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "queti"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quetsi"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quseti"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusti"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqesti"
-    replace: "questi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qesto"
+  - triggers:
+    - "qesto"
+    - "qeusto"
+    - "queso"
+    - "quesot"
+    - "queto"
+    - "quetso"
+    - "quseto"
+    - "qusto"
+    - "uqesto"
     replace: "questo"
     propagate_case: true
     word: true
 
-  - trigger: "qeusto"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "queso"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "quesot"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "queto"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "quetso"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "quseto"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "qusto"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqesto"
-    replace: "questo"
-    propagate_case: true
-    word: true
-
-  - trigger: "qiu"
+  - triggers:
+    - "qiu"
+    - "uqi"
     replace: "qui"
     propagate_case: true
     word: true
 
-  - trigger: "uqi"
-    replace: "qui"
-    propagate_case: true
-    word: true
-
-  - trigger: "qindi"
+  - triggers:
+    - "qindi"
+    - "qiundi"
+    - "quidi"
+    - "quidni"
+    - "quini"
+    - "quinid"
+    - "qundi"
+    - "qunidi"
+    - "uqindi"
     replace: "quindi"
     propagate_case: true
     word: true
 
-  - trigger: "qiundi"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quidi"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quidni"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quini"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "quinid"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qundi"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "qunidi"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "uqindi"
-    replace: "quindi"
-    propagate_case: true
-    word: true
-
-  - trigger: "argazzo"
+  - triggers:
+    - "argazzo"
+    - "raagzzo"
+    - "raazzo"
+    - "ragazo"
+    - "ragazoz"
+    - "ragzazo"
+    - "ragzzo"
+    - "rgaazzo"
+    - "rgazzo"
     replace: "ragazzo"
     propagate_case: true
     word: true
 
-  - trigger: "raagzzo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "raazzo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ragazo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ragazoz"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ragzazo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ragzzo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgaazzo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rgazzo"
-    replace: "ragazzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "erstare"
+  - triggers:
+    - "erstare"
+    - "resare"
+    - "resatre"
+    - "restae"
+    - "restaer"
+    - "restrae"
+    - "restre"
+    - "retare"
+    - "retsare"
+    - "rsetare"
+    - "rstare"
     replace: "restare"
     propagate_case: true
     word: true
 
-  - trigger: "resare"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "resatre"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "restae"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "restaer"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "restrae"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "restre"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "retare"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "retsare"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsetare"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "rstare"
-    replace: "restare"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsposta"
+  - triggers:
+    - "irsposta"
+    - "riposta"
+    - "ripsosta"
+    - "risopsta"
+    - "risosta"
+    - "risposa"
+    - "risposat"
+    - "rispota"
+    - "rispotsa"
+    - "rispsota"
+    - "rispsta"
+    - "rsiposta"
+    - "rsposta"
     replace: "risposta"
     propagate_case: true
     word: true
 
-  - trigger: "riposta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "ripsosta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "risopsta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "risosta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "risposa"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "risposat"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispota"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispotsa"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispsota"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rispsta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiposta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsposta"
-    replace: "risposta"
-    propagate_case: true
-    word: true
-
-  - trigger: "irsultato"
+  - triggers:
+    - "irsultato"
+    - "risltato"
+    - "rislutato"
+    - "risulato"
+    - "risulatto"
+    - "risultao"
+    - "risultaot"
+    - "risulttao"
+    - "risultto"
+    - "risutato"
+    - "risutlato"
+    - "riultato"
+    - "riusltato"
+    - "rsiultato"
+    - "rsultato"
     replace: "risultato"
     propagate_case: true
     word: true
 
-  - trigger: "risltato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "rislutato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risulato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risulatto"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risultao"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risultaot"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risulttao"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risultto"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risutato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "risutlato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "riultato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "riusltato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsiultato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "rsultato"
-    replace: "risultato"
-    propagate_case: true
-    word: true
-
-  - trigger: "aspere"
+  - triggers:
+    - "aspere"
+    - "saepre"
+    - "saere"
+    - "sapee"
+    - "sapeer"
+    - "sapre"
+    - "sapree"
+    - "spaere"
+    - "spere"
     replace: "sapere"
     propagate_case: true
     word: true
 
-  - trigger: "saepre"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "saere"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapee"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapeer"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapre"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "sapree"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "spaere"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "spere"
-    replace: "sapere"
-    propagate_case: true
-    word: true
-
-  - trigger: "csrivere"
+  - triggers:
+    - "csrivere"
+    - "scirvere"
+    - "scivere"
+    - "scriere"
+    - "scrievre"
+    - "scrivee"
+    - "scriveer"
+    - "scrivre"
+    - "scrivree"
+    - "scrvere"
+    - "scrviere"
+    - "srcivere"
+    - "srivere"
     replace: "scrivere"
     propagate_case: true
     word: true
 
-  - trigger: "scirvere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scivere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrievre"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivee"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scriveer"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivre"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrivree"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrvere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "scrviere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "srcivere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "srivere"
-    replace: "scrivere"
-    propagate_case: true
-    word: true
-
-  - trigger: "csuola"
+  - triggers:
+    - "csuola"
+    - "scola"
+    - "scoula"
+    - "scula"
+    - "sculoa"
+    - "scuoa"
+    - "scuoal"
+    - "sucola"
+    - "suola"
     replace: "scuola"
     propagate_case: true
     word: true
 
-  - trigger: "scola"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "scoula"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "scula"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "sculoa"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "scuoa"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "scuoal"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "sucola"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "suola"
-    replace: "scuola"
-    propagate_case: true
-    word: true
-
-  - trigger: "csusa"
+  - triggers:
+    - "csusa"
+    - "scsa"
+    - "scsua"
+    - "scua"
+    - "scuas"
+    - "sucsa"
+    - "susa"
     replace: "scusa"
     propagate_case: true
     word: true
 
-  - trigger: "scsa"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "scsua"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "scua"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "scuas"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "sucsa"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "susa"
-    replace: "scusa"
-    propagate_case: true
-    word: true
-
-  - trigger: "esbbene"
+  - triggers:
+    - "esbbene"
+    - "sbbene"
+    - "sbebene"
+    - "sebbee"
+    - "sebbeen"
+    - "sebbne"
+    - "sebbnee"
+    - "sebebne"
+    - "sebene"
     replace: "sebbene"
     propagate_case: true
     word: true
 
-  - trigger: "sbbene"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sbebene"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebbee"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebbeen"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebbne"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebbnee"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebebne"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "sebene"
-    replace: "sebbene"
-    propagate_case: true
-    word: true
-
-  - trigger: "esconda"
+  - triggers:
+    - "esconda"
+    - "sceonda"
+    - "sconda"
+    - "secnda"
+    - "secnoda"
+    - "secoda"
+    - "secodna"
+    - "secona"
+    - "seconad"
+    - "seocnda"
+    - "seonda"
     replace: "seconda"
     propagate_case: true
     word: true
 
-  - trigger: "sceonda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "sconda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "secnda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "secnoda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "secoda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "secodna"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "secona"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "seconad"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "seocnda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "seonda"
-    replace: "seconda"
-    propagate_case: true
-    word: true
-
-  - trigger: "escondo"
+  - triggers:
+    - "escondo"
+    - "sceondo"
+    - "scondo"
+    - "secndo"
+    - "secnodo"
+    - "secodno"
+    - "secodo"
+    - "secono"
+    - "seconod"
+    - "seocndo"
+    - "seondo"
     replace: "secondo"
     propagate_case: true
     word: true
 
-  - trigger: "sceondo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "scondo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "secndo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "secnodo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "secodno"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "secodo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "secono"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "seconod"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "seocndo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "seondo"
-    replace: "secondo"
-    propagate_case: true
-    word: true
-
-  - trigger: "esi"
+  - triggers:
+    - "esi"
+    - "sie"
     replace: "sei"
     propagate_case: true
     word: true
 
-  - trigger: "sie"
-    replace: "sei"
-    propagate_case: true
-    word: true
-
-  - trigger: "esmpre"
+  - triggers:
+    - "esmpre"
+    - "sempe"
+    - "semper"
+    - "semre"
+    - "semrpe"
+    - "sepmre"
+    - "sepre"
+    - "smepre"
+    - "smpre"
     replace: "sempre"
     propagate_case: true
     word: true
 
-  - trigger: "sempe"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "semper"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "semre"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "semrpe"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "sepmre"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "sepre"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "smepre"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "smpre"
-    replace: "sempre"
-    propagate_case: true
-    word: true
-
-  - trigger: "esntire"
+  - triggers:
+    - "esntire"
+    - "senire"
+    - "senitre"
+    - "sentie"
+    - "sentier"
+    - "sentre"
+    - "sentrie"
+    - "setire"
+    - "setnire"
+    - "snetire"
+    - "sntire"
     replace: "sentire"
     propagate_case: true
     word: true
 
-  - trigger: "senire"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "senitre"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentie"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentier"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentre"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "sentrie"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "setire"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "setnire"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "snetire"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "sntire"
-    replace: "sentire"
-    propagate_case: true
-    word: true
-
-  - trigger: "esnza"
+  - triggers:
+    - "esnza"
+    - "sena"
+    - "senaz"
+    - "seza"
+    - "sezna"
+    - "sneza"
+    - "snza"
     replace: "senza"
     propagate_case: true
     word: true
 
-  - trigger: "sena"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "senaz"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "seza"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "sezna"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "sneza"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "snza"
-    replace: "senza"
-    propagate_case: true
-    word: true
-
-  - trigger: "esrvizio"
+  - triggers:
+    - "esrvizio"
+    - "serivzio"
+    - "serizio"
+    - "serviio"
+    - "serviizo"
+    - "servizo"
+    - "servizoi"
+    - "servziio"
+    - "servzio"
+    - "sevizio"
+    - "sevrizio"
+    - "srevizio"
+    - "srvizio"
     replace: "servizio"
     propagate_case: true
     word: true
 
-  - trigger: "serivzio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "serizio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "serviio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "serviizo"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "servizo"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "servizoi"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "servziio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "servzio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "sevizio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "sevrizio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "srevizio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "srvizio"
-    replace: "servizio"
-    propagate_case: true
-    word: true
-
-  - trigger: "esttimana"
+  - triggers:
+    - "esttimana"
+    - "setimana"
+    - "setitmana"
+    - "settiamna"
+    - "settiana"
+    - "settimaa"
+    - "settimaan"
+    - "settimna"
+    - "settimnaa"
+    - "settmana"
+    - "settmiana"
+    - "stetimana"
+    - "sttimana"
     replace: "settimana"
     propagate_case: true
     word: true
 
-  - trigger: "setimana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "setitmana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settiamna"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settiana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settimaa"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settimaan"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settimna"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settimnaa"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settmana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "settmiana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "stetimana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "sttimana"
-    replace: "settimana"
-    propagate_case: true
-    word: true
-
-  - trigger: "isamo"
+  - triggers:
+    - "isamo"
+    - "saimo"
+    - "samo"
+    - "siao"
+    - "siaom"
+    - "simao"
+    - "simo"
     replace: "siamo"
     propagate_case: true
     word: true
 
-  - trigger: "saimo"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "samo"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "siao"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "siaom"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "simao"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "simo"
-    replace: "siamo"
-    propagate_case: true
-    word: true
-
-  - trigger: "iscuramente"
+  - triggers:
+    - "iscuramente"
+    - "sciuramente"
+    - "scuramente"
+    - "sicramente"
+    - "sicruamente"
+    - "sicuamente"
+    - "sicuarmente"
+    - "sicuraemnte"
+    - "sicuraente"
+    - "sicuramene"
+    - "sicuramenet"
+    - "sicuramete"
+    - "sicurametne"
+    - "sicuramnete"
+    - "sicuramnte"
+    - "sicurmaente"
+    - "sicurmente"
+    - "siucramente"
+    - "siuramente"
     replace: "sicuramente"
     propagate_case: true
     word: true
 
-  - trigger: "sciuramente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "scuramente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicramente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicruamente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuamente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuarmente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuraemnte"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuraente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuramene"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuramenet"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuramete"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicurametne"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuramnete"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuramnte"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicurmaente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicurmente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "siucramente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "siuramente"
-    replace: "sicuramente"
-    propagate_case: true
-    word: true
-
-  - trigger: "iscuro"
+  - triggers:
+    - "iscuro"
+    - "sciuro"
+    - "scuro"
+    - "sicro"
+    - "sicruo"
+    - "sicuo"
+    - "sicuor"
+    - "siucro"
+    - "siuro"
     replace: "sicuro"
     propagate_case: true
     word: true
 
-  - trigger: "sciuro"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "scuro"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicro"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicruo"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuo"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "sicuor"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "siucro"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "siuro"
-    replace: "sicuro"
-    propagate_case: true
-    word: true
-
-  - trigger: "isete"
+  - triggers:
+    - "isete"
+    - "seite"
+    - "sete"
+    - "siee"
+    - "sieet"
+    - "site"
+    - "sitee"
     replace: "siete"
     propagate_case: true
     word: true
 
-  - trigger: "seite"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "sete"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "siee"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "sieet"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "site"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "sitee"
-    replace: "siete"
-    propagate_case: true
-    word: true
-
-  - trigger: "isstema"
+  - triggers:
+    - "isstema"
+    - "sisema"
+    - "sisetma"
+    - "sistea"
+    - "sisteam"
+    - "sistma"
+    - "sistmea"
+    - "sitema"
+    - "sitsema"
+    - "ssitema"
+    - "sstema"
     replace: "sistema"
     propagate_case: true
     word: true
 
-  - trigger: "sisema"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sisetma"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sistea"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sisteam"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sistma"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sistmea"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sitema"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sitsema"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "ssitema"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "sstema"
-    replace: "sistema"
-    propagate_case: true
-    word: true
-
-  - trigger: "istuazione"
+  - triggers:
+    - "istuazione"
+    - "sitauzione"
+    - "sitazione"
+    - "situaione"
+    - "situaizone"
+    - "situazine"
+    - "situazinoe"
+    - "situazioe"
+    - "situazioen"
+    - "situazoine"
+    - "situazone"
+    - "situzaione"
+    - "situzione"
+    - "siuazione"
+    - "siutazione"
+    - "stiuazione"
+    - "stuazione"
     replace: "situazione"
     propagate_case: true
     word: true
 
-  - trigger: "sitauzione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "sitazione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situaione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situaizone"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazine"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazinoe"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazioe"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazioen"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazoine"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situazone"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situzaione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "situzione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "siuazione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "siutazione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "stiuazione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "stuazione"
-    replace: "situazione"
-    propagate_case: true
-    word: true
-
-  - trigger: "osluzione"
+  - triggers:
+    - "osluzione"
+    - "slouzione"
+    - "sluzione"
+    - "soluione"
+    - "soluizone"
+    - "soluzine"
+    - "soluzinoe"
+    - "soluzioe"
+    - "soluzioen"
+    - "soluzoine"
+    - "soluzone"
+    - "solzione"
+    - "solzuione"
+    - "soulzione"
+    - "souzione"
     replace: "soluzione"
     propagate_case: true
     word: true
 
-  - trigger: "slouzione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "sluzione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluizone"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzine"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzinoe"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzioe"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzioen"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzoine"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzone"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "solzione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "solzuione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "soulzione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "souzione"
-    replace: "soluzione"
-    propagate_case: true
-    word: true
-
-  - trigger: "osluzioni"
+  - triggers:
+    - "osluzioni"
+    - "slouzioni"
+    - "sluzioni"
+    - "soluioni"
+    - "soluizoni"
+    - "soluzini"
+    - "soluzinoi"
+    - "soluzioi"
+    - "soluzioin"
+    - "soluzoini"
+    - "soluzoni"
+    - "solzioni"
+    - "solzuioni"
+    - "soulzioni"
+    - "souzioni"
     replace: "soluzioni"
     propagate_case: true
     word: true
 
-  - trigger: "slouzioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "sluzioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluizoni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzini"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzinoi"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzioi"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzioin"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzoini"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soluzoni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "solzioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "solzuioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "soulzioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "souzioni"
-    replace: "soluzioni"
-    propagate_case: true
-    word: true
-
-  - trigger: "osno"
+  - triggers:
+    - "osno"
+    - "snoo"
+    - "soon"
     replace: "sono"
     propagate_case: true
     word: true
 
-  - trigger: "snoo"
-    replace: "sono"
-    propagate_case: true
-    word: true
-
-  - trigger: "soon"
-    replace: "sono"
-    propagate_case: true
-    word: true
-
-  - trigger: "ospra"
+  - triggers:
+    - "ospra"
+    - "sopa"
+    - "sopar"
+    - "sora"
+    - "sorpa"
+    - "spora"
+    - "spra"
     replace: "sopra"
     propagate_case: true
     word: true
 
-  - trigger: "sopa"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "sopar"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "sora"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "sorpa"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "spora"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "spra"
-    replace: "sopra"
-    propagate_case: true
-    word: true
-
-  - trigger: "osrella"
+  - triggers:
+    - "osrella"
+    - "soella"
+    - "soerlla"
+    - "sorela"
+    - "sorelal"
+    - "sorlela"
+    - "sorlla"
+    - "srella"
+    - "sroella"
     replace: "sorella"
     propagate_case: true
     word: true
 
-  - trigger: "soella"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "soerlla"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "sorela"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "sorelal"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "sorlela"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "sorlla"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "srella"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "sroella"
-    replace: "sorella"
-    propagate_case: true
-    word: true
-
-  - trigger: "ostto"
+  - triggers:
+    - "ostto"
+    - "soto"
+    - "sotot"
+    - "stoto"
+    - "stto"
     replace: "sotto"
     propagate_case: true
     word: true
 
-  - trigger: "soto"
-    replace: "sotto"
-    propagate_case: true
-    word: true
-
-  - trigger: "sotot"
-    replace: "sotto"
-    propagate_case: true
-    word: true
-
-  - trigger: "stoto"
-    replace: "sotto"
-    propagate_case: true
-    word: true
-
-  - trigger: "stto"
-    replace: "sotto"
-    propagate_case: true
-    word: true
-
-  - trigger: "sare"
+  - triggers:
+    - "sare"
+    - "satre"
+    - "stae"
+    - "staer"
+    - "strae"
+    - "stre"
+    - "tsare"
     replace: "stare"
     propagate_case: true
     word: true
 
-  - trigger: "satre"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "stae"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "staer"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "strae"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "stre"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsare"
-    replace: "stare"
-    propagate_case: true
-    word: true
-
-  - trigger: "soria"
+  - triggers:
+    - "soria"
+    - "sotria"
+    - "stoia"
+    - "stoira"
+    - "stora"
+    - "storai"
+    - "stria"
+    - "stroia"
+    - "tsoria"
     replace: "storia"
     propagate_case: true
     word: true
 
-  - trigger: "sotria"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "stoia"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "stoira"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "stora"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "storai"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "stria"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "stroia"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsoria"
-    replace: "storia"
-    propagate_case: true
-    word: true
-
-  - trigger: "sretto"
+  - triggers:
+    - "sretto"
+    - "srtetto"
+    - "stertto"
+    - "stetto"
+    - "streto"
+    - "stretot"
+    - "strteto"
+    - "strtto"
+    - "tsretto"
     replace: "stretto"
     propagate_case: true
     word: true
 
-  - trigger: "srtetto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "stertto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "stetto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "streto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "stretot"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "strteto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "strtto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsretto"
-    replace: "stretto"
-    propagate_case: true
-    word: true
-
-  - trigger: "sau"
+  - triggers:
+    - "sau"
+    - "usa"
     replace: "sua"
     propagate_case: true
     word: true
 
-  - trigger: "usa"
-    replace: "sua"
-    propagate_case: true
-    word: true
-
-  - trigger: "sbito"
+  - triggers:
+    - "sbito"
+    - "sbuito"
+    - "subio"
+    - "subiot"
+    - "subtio"
+    - "subto"
+    - "suibto"
+    - "suito"
+    - "usbito"
     replace: "subito"
     propagate_case: true
     word: true
 
-  - trigger: "sbuito"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "subio"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "subiot"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "subtio"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "subto"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "suibto"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "suito"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "usbito"
-    replace: "subito"
-    propagate_case: true
-    word: true
-
-  - trigger: "seu"
+  - triggers:
+    - "seu"
+    - "use"
     replace: "sue"
     propagate_case: true
     word: true
 
-  - trigger: "use"
-    replace: "sue"
-    propagate_case: true
-    word: true
-
-  - trigger: "sou"
+  - triggers:
+    - "sou"
+    - "uso"
     replace: "suo"
     propagate_case: true
     word: true
 
-  - trigger: "uso"
-    replace: "suo"
-    propagate_case: true
-    word: true
-
-  - trigger: "soui"
+  - triggers:
+    - "soui"
+    - "suio"
+    - "usoi"
     replace: "suoi"
     propagate_case: true
     word: true
 
-  - trigger: "suio"
-    replace: "suoi"
-    propagate_case: true
-    word: true
-
-  - trigger: "usoi"
-    replace: "suoi"
-    propagate_case: true
-    word: true
-
-  - trigger: "siluppo"
+  - triggers:
+    - "siluppo"
+    - "sivluppo"
+    - "svilppo"
+    - "svilpupo"
+    - "svilupo"
+    - "svilupop"
+    - "sviulppo"
+    - "sviuppo"
+    - "svliuppo"
+    - "svluppo"
+    - "vsiluppo"
     replace: "sviluppo"
     propagate_case: true
     word: true
 
-  - trigger: "sivluppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svilppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svilpupo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svilupo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svilupop"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sviulppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "sviuppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svliuppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "svluppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsiluppo"
-    replace: "sviluppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "atnto"
+  - triggers:
+    - "atnto"
+    - "tano"
+    - "tanot"
+    - "tatno"
+    - "tato"
+    - "tnato"
+    - "tnto"
     replace: "tanto"
     propagate_case: true
     word: true
 
-  - trigger: "tano"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tanot"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tatno"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tato"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tnato"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tnto"
-    replace: "tanto"
-    propagate_case: true
-    word: true
-
-  - trigger: "etmpo"
+  - triggers:
+    - "etmpo"
+    - "temo"
+    - "temop"
+    - "tepmo"
+    - "tepo"
+    - "tmepo"
+    - "tmpo"
     replace: "tempo"
     propagate_case: true
     word: true
 
-  - trigger: "temo"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "temop"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tepmo"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tepo"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tmepo"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tmpo"
-    replace: "tempo"
-    propagate_case: true
-    word: true
-
-  - trigger: "etnere"
+  - triggers:
+    - "etnere"
+    - "teenre"
+    - "teere"
+    - "tenee"
+    - "teneer"
+    - "tenre"
+    - "tenree"
+    - "tneere"
+    - "tnere"
     replace: "tenere"
     propagate_case: true
     word: true
 
-  - trigger: "teenre"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "teere"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "tenee"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "teneer"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "tenre"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "tenree"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "tneere"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "tnere"
-    replace: "tenere"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrza"
+  - triggers:
+    - "etrza"
+    - "tera"
+    - "teraz"
+    - "teza"
+    - "tezra"
+    - "treza"
+    - "trza"
     replace: "terza"
     propagate_case: true
     word: true
 
-  - trigger: "tera"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "teraz"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "teza"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "tezra"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "treza"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "trza"
-    replace: "terza"
-    propagate_case: true
-    word: true
-
-  - trigger: "etrzo"
+  - triggers:
+    - "etrzo"
+    - "tero"
+    - "teroz"
+    - "tezo"
+    - "tezro"
+    - "trezo"
+    - "trzo"
     replace: "terzo"
     propagate_case: true
     word: true
 
-  - trigger: "tero"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "teroz"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tezo"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tezro"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trezo"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trzo"
-    replace: "terzo"
-    propagate_case: true
-    word: true
-
-  - trigger: "etsta"
+  - triggers:
+    - "etsta"
+    - "tesa"
+    - "tesat"
+    - "teta"
+    - "tetsa"
+    - "tseta"
+    - "tsta"
     replace: "testa"
     propagate_case: true
     word: true
 
-  - trigger: "tesa"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "tesat"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "teta"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "tetsa"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "tseta"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "tsta"
-    replace: "testa"
-    propagate_case: true
-    word: true
-
-  - trigger: "itpo"
+  - triggers:
+    - "itpo"
+    - "tiop"
+    - "tpio"
     replace: "tipo"
     propagate_case: true
     word: true
 
-  - trigger: "tiop"
-    replace: "tipo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tpio"
-    replace: "tipo"
-    propagate_case: true
-    word: true
-
-  - trigger: "otrnare"
+  - triggers:
+    - "otrnare"
+    - "tonare"
+    - "tonrare"
+    - "toranre"
+    - "torare"
+    - "tornae"
+    - "tornaer"
+    - "tornrae"
+    - "tornre"
+    - "trnare"
+    - "tronare"
     replace: "tornare"
     propagate_case: true
     word: true
 
-  - trigger: "tonare"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tonrare"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "toranre"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "torare"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornae"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornaer"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornrae"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tornre"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trnare"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tronare"
-    replace: "tornare"
-    propagate_case: true
-    word: true
-
-  - trigger: "rta"
+  - triggers:
+    - "rta"
+    - "tar"
     replace: "tra"
     propagate_case: true
     word: true
 
-  - trigger: "tar"
-    replace: "tra"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtoppo"
+  - triggers:
+    - "rtoppo"
+    - "toppo"
+    - "torppo"
+    - "tropo"
+    - "tropop"
+    - "trpopo"
+    - "trppo"
     replace: "troppo"
     propagate_case: true
     word: true
 
-  - trigger: "toppo"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "torppo"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tropo"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "tropop"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trpopo"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "trppo"
-    replace: "troppo"
-    propagate_case: true
-    word: true
-
-  - trigger: "rtovare"
+  - triggers:
+    - "rtovare"
+    - "torvare"
+    - "tovare"
+    - "troare"
+    - "troavre"
+    - "trovae"
+    - "trovaer"
+    - "trovrae"
+    - "trovre"
+    - "trvare"
+    - "trvoare"
     replace: "trovare"
     propagate_case: true
     word: true
 
-  - trigger: "torvare"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tovare"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "troare"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "troavre"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovae"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovaer"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovrae"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trovre"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trvare"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "trvoare"
-    replace: "trovare"
-    propagate_case: true
-    word: true
-
-  - trigger: "tau"
+  - triggers:
+    - "tau"
+    - "uta"
     replace: "tua"
     propagate_case: true
     word: true
 
-  - trigger: "uta"
-    replace: "tua"
-    propagate_case: true
-    word: true
-
-  - trigger: "teu"
+  - triggers:
+    - "teu"
+    - "ute"
     replace: "tue"
     propagate_case: true
     word: true
 
-  - trigger: "ute"
-    replace: "tue"
-    propagate_case: true
-    word: true
-
-  - trigger: "tou"
+  - triggers:
+    - "tou"
+    - "uto"
     replace: "tuo"
     propagate_case: true
     word: true
 
-  - trigger: "uto"
-    replace: "tuo"
-    propagate_case: true
-    word: true
-
-  - trigger: "toui"
+  - triggers:
+    - "toui"
+    - "tuio"
+    - "utoi"
     replace: "tuoi"
     propagate_case: true
     word: true
 
-  - trigger: "tuio"
-    replace: "tuoi"
-    propagate_case: true
-    word: true
-
-  - trigger: "utoi"
-    replace: "tuoi"
-    propagate_case: true
-    word: true
-
-  - trigger: "tttavia"
+  - triggers:
+    - "tttavia"
+    - "ttutavia"
+    - "tutatvia"
+    - "tutavia"
+    - "tuttaia"
+    - "tuttaiva"
+    - "tuttava"
+    - "tuttavai"
+    - "tuttvaia"
+    - "tuttvia"
+    - "utttavia"
     replace: "tuttavia"
     propagate_case: true
     word: true
 
-  - trigger: "ttutavia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tutatvia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tutavia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttaia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttaiva"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttava"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttavai"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttvaia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuttvia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "utttavia"
-    replace: "tuttavia"
-    propagate_case: true
-    word: true
-
-  - trigger: "ttto"
+  - triggers:
+    - "ttto"
+    - "ttuto"
+    - "tuto"
+    - "tutot"
+    - "uttto"
     replace: "tutto"
     propagate_case: true
     word: true
 
-  - trigger: "ttuto"
-    replace: "tutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tuto"
-    replace: "tutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "tutot"
-    replace: "tutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "uttto"
-    replace: "tutto"
-    propagate_case: true
-    word: true
-
-  - trigger: "lutima"
+  - triggers:
+    - "lutima"
+    - "ulima"
+    - "ulitma"
+    - "ultia"
+    - "ultiam"
+    - "ultma"
+    - "ultmia"
+    - "utima"
+    - "utlima"
     replace: "ultima"
     propagate_case: true
     word: true
 
-  - trigger: "ulima"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "ulitma"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultia"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultiam"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultma"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultmia"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "utima"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "utlima"
-    replace: "ultima"
-    propagate_case: true
-    word: true
-
-  - trigger: "lutimo"
+  - triggers:
+    - "lutimo"
+    - "ulimo"
+    - "ulitmo"
+    - "ultio"
+    - "ultiom"
+    - "ultmio"
+    - "ultmo"
+    - "utimo"
+    - "utlimo"
     replace: "ultimo"
     propagate_case: true
     word: true
 
-  - trigger: "ulimo"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ulitmo"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultio"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultiom"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultmio"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "ultmo"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "utimo"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "utlimo"
-    replace: "ultimo"
-    propagate_case: true
-    word: true
-
-  - trigger: "nua"
+  - triggers:
+    - "nua"
+    - "uan"
     replace: "una"
     propagate_case: true
     word: true
 
-  - trigger: "uan"
-    replace: "una"
-    propagate_case: true
-    word: true
-
-  - trigger: "nuo"
+  - triggers:
+    - "nuo"
+    - "uon"
     replace: "uno"
     propagate_case: true
     word: true
 
-  - trigger: "uon"
-    replace: "uno"
-    propagate_case: true
-    word: true
-
-  - trigger: "oumo"
+  - triggers:
+    - "oumo"
+    - "umoo"
+    - "uoom"
     replace: "uomo"
     propagate_case: true
     word: true
 
-  - trigger: "umoo"
-    replace: "uomo"
-    propagate_case: true
-    word: true
-
-  - trigger: "uoom"
-    replace: "uomo"
-    propagate_case: true
-    word: true
-
-  - trigger: "suare"
+  - triggers:
+    - "suare"
+    - "uare"
+    - "uasre"
+    - "usae"
+    - "usaer"
+    - "usrae"
+    - "usre"
     replace: "usare"
     propagate_case: true
     word: true
 
-  - trigger: "uare"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "uasre"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "usae"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "usaer"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "usrae"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "usre"
-    replace: "usare"
-    propagate_case: true
-    word: true
-
-  - trigger: "avdo"
+  - triggers:
+    - "avdo"
+    - "vaod"
+    - "vdao"
     replace: "vado"
     propagate_case: true
     word: true
 
-  - trigger: "vaod"
-    replace: "vado"
-    propagate_case: true
-    word: true
-
-  - trigger: "vdao"
-    replace: "vado"
-    propagate_case: true
-    word: true
-
-  - trigger: "avi"
+  - triggers:
+    - "avi"
+    - "via"
     replace: "vai"
     propagate_case: true
     word: true
 
-  - trigger: "via"
-    replace: "vai"
-    propagate_case: true
-    word: true
-
-  - trigger: "avnno"
+  - triggers:
+    - "avnno"
+    - "vano"
+    - "vanon"
+    - "vnano"
+    - "vnno"
     replace: "vanno"
     propagate_case: true
     word: true
 
-  - trigger: "vano"
-    replace: "vanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vanon"
-    replace: "vanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vnano"
-    replace: "vanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "vnno"
-    replace: "vanno"
-    propagate_case: true
-    word: true
-
-  - trigger: "evcchia"
+  - triggers:
+    - "evcchia"
+    - "vcchia"
+    - "vcechia"
+    - "veccha"
+    - "vecchai"
+    - "veccia"
+    - "vecciha"
+    - "vechcia"
+    - "vechia"
     replace: "vecchia"
     propagate_case: true
     word: true
 
-  - trigger: "vcchia"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "vcechia"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "veccha"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "vecchai"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "veccia"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "vecciha"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "vechcia"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "vechia"
-    replace: "vecchia"
-    propagate_case: true
-    word: true
-
-  - trigger: "evcchio"
+  - triggers:
+    - "evcchio"
+    - "vcchio"
+    - "vcechio"
+    - "veccho"
+    - "vecchoi"
+    - "vecciho"
+    - "veccio"
+    - "vechcio"
+    - "vechio"
     replace: "vecchio"
     propagate_case: true
     word: true
 
-  - trigger: "vcchio"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "vcechio"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "veccho"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "vecchoi"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "vecciho"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "veccio"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "vechcio"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "vechio"
-    replace: "vecchio"
-    propagate_case: true
-    word: true
-
-  - trigger: "evdere"
+  - triggers:
+    - "evdere"
+    - "vdeere"
+    - "vdere"
+    - "vedee"
+    - "vedeer"
+    - "vedre"
+    - "vedree"
+    - "veedre"
+    - "veere"
     replace: "vedere"
     propagate_case: true
     word: true
 
-  - trigger: "vdeere"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vdere"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedee"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedeer"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedre"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vedree"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "veedre"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "veere"
-    replace: "vedere"
-    propagate_case: true
-    word: true
-
-  - trigger: "evloce"
+  - triggers:
+    - "evloce"
+    - "velce"
+    - "velcoe"
+    - "veloe"
+    - "veloec"
+    - "veoce"
+    - "veolce"
+    - "vleoce"
+    - "vloce"
     replace: "veloce"
     propagate_case: true
     word: true
 
-  - trigger: "velce"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "velcoe"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloe"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloec"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "veoce"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "veolce"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "vleoce"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "vloce"
-    replace: "veloce"
-    propagate_case: true
-    word: true
-
-  - trigger: "evlocemente"
+  - triggers:
+    - "evlocemente"
+    - "velcemente"
+    - "velcoemente"
+    - "veloceemnte"
+    - "veloceente"
+    - "velocemene"
+    - "velocemenet"
+    - "velocemete"
+    - "velocemetne"
+    - "velocemnete"
+    - "velocemnte"
+    - "velocmeente"
+    - "velocmente"
+    - "veloecmente"
+    - "veloemente"
+    - "veocemente"
+    - "veolcemente"
+    - "vleocemente"
+    - "vlocemente"
     replace: "velocemente"
     propagate_case: true
     word: true
 
-  - trigger: "velcemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velcoemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloceemnte"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloceente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemene"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemenet"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemete"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemetne"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemnete"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocemnte"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocmeente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "velocmente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloecmente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veloemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veocemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "veolcemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "vleocemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "vlocemente"
-    replace: "velocemente"
-    propagate_case: true
-    word: true
-
-  - trigger: "evnire"
+  - triggers:
+    - "evnire"
+    - "veinre"
+    - "veire"
+    - "venie"
+    - "venier"
+    - "venre"
+    - "venrie"
+    - "vneire"
+    - "vnire"
     replace: "venire"
     propagate_case: true
     word: true
 
-  - trigger: "veinre"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "veire"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "venie"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "venier"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "venre"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "venrie"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "vneire"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "vnire"
-    replace: "venire"
-    propagate_case: true
-    word: true
-
-  - trigger: "evrso"
+  - triggers:
+    - "evrso"
+    - "vero"
+    - "veros"
+    - "veso"
+    - "vesro"
+    - "vreso"
+    - "vrso"
     replace: "verso"
     propagate_case: true
     word: true
 
-  - trigger: "vero"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "veros"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "veso"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "vesro"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "vreso"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "vrso"
-    replace: "verso"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivcino"
+  - triggers:
+    - "ivcino"
+    - "vciino"
+    - "vcino"
+    - "vicio"
+    - "vicion"
+    - "vicnio"
+    - "vicno"
+    - "viicno"
+    - "viino"
     replace: "vicino"
     propagate_case: true
     word: true
 
-  - trigger: "vciino"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "vcino"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "vicio"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "vicion"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "vicnio"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "vicno"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "viicno"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "viino"
-    replace: "vicino"
-    propagate_case: true
-    word: true
-
-  - trigger: "ivta"
+  - triggers:
+    - "ivta"
+    - "viat"
+    - "vtia"
     replace: "vita"
     propagate_case: true
     word: true
 
-  - trigger: "viat"
-    replace: "vita"
-    propagate_case: true
-    word: true
-
-  - trigger: "vtia"
-    replace: "vita"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovi"
+  - triggers:
+    - "ovi"
+    - "vio"
     replace: "voi"
     propagate_case: true
     word: true
 
-  - trigger: "vio"
-    replace: "voi"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovlere"
+  - triggers:
+    - "ovlere"
+    - "vlere"
+    - "vloere"
+    - "voelre"
+    - "voere"
+    - "volee"
+    - "voleer"
+    - "volre"
+    - "volree"
     replace: "volere"
     propagate_case: true
     word: true
 
-  - trigger: "vlere"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "vloere"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "voelre"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "voere"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "volee"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "voleer"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "volre"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "volree"
-    replace: "volere"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovstra"
+  - triggers:
+    - "ovstra"
+    - "vosra"
+    - "vosrta"
+    - "vosta"
+    - "vostar"
+    - "votra"
+    - "votsra"
+    - "vsotra"
+    - "vstra"
     replace: "vostra"
     propagate_case: true
     word: true
 
-  - trigger: "vosra"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosrta"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosta"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "vostar"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "votra"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "votsra"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsotra"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "vstra"
-    replace: "vostra"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovstre"
+  - triggers:
+    - "ovstre"
+    - "vosre"
+    - "vosrte"
+    - "voste"
+    - "voster"
+    - "votre"
+    - "votsre"
+    - "vsotre"
+    - "vstre"
     replace: "vostre"
     propagate_case: true
     word: true
 
-  - trigger: "vosre"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosrte"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "voste"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "voster"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "votre"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "votsre"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsotre"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "vstre"
-    replace: "vostre"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovstri"
+  - triggers:
+    - "ovstri"
+    - "vosri"
+    - "vosrti"
+    - "vosti"
+    - "vostir"
+    - "votri"
+    - "votsri"
+    - "vsotri"
+    - "vstri"
     replace: "vostri"
     propagate_case: true
     word: true
 
-  - trigger: "vosri"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosrti"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosti"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "vostir"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "votri"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "votsri"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsotri"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "vstri"
-    replace: "vostri"
-    propagate_case: true
-    word: true
-
-  - trigger: "ovstro"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosro"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosrto"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vosto"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vostor"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "votro"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "votsro"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vsotro"
-    replace: "vostro"
-    propagate_case: true
-    word: true
-
-  - trigger: "vstro"
+  - triggers:
+    - "ovstro"
+    - "vosro"
+    - "vosrto"
+    - "vosto"
+    - "vostor"
+    - "votro"
+    - "votsro"
+    - "vsotro"
+    - "vstro"
     replace: "vostro"
     propagate_case: true
     word: true


### PR DESCRIPTION
## Summary

This PR adds three packages from the [refuos](https://github.com/heavybeard/refuos) project — a real-time Italian and developer autocorrection suite for Espanso.

### Packages

| Package | Rules | What it fixes |
|---|---|---|
| `refuos-italiano` | ~2,600 | Everyday Italian words: `acnhe` → `anche`, `comunqeu` → `comunque` |
| `refuos-accenti` | ~4,800 | Italian accents, future-tense verbs, `-ità` nouns: `perche` → `perché`, `aggiungero` → `aggiungerò` |
| `refuos-dev` | ~3,200 | Tech and code terms: `cosnt` → `const`, `reutrn` → `return`, `dockerfiel` → `dockerfile` |

**Total: 10,500+ rules** across 3 independent packages.

### How it works

A Python generator reads word lists from plain-text dictionaries and produces all plausible typo variants: adjacent-key transpositions, missing double letters, wrong accents, dropped characters. The output is the YAML you see in `package.yml`.

### Notes

- The three packages are **fully independent** — users can install any subset.
- The `refuos-dev` package is language-agnostic (JavaScript, TypeScript, Python, Go, Java, etc.).
- All rules use `word: true` to avoid false positives inside longer words.
- Accented words intentionally omit `propagate_case: true` since accented uppercase is not standard Italian typography.
- Source: <https://github.com/heavybeard/refuos>

Made with [Cursor](https://cursor.com)