### PR TITLE
feat: add zero-dependency password-gen-win package

### DIFF
--- a/packages/password-gen-win/0.1.0/README.md
+++ b/packages/password-gen-win/0.1.0/README.md
@@ -46,4 +46,12 @@ espanso package install password-gen-win
 ## Requirements
 
 - **Operating System**: Windows
-- **Engine**: PowerShell (Built-in)
+- **Engine**: PowerShell Version 5.1 (Built-in)
+
+## Platform Compatibility
+
+While designed for Windows, this package also works on **macOS and Linux** with [PowerShell 7](https://github.com/PowerShell/PowerShell) (`pwsh`) installed. To enable this, either:
+
+- Change `shell: powershell` to `shell: pwsh` in `package.yml`, or
+- Symlink `powershell` to `pwsh` on your system.
+  > **Note for Linux users:** `Set-Clipboard` functionality to copy the password to clipboard may or may not work.

--- a/packages/password-gen-win/0.1.0/README.md
+++ b/packages/password-gen-win/0.1.0/README.md
@@ -1,0 +1,49 @@
+# Password Generator (Windows)
+
+A powerful, zero-dependency Espanso package for generating random passwords instantly. Designed specifically for Windows, it leverages native PowerShell to generate secure strings, paste them into your active window, and automatically save them to your clipboard.
+
+## Features
+
+- ✨ **Smart Triggers**: Specify your desired length directly in the trigger.
+- 📋 **Auto-Clipboard**: Every generated password is automatically copied to your Windows clipboard for easy use in secondary fields (like "Confirm Password").
+- 🔒 **Secure**: Generates unpredictable strings using native system libraries.
+- 🚀 **Zero Dependencies**: Works out-of-the-box on Windows using built-in PowerShell.
+
+---
+
+## How to Use
+
+Simply type a trigger followed by the **2-digit length** you want.
+
+> **Important:** The length must always be **two digits**. For lengths less than 10, use a leading zero (e.g., `08` instead of `8`).
+
+### 1. Available Triggers
+
+| Trigger        | Complexity   | Character Set                             | Example  |
+| :------------- | :----------- | :---------------------------------------- | :------- |
+| `:pw[length]`  | **Standard** | Letters (A-Z, a-z) + Numbers (0-9)        | `:pw12`  |
+| `:pws[length]` | **Secure**   | Letters + Numbers + **Symbols** (!@#$...) | `:pws16` |
+| `:pwn[length]` | **Numeric**  | **Numbers only** (PIN style)              | `:pwn06` |
+
+### 2. Practical Examples
+
+- Typing **`:pw12`** results in: `a7B2k9L1p4Xz`
+- Typing **`:pws20`** results in: `k#9!2L$p*7xQ9^mN2@5z`
+- Typing **`:pwn04`** results in: `8293` (Perfect for quick PINs!)
+
+---
+
+## Why Two Digits?
+
+To ensure maximum speed and reliability, this package waits for exactly two digits after the prefix. This prevents the trigger from firing "too early" (e.g., firing on `:pw2` before you have time to type the `0` for `:pw20`).
+
+## Installation
+
+```
+espanso package install password-gen-win
+```
+
+## Requirements
+
+- **Operating System**: Windows
+- **Engine**: PowerShell (Built-in)

--- a/packages/password-gen-win/0.1.0/_manifest.yml
+++ b/packages/password-gen-win/0.1.0/_manifest.yml
@@ -1,0 +1,10 @@
+name: password-gen-win
+title: Password Generator (Windows)
+description: Generate random passwords of any length (up to 99) and automatically copy to clipboard. Optimized for Windows with native PowerShell.
+version: 0.1.0
+author: kaniamutan14
+homepage: https://github.com/kaniamutan14/
+tags:
+  - utility
+  - security
+  - windows

--- a/packages/password-gen-win/0.1.0/package.yml
+++ b/packages/password-gen-win/0.1.0/package.yml
@@ -1,59 +1,30 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/dev/schemas/match.schema.json
 
 matches:
-  # Standard: Letters + Numbers
-  - regex: ':pw(?P<len>\d{2})'
+  - regex: ':pw(?P<mode>s|n|)(?P<len>\d{2})'
     replace: "{{output}}"
     vars:
       - name: output
         type: shell
         params:
           cmd: |
-            $len = [int]('{{len}}');
-            $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
-            $bytes = New-Object byte[] $len;
-            $rng.GetBytes($bytes);
-            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
-            $rng.Dispose();
-            Set-Clipboard -Value $pw;
-            Write-Output $pw
-          shell: powershell
-
-  # Secure: Letters + Numbers + Symbols
-  - regex: ':pws(?P<len>\d{2})'
-    replace: "{{output}}"
-    vars:
-      - name: output
-        type: shell
-        params:
-          cmd: |
-            $len = [int]('{{len}}');
-            $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?';
-            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
-            $bytes = New-Object byte[] $len;
-            $rng.GetBytes($bytes);
-            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
-            $rng.Dispose();
-            Set-Clipboard -Value $pw;
-            Write-Output $pw
-          shell: powershell
-
-  # Numeric: Numbers only
-  - regex: ':pwn(?P<len>\d{2})'
-    replace: "{{output}}"
-    vars:
-      - name: output
-        type: shell
-        params:
-          cmd: |
-            $len = [int]('{{len}}');
-            $chars = '0123456789';
-            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
-            $bytes = New-Object byte[] $len;
-            $rng.GetBytes($bytes);
-            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
-            $rng.Dispose();
-            Set-Clipboard -Value $pw;
+            $mode = '{{mode}}'
+            $chars = switch ($mode) {
+              's' { 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?' }
+              'n' { '0123456789' }
+              default { 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' }
+            }
+            $len = [int]('{{len}}')
+            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+            $limit = 256 - (256 % $chars.Length)
+            $result = New-Object System.Text.StringBuilder
+            $buf = New-Object byte[] 1
+            while ($result.Length -lt $len) {
+              $rng.GetBytes($buf)
+              if ($buf[0] -lt $limit) { [void]$result.Append($chars[$buf[0] % $chars.Length]) }
+            }
+            $pw = $result.ToString()
+            $rng.Dispose()
+            Set-Clipboard -Value $pw
             Write-Output $pw
           shell: powershell

--- a/packages/password-gen-win/0.1.0/package.yml
+++ b/packages/password-gen-win/0.1.0/package.yml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/espanso/espanso/dev/schemas/match.schema.json
+
+matches:
+  # Standard: Letters + Numbers
+  - regex: ':pw(?P<len>\d{2})'
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: |
+            $len = [int]('{{len}}');
+            $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
+            $bytes = New-Object byte[] $len;
+            $rng.GetBytes($bytes);
+            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
+            $rng.Dispose();
+            Set-Clipboard -Value $pw;
+            Write-Output $pw
+          shell: powershell
+
+  # Secure: Letters + Numbers + Symbols
+  - regex: ':pws(?P<len>\d{2})'
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: |
+            $len = [int]('{{len}}');
+            $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{}|;:,.<>?';
+            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
+            $bytes = New-Object byte[] $len;
+            $rng.GetBytes($bytes);
+            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
+            $rng.Dispose();
+            Set-Clipboard -Value $pw;
+            Write-Output $pw
+          shell: powershell
+
+  # Numeric: Numbers only
+  - regex: ':pwn(?P<len>\d{2})'
+    replace: "{{output}}"
+    vars:
+      - name: output
+        type: shell
+        params:
+          cmd: |
+            $len = [int]('{{len}}');
+            $chars = '0123456789';
+            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create();
+            $bytes = New-Object byte[] $len;
+            $rng.GetBytes($bytes);
+            $pw = -join ($bytes | ForEach-Object { $chars[$_ % $chars.Length] });
+            $rng.Dispose();
+            Set-Clipboard -Value $pw;
+            Write-Output $pw
+          shell: powershell


### PR DESCRIPTION
 ### Description
 This PR introduces `password-gen-win`, a zero-dependency password generator specifically designed for Windows. It
generates random strings of variable lengths, pastes them, and automatically copies them to the Windows clipboard
for secondary confirmation fields.    
### Key Features
* **Smart Triggers:** Users can define the exact length of the password directly in the trigger (e.g., `:pw16`,
`:pws20`, `:pwn06`).
* **Auto-Clipboard:** Uses native `Set-Clipboard` so the generated string is immediately available to paste again.
* **Zero Dependencies:** Runs entirely on native Windows PowerShell without requiring Python or other external
tools.
   