### PR TITLE
Add new "no-fn-tilde" package

### DIFF
--- a/packages/no-fn-tilde/0.1.0/README.md
+++ b/packages/no-fn-tilde/0.1.0/README.md
@@ -1,8 +1,9 @@
 # No FN Tilde
 
-## English 🇺🇸
+## English
 
-## PT-BR 🇧🇷
+I used a ZIYOULANG K68 keyboard for a long time, which does not have a dedicated tilde key. This makes typing uncomfortable, as entering a tilde requires pressing three keys (Fn + Shift + Esc). This package aims to reduce the need to manually type the tilde in Portuguese words ending in ção and ções by automatically inserting it when appropriate.
 
-Usei por um bom tempo um teclado ZIYOULANG K68, o qual não possui uma tecla dedicada para til, o que causa um desconforto, visto que é necessário pressionar 3 teclas para acionar o til (fn + shift + esc), esse pacote visa diminuir a necessidade de acionar o til em palavras terminadas em ção e ções, auto adicionando o til automaticamente.
+## Português Brasileiro
 
+Usei por um bom tempo um teclado ZIYOULANG K68, o qual não possui uma tecla dedicada para til, o que causa um desconforto, visto que é necessário pressionar 3 teclas para acionar o til (Fn + Shift + Esc). Este pacote visa diminuir a necessidade de acionar o til em palavras terminadas em ção e ções, adicionando-o automaticamente quando apropriado.

--- a/packages/no-fn-tilde/0.1.0/README.md
+++ b/packages/no-fn-tilde/0.1.0/README.md
@@ -1,0 +1,10 @@
+# No FN Tilde
+
+## US 🇺🇸
+
+I used a ZIYOULANG K68 keyboard for a long time, which does not have a dedicated tilde key. This makes typing uncomfortable, as entering a tilde requires pressing three keys (Fn + Shift + Esc). This package aims to reduce the need to manually type the tilde in Portuguese words ending in ção and ções by automatically inserting it when appropriate.
+
+## PT-BR 🇺🇸
+
+Usei por um bom tempo um teclado ZIYOULANG K68, o qual não possui uma tecla dedicada para til, o que causa um desconforto, visto que é necessário pressionar 3 teclas para acionar o til (fn + shift + esc), esse pacote visa diminuir a necessidade de acionar o til em palavras terminadas em ção e ções, auto adicionando o til automaticamente.
+

--- a/packages/no-fn-tilde/0.1.0/README.md
+++ b/packages/no-fn-tilde/0.1.0/README.md
@@ -1,10 +1,8 @@
 # No FN Tilde
 
-## US 🇺🇸
+## English 🇺🇸
 
-I used a ZIYOULANG K68 keyboard for a long time, which does not have a dedicated tilde key. This makes typing uncomfortable, as entering a tilde requires pressing three keys (Fn + Shift + Esc). This package aims to reduce the need to manually type the tilde in Portuguese words ending in ção and ções by automatically inserting it when appropriate.
-
-## PT-BR 🇺🇸
+## PT-BR 🇧🇷
 
 Usei por um bom tempo um teclado ZIYOULANG K68, o qual não possui uma tecla dedicada para til, o que causa um desconforto, visto que é necessário pressionar 3 teclas para acionar o til (fn + shift + esc), esse pacote visa diminuir a necessidade de acionar o til em palavras terminadas em ção e ções, auto adicionando o til automaticamente.
 

--- a/packages/no-fn-tilde/0.1.0/_manifest.yml
+++ b/packages/no-fn-tilde/0.1.0/_manifest.yml
@@ -1,7 +1,7 @@
 name: "no-fn-tilde"
 title: "No FN Tilde"
 description: A simple package to help type words with tildes on ANSI keyboards without a dedicated tilde key
-homepage: "https://github.com/ArturNTx/nofntilde"
+homepage: "https://github.com/ArturNTx/espanso-package-hub"
 version: 0.1.0
 author: Artur V. Neto
-tags: ["pt-br", "ansi", "tilde"]
+tags: ["pt-br", "portuguese", "ansi", "tilde", "languages"]

--- a/packages/no-fn-tilde/0.1.0/_manifest.yml
+++ b/packages/no-fn-tilde/0.1.0/_manifest.yml
@@ -1,0 +1,7 @@
+name: "no-fn-tilde"
+title: "No FN Tilde"
+description: A simple package to help type words with tildes on ANSI keyboards without a dedicated tilde key
+homepage: "https://github.com/ArturNTx/nofntilde"
+version: 0.1.0
+author: Artur V. Neto
+tags: ["pt-br", "ansi", "tilde"]

--- a/packages/no-fn-tilde/0.1.0/package.yml
+++ b/packages/no-fn-tilde/0.1.0/package.yml
@@ -1,5 +1,5 @@
 matches:
-  - regex: "\\b(?P<word>\\w*)çao\\b"
+  - regex: "\\b(?P<word>\\w+)çao\\b"
     replace: "{{word}}ção"
-  - regex: "\\b(?P<word>\\w*)çoes\\b"
+  - regex: "\\b(?P<word>\\w+)çoes\\b"
     replace: "{{word}}ções"

--- a/packages/no-fn-tilde/0.1.0/package.yml
+++ b/packages/no-fn-tilde/0.1.0/package.yml
@@ -1,0 +1,5 @@
+matches:
+  - regex: "\\b(?P<word>\\w*)çao\\b"
+    replace: "{{word}}ção"
+  - regex: "\\b(?P<word>\\w*)çoes\\b"
+    replace: "{{word}}ções"


### PR DESCRIPTION
A simple package to help type words with tildes on ANSI keyboards without a dedicated tilde key