### PR TITLE
Fix formatting in package.yml for emoji picker

### DIFF
--- a/packages/emoji-picker/1.17.0/package.yml
+++ b/packages/emoji-picker/1.17.0/package.yml
@@ -1,10 +1,10 @@
 matches:
-- triggers: [":em"]
-  replace: "{{output}}"
-  vars:
-  - name: output
-    type: choice
-    params:
+ - triggers: [":em"]
+   replace: "{{output}}"
+   vars:
+   - name: output
+     type: choice
+     params:
       values:
         - label: "😀 :grinning_face:"
           id: "😀"


### PR DESCRIPTION
I just downloaded Espanso today, and while exploring extensions, I came across this extension called emoji-picker, which helps me choose from a variety of emojis.

However, after installing the extension, I found that typing ":em" yielded no response. I dug into package.yml and noticed that the indentation was slightly off. I added the missing space, and now it works perfectly!

Hope this helps solve the issue! ✨